### PR TITLE
feat: Add fdb devices command

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ fdb kill
 
 | Command | Description |
 |---------|-------------|
+| `fdb devices` | List connected devices |
 | `fdb launch --device <id> --project <path>` | Launch app, wait for start |
 | `fdb reload` | Hot reload |
 | `fdb restart` | Hot restart |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -21,24 +21,15 @@ tasks:
   # Device detection
   # ---------------------------------------------------------------------------
   detect-device:
-    desc: Auto-detect a connected device ID (iOS Simulator or Android emulator)
+    desc: Auto-detect a connected device ID (first device reported by fdb devices)
     cmds:
       - |
-        DEVICE=$(flutter devices --machine 2>/dev/null | python3 -c '
-        import json, sys
-        devices = json.load(sys.stdin)
-        skip = {"macos", "linux", "windows", "chrome"}
-        for d in devices:
-            did = d["id"]
-            name = d.get("name", "").lower()
-            if did in skip or "chrome" in name:
-                continue
-            print(did)
-            sys.exit(0)
-        sys.exit(1)
-        ' 2>/dev/null)
+        DEVICE=$({{.FDB}} devices 2>/dev/null \
+          | grep '^DEVICE_ID=' \
+          | head -1 \
+          | sed 's/DEVICE_ID=\([^ ]*\).*/\1/')
         if [ -z "$DEVICE" ]; then
-          echo "ERROR: No mobile device or simulator found. Start a simulator or connect a device." >&2
+          echo "ERROR: No device found. Start a simulator or connect a device." >&2
           exit 1
         fi
         echo "$DEVICE"
@@ -46,6 +37,25 @@ tasks:
   # ---------------------------------------------------------------------------
   # Individual fdb command tests
   # ---------------------------------------------------------------------------
+  test:devices:
+    desc: "List connected devices"
+    cmds:
+      - |
+        echo "==> Listing devices"
+        OUTPUT=$({{.FDB}} devices 2>&1)
+        EXIT_CODE=$?
+        echo "$OUTPUT"
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "FAIL: fdb devices exited with code $EXIT_CODE" >&2
+          exit 1
+        fi
+        if echo "$OUTPUT" | grep -q "DEVICE_ID="; then
+          echo "PASS: fdb devices"
+        else
+          echo "FAIL: fdb devices - no DEVICE_ID= lines in output" >&2
+          exit 1
+        fi
+
   test:launch:
     desc: "Launch the test app on a device (set DEVICE or auto-detect)"
     vars:
@@ -278,6 +288,7 @@ tasks:
       - task: setup
       - defer:
           task: cleanup
+      - task: test:devices
       - task: test:launch
         vars:
           DEVICE: '{{.DEVICE}}'

--- a/bin/fdb.dart
+++ b/bin/fdb.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:fdb/commands/devices.dart';
 import 'package:fdb/commands/kill.dart';
 import 'package:fdb/commands/launch.dart';
 import 'package:fdb/commands/logs.dart';
@@ -15,6 +16,7 @@ const usage = '''
 Usage: fdb <command> [args]
 
 Commands:
+  devices     List connected devices
   launch      Launch a Flutter app
   reload      Hot reload the running app
   restart     Hot restart the running app
@@ -47,6 +49,8 @@ Future<void> main(List<String> args) async {
 
 Future<int> _runCommand(String command, List<String> args) {
   switch (command) {
+    case 'devices':
+      return runDevices(args);
     case 'launch':
       return runLaunch(args);
     case 'reload':

--- a/docs/README.agents.md
+++ b/docs/README.agents.md
@@ -68,6 +68,7 @@ curl -fsSL https://raw.githubusercontent.com/andrzejchm/fdb/main/docs/skills/int
 
 | Command | Description |
 |---------|-------------|
+| `fdb devices` | List connected devices |
 | `fdb launch --device <id> --project <path>` | Launch app, wait for start |
 | `fdb reload` | Hot reload (SIGUSR1) |
 | `fdb restart` | Hot restart (SIGUSR2) |
@@ -87,7 +88,7 @@ fdb launch --device <device_id> --project <path> [--flavor <flavor>] [--target <
 
 Output: `APP_STARTED`, `VM_SERVICE_URI=...`, `PID=...`, `LOG_FILE=...`
 
-Find device IDs: `flutter devices`
+Find device IDs: `fdb devices`
 
 ### Hot reload / restart
 
@@ -137,16 +138,11 @@ fdb kill      # stop app, clean up temp files
 ## Agent Patterns
 
 ```bash
-# Launch app, inspect it, then kill
-DEVICE=$(flutter devices --machine 2>/dev/null | python3 -c '
-import json, sys
-devices = json.load(sys.stdin)
-skip = {"macos", "linux", "windows", "chrome"}
-for d in devices:
-    if d["id"] not in skip:
-        print(d["id"]); sys.exit(0)
-sys.exit(1)
-')
+# List available devices
+fdb devices
+
+# Pick a device ID from the output and launch
+DEVICE=$(fdb devices 2>/dev/null | grep '^DEVICE_ID=' | head -1 | sed 's/DEVICE_ID=\([^ ]*\).*/\1/')
 fdb launch --device "$DEVICE" --project /path/to/flutter/app
 fdb tree --depth 5 --user-only
 fdb screenshot

--- a/docs/skills/interacting-with-flutter-apps/SKILL.md
+++ b/docs/skills/interacting-with-flutter-apps/SKILL.md
@@ -15,6 +15,19 @@ Verify: `fdb status`
 
 ## Commands
 
+### List devices
+
+```bash
+fdb devices
+```
+
+Output (one line per device):
+```
+DEVICE_ID=<id> NAME=<name> PLATFORM=<targetPlatform> EMULATOR=<true|false>
+```
+
+Lists all devices Flutter can target: physical phones, emulators, simulators, desktop, and web.
+
 ### Launch app
 
 ```bash
@@ -23,7 +36,7 @@ fdb launch --device <device_id> --project <path> [--flavor <flavor>] [--target <
 
 Output: `APP_STARTED`, `VM_SERVICE_URI=...`, `PID=...`, `LOG_FILE=...`
 
-Find device IDs: `flutter devices`
+Find device IDs: `fdb devices`
 
 ### Hot reload / restart
 

--- a/lib/commands/devices.dart
+++ b/lib/commands/devices.dart
@@ -1,0 +1,61 @@
+import 'dart:convert';
+import 'dart:io';
+
+/// Lists connected devices by running `flutter devices --machine` and
+/// emitting one KEY=VALUE line per device.
+Future<int> runDevices(List<String> args) async {
+  final result = await Process.run('flutter', [
+    'devices',
+    '--machine',
+  ]);
+
+  if (result.exitCode != 0) {
+    stderr.writeln('ERROR: flutter devices failed: ${result.stderr}');
+    return 1;
+  }
+
+  final json = _extractJson(result.stdout as String);
+  if (json == null) {
+    stderr.writeln('ERROR: No devices found');
+    return 1;
+  }
+
+  final List<dynamic> devices;
+  try {
+    devices = jsonDecode(json) as List<dynamic>;
+  } catch (e) {
+    stderr.writeln('ERROR: Failed to parse flutter devices output: $e');
+    return 1;
+  }
+
+  if (devices.isEmpty) {
+    stderr.writeln('ERROR: No devices found');
+    return 1;
+  }
+
+  for (final device in devices) {
+    final d = device as Map<String, dynamic>;
+    final id = d['id'] as String;
+    final name = d['name'] as String;
+    final platform = d['targetPlatform'] as String;
+    final emulator = d['emulator'] as bool;
+    stdout.writeln(
+      'DEVICE_ID=$id NAME=$name PLATFORM=$platform EMULATOR=$emulator',
+    );
+  }
+  return 0;
+}
+
+/// Extracts the JSON array from `flutter devices --machine` output.
+///
+/// Flutter may prepend non-JSON text (download progress, upgrade banners)
+/// before the actual JSON array. We scan for the first `[` to find the
+/// array start.
+String? _extractJson(String output) {
+  final start = output.indexOf('[');
+  if (start == -1) return null;
+  // Find the matching closing bracket from the end
+  final end = output.lastIndexOf(']');
+  if (end == -1 || end < start) return null;
+  return output.substring(start, end + 1);
+}


### PR DESCRIPTION
Agents had to shell out to `flutter devices --machine` + Python to discover device IDs before launching. This adds `fdb devices` so they can stay within fdb.

Wraps `flutter devices --machine` rather than reimplementing discovery with `adb`/`xcrun simctl` -- covers all platforms Flutter supports (Android, iOS physical+simulator, macOS, Linux, Windows, Chrome) with zero maintenance. Parses JSON defensively to handle known Flutter stdout pollution bugs.

Also replaces the Python-based `detect-device` Taskfile task with `fdb devices` and updates all docs.

Closes #3