### PR TITLE
feat: Add fdb devices command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Guide for AI coding agents working in this repository.
 
-## 1. Project Overview
+## Project Overview
 
 **fdb (Flutter Debug Bridge)** — a pure Dart CLI tool that lets AI agents interact
 with running Flutter apps on physical devices and simulators. It launches Flutter apps
@@ -24,6 +24,7 @@ lib/
   process_utils.dart          # PID/process helper functions
   vm_service.dart             # WebSocket JSON-RPC to Flutter VM service
   commands/
+    devices.dart              # List connected devices
     kill.dart                 # Stop running app
     launch.dart               # Launch Flutter app detached
     logs.dart                 # Filtered log viewing + follow mode
@@ -36,138 +37,38 @@ lib/
     tree.dart                 # Widget tree inspection
 ```
 
-## 2. Build / Lint / Test Commands
-
-There is no build step, no CI, no test suite, and no analysis_options.yaml yet.
-Standard Dart tooling applies:
+## Build Commands
 
 ```bash
-# Install dependencies (currently none)
-dart pub get
-
-# Run locally without installing
-dart run bin/fdb.dart <command> [args]
-
-# Install globally from local path
-dart pub global activate --source path .
-
-# Install globally from git
-dart pub global activate --source git https://github.com/andrzejchm/fdb.git
-
-# Static analysis (uses Dart defaults — no analysis_options.yaml)
-dart analyze
-
-# Format
-dart format .
-
-# Run all tests (none exist yet)
-dart test
-
-# Run a single test file
-dart test test/path/to_test.dart
-
-# Run a single test by name
-dart test --name "test description" test/path/to_test.dart
+dart pub get                          # Install dependencies
+dart run bin/fdb.dart <command>       # Run locally
+dart pub global activate --source path .  # Install globally (local)
+dart analyze                          # Static analysis
+dart format .                         # Format
 ```
 
-## 3. Code Style Guidelines
+## References
 
-### Imports
+| Topic | What it covers | Reference |
+|-------|---------------|-----------|
+| Testing | Test commands, requirements, output conventions | [TESTING.md](TESTING.md) |
+| Code style | Imports, naming, formatting, architecture, error handling | [CODE-STYLE.md](CODE-STYLE.md) |
 
-1. `dart:` SDK imports first, sorted alphabetically.
-2. Blank line.
-3. `package:fdb/...` imports, sorted alphabetically.
-4. No third-party packages — do not add dependencies without explicit approval.
+### Testing (quick reference)
 
-```dart
-import 'dart:async';
-import 'dart:convert';
-import 'dart:io';
+- Every change must be tested before a PR is opened.
+- `task smoke` — full end-to-end test of all commands.
+- `task test:<command>` — individual command test.
+- `task analyze` — lint + format check.
 
-import 'package:fdb/constants.dart';
-import 'package:fdb/process_utils.dart';
-```
+**Full details**: [TESTING.md](TESTING.md)
 
-### Naming conventions
+### Code style (quick reference)
 
-| Element              | Convention    | Example                        |
-|----------------------|---------------|--------------------------------|
-| Files                | `snake_case`  | `process_utils.dart`           |
-| Top-level functions  | `camelCase`   | `runLaunch`, `readPid`         |
-| Private functions    | `_camelCase`  | `_extractVmUri`, `_isAlive`    |
-| Constants            | `camelCase`   | `pidFile`, `launchTimeoutSeconds` |
-| Variables            | `camelCase`   | `vmUri`, `launcherPid`         |
-| Command entry points | `runXxx`      | `runKill`, `runTree`           |
+- No classes — top-level functions only.
+- No third-party packages.
+- Each command: `lib/commands/<name>.dart` exporting `Future<int> runXxx(List<String> args)`.
+- Errors to `stderr` prefixed with `ERROR: `, status tokens to `stdout` in `UPPER_SNAKE_CASE`.
+- Manual arg parsing with `for` loop + `switch`.
 
-### Formatting
-
-- 2-space indentation (Dart default).
-- Single quotes for strings.
-- Trailing commas on multi-line parameter lists.
-- String interpolation: `'$variable'` / `'${expression}'`.
-- `final` for all local variables that are not reassigned.
-- `var` only when the variable is reassigned later.
-- `const` for compile-time constants (top-level and in constructors).
-
-### Dart 3.x features in use
-
-- Switch expressions without `break`:
-  ```dart
-  switch (args[i]) {
-    case '--device':
-      device = args[++i];
-    case '--project':
-      project = args[++i];
-  }
-  ```
-- Collection `if` / spread: `if (flavor != null) ...['--flavor', flavor]`
-- Type casts with `as` on JSON maps: `response['result'] as Map<String, dynamic>?`
-
-### Types
-
-- Use explicit types for function signatures and return types.
-- Use `var` / `final` for local variable inference when the type is obvious.
-- JSON values are typed as `Map<String, dynamic>` or `List<dynamic>`.
-- Nullable types with `?` — always null-check before use.
-
-### Architecture
-
-- **No classes.** The codebase is entirely top-level functions and constants.
-- Each command lives in its own file under `lib/commands/` and exports
-  exactly one public function: `Future<int> runXxx(List<String> args)`.
-- Shared logic goes in `lib/` root files (`process_utils.dart`,
-  `vm_service.dart`, `constants.dart`).
-- Arguments are parsed manually with a `for` loop + `switch` — no CLI framework.
-
-### Error handling
-
-- Every command function returns `Future<int>` — `0` for success, `1` for failure.
-- Errors go to `stderr` prefixed with `ERROR: `:
-  ```dart
-  stderr.writeln('ERROR: No PID file found. Is the app running?');
-  return 1;
-  ```
-- Machine-readable status tokens go to `stdout` in `UPPER_SNAKE_CASE`:
-  `APP_STARTED`, `APP_KILLED`, `RELOADED`, `SCREENSHOT_SAVED=<path>`.
-- Key=value pairs on stdout for structured output: `PID=12345`, `VM_SERVICE_URI=ws://...`.
-- `catch (_)` only for non-critical failures where the error value is irrelevant
-  (e.g., checking if a process is still alive).
-- `StateError` for missing preconditions (VM service URI not found).
-- `TimeoutException` is caught and rethrown — never swallowed.
-- Null-check every external data read (files, JSON fields, process output).
-- The top-level `main` in `bin/fdb.dart` has a catch-all that writes to stderr
-  and exits with code 1.
-
-### Doc comments
-
-- Use `///` doc comments on public functions that are non-trivial.
-- Skip doc comments on simple command entry points where the name is self-explanatory.
-- Inline `//` comments for non-obvious logic.
-
-### Adding a new command
-
-1. Create `lib/commands/your_command.dart` with `Future<int> runYourCommand(List<String> args)`.
-2. Write errors to `stderr` prefixed with `ERROR: `, status tokens to `stdout`.
-3. Add a `case` to the `switch` in `bin/fdb.dart:_runCommand`.
-4. Add the command to the `usage` string in `bin/fdb.dart`.
-5. Update `README.md` commands table.
+**Full details**: [CODE-STYLE.md](CODE-STYLE.md)

--- a/CODE-STYLE.md
+++ b/CODE-STYLE.md
@@ -1,0 +1,114 @@
+# Code Style
+
+Rules for writing Dart code in the fdb codebase.
+
+## Contents
+- Imports
+- Naming Conventions
+- Formatting
+- Dart 3.x Features
+- Types
+- Architecture
+- Error Handling
+- Doc Comments
+- Adding a New Command
+
+## Imports
+
+1. `dart:` SDK imports first, sorted alphabetically.
+2. Blank line.
+3. `package:fdb/...` imports, sorted alphabetically.
+4. No third-party packages — do not add dependencies without explicit approval.
+
+```dart
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:fdb/constants.dart';
+import 'package:fdb/process_utils.dart';
+```
+
+## Naming Conventions
+
+| Element              | Convention    | Example                        |
+|----------------------|---------------|--------------------------------|
+| Files                | `snake_case`  | `process_utils.dart`           |
+| Top-level functions  | `camelCase`   | `runLaunch`, `readPid`         |
+| Private functions    | `_camelCase`  | `_extractVmUri`, `_isAlive`    |
+| Constants            | `camelCase`   | `pidFile`, `launchTimeoutSeconds` |
+| Variables            | `camelCase`   | `vmUri`, `launcherPid`         |
+| Command entry points | `runXxx`      | `runKill`, `runTree`           |
+
+## Formatting
+
+- 2-space indentation (Dart default).
+- Single quotes for strings.
+- Trailing commas on multi-line parameter lists.
+- String interpolation: `'$variable'` / `'${expression}'`.
+- `final` for all local variables that are not reassigned.
+- `var` only when the variable is reassigned later.
+- `const` for compile-time constants (top-level and in constructors).
+
+## Dart 3.x Features
+
+- Switch expressions without `break`:
+  ```dart
+  switch (args[i]) {
+    case '--device':
+      device = args[++i];
+    case '--project':
+      project = args[++i];
+  }
+  ```
+- Collection `if` / spread: `if (flavor != null) ...['--flavor', flavor]`
+- Type casts with `as` on JSON maps: `response['result'] as Map<String, dynamic>?`
+
+## Types
+
+- Use explicit types for function signatures and return types.
+- Use `var` / `final` for local variable inference when the type is obvious.
+- JSON values are typed as `Map<String, dynamic>` or `List<dynamic>`.
+- Nullable types with `?` — always null-check before use.
+
+## Architecture
+
+- **No classes.** The codebase is entirely top-level functions and constants.
+- Each command lives in its own file under `lib/commands/` and exports
+  exactly one public function: `Future<int> runXxx(List<String> args)`.
+- Shared logic goes in `lib/` root files (`process_utils.dart`,
+  `vm_service.dart`, `constants.dart`).
+- Arguments are parsed manually with a `for` loop + `switch` — no CLI framework.
+
+## Error Handling
+
+- Every command function returns `Future<int>` — `0` for success, `1` for failure.
+- Errors go to `stderr` prefixed with `ERROR: `:
+  ```dart
+  stderr.writeln('ERROR: No PID file found. Is the app running?');
+  return 1;
+  ```
+- Machine-readable status tokens go to `stdout` in `UPPER_SNAKE_CASE`:
+  `APP_STARTED`, `APP_KILLED`, `RELOADED`, `SCREENSHOT_SAVED=<path>`.
+- Key=value pairs on stdout for structured output: `PID=12345`, `VM_SERVICE_URI=ws://...`.
+- `catch (_)` only for non-critical failures where the error value is irrelevant
+  (e.g., checking if a process is still alive).
+- `StateError` for missing preconditions (VM service URI not found).
+- `TimeoutException` is caught and rethrown — never swallowed.
+- Null-check every external data read (files, JSON fields, process output).
+- The top-level `main` in `bin/fdb.dart` has a catch-all that writes to stderr
+  and exits with code 1.
+
+## Doc Comments
+
+- Use `///` doc comments on public functions that are non-trivial.
+- Skip doc comments on simple command entry points where the name is self-explanatory.
+- Inline `//` comments for non-obvious logic.
+
+## Adding a New Command
+
+1. Create `lib/commands/your_command.dart` with `Future<int> runYourCommand(List<String> args)`.
+2. Write errors to `stderr` prefixed with `ERROR: `, status tokens to `stdout`.
+3. Add a `case` to the `switch` in `bin/fdb.dart:_runCommand`.
+4. Add the command to the `usage` string in `bin/fdb.dart`.
+5. Update `README.md` commands table.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ fdb kill
 
 | Command | Description |
 |---------|-------------|
+| `fdb devices` | List connected devices |
 | `fdb launch --device <id> --project <path>` | Launch app, wait for start |
 | `fdb reload` | Hot reload |
 | `fdb restart` | Hot restart |

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,58 @@
+# Testing
+
+Rules and commands for testing fdb changes.
+
+## Contents
+- Requirements
+- Test Commands
+- Test Output Conventions
+- Adding Tests for New Commands
+
+## Requirements
+
+Every change must be tested before work is considered done. Do not
+create a pull request until you have verified the change works by
+running the appropriate tests and confirming they pass.
+
+## Test Commands
+
+```bash
+# Full end-to-end smoke test (all commands)
+task smoke
+task smoke DEVICE=iPhone-16    # specific device
+
+# Individual command tests (app must be running for most)
+task test:devices
+task test:launch DEVICE=<id>
+task test:status
+task test:reload
+task test:restart
+task test:logs
+task test:logs-tag
+task test:tree
+task test:screenshot
+task test:select
+task test:kill
+task test:status-stopped
+
+# Static analysis + formatting
+task analyze
+
+# Unit tests
+task test:unit
+
+# Cleanup
+task cleanup
+```
+
+## Test Output Conventions
+
+Each test task prints:
+- `PASS: fdb <command>` on success.
+- `FAIL: fdb <command> - <reason>` on failure (to stderr, exits 1).
+
+## Adding Tests for New Commands
+
+1. Add a `test:your-command` task to `Taskfile.yml` following the existing pattern.
+2. Add the new task to the `smoke` task sequence.
+3. Run `task test:your-command` and confirm `PASS` before opening a PR.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -21,24 +21,15 @@ tasks:
   # Device detection
   # ---------------------------------------------------------------------------
   detect-device:
-    desc: Auto-detect a connected device ID (iOS Simulator or Android emulator)
+    desc: Auto-detect a connected device ID (first device reported by fdb devices)
     cmds:
       - |
-        DEVICE=$(flutter devices --machine 2>/dev/null | python3 -c '
-        import json, sys
-        devices = json.load(sys.stdin)
-        skip = {"macos", "linux", "windows", "chrome"}
-        for d in devices:
-            did = d["id"]
-            name = d.get("name", "").lower()
-            if did in skip or "chrome" in name:
-                continue
-            print(did)
-            sys.exit(0)
-        sys.exit(1)
-        ' 2>/dev/null)
+        DEVICE=$({{.FDB}} devices 2>/dev/null \
+          | grep '^DEVICE_ID=' \
+          | head -1 \
+          | sed 's/DEVICE_ID=\([^ ]*\).*/\1/')
         if [ -z "$DEVICE" ]; then
-          echo "ERROR: No mobile device or simulator found. Start a simulator or connect a device." >&2
+          echo "ERROR: No device found. Start a simulator or connect a device." >&2
           exit 1
         fi
         echo "$DEVICE"
@@ -46,6 +37,25 @@ tasks:
   # ---------------------------------------------------------------------------
   # Individual fdb command tests
   # ---------------------------------------------------------------------------
+  test:devices:
+    desc: "List connected devices"
+    cmds:
+      - |
+        echo "==> Listing devices"
+        OUTPUT=$({{.FDB}} devices 2>&1)
+        EXIT_CODE=$?
+        echo "$OUTPUT"
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "FAIL: fdb devices exited with code $EXIT_CODE" >&2
+          exit 1
+        fi
+        if echo "$OUTPUT" | grep -q "DEVICE_ID="; then
+          echo "PASS: fdb devices"
+        else
+          echo "FAIL: fdb devices - no DEVICE_ID= lines in output" >&2
+          exit 1
+        fi
+
   test:launch:
     desc: "Launch the test app on a device (set DEVICE or auto-detect)"
     vars:
@@ -278,6 +288,7 @@ tasks:
       - task: setup
       - defer:
           task: cleanup
+      - task: test:devices
       - task: test:launch
         vars:
           DEVICE: '{{.DEVICE}}'

--- a/bin/fdb.dart
+++ b/bin/fdb.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:fdb/commands/devices.dart';
 import 'package:fdb/commands/kill.dart';
 import 'package:fdb/commands/launch.dart';
 import 'package:fdb/commands/logs.dart';
@@ -15,6 +16,7 @@ const usage = '''
 Usage: fdb <command> [args]
 
 Commands:
+  devices     List connected devices
   launch      Launch a Flutter app
   reload      Hot reload the running app
   restart     Hot restart the running app
@@ -47,6 +49,8 @@ Future<void> main(List<String> args) async {
 
 Future<int> _runCommand(String command, List<String> args) {
   switch (command) {
+    case 'devices':
+      return runDevices(args);
     case 'launch':
       return runLaunch(args);
     case 'reload':

--- a/docs/README.agents.md
+++ b/docs/README.agents.md
@@ -68,6 +68,7 @@ curl -fsSL https://raw.githubusercontent.com/andrzejchm/fdb/main/docs/skills/int
 
 | Command | Description |
 |---------|-------------|
+| `fdb devices` | List connected devices |
 | `fdb launch --device <id> --project <path>` | Launch app, wait for start |
 | `fdb reload` | Hot reload (SIGUSR1) |
 | `fdb restart` | Hot restart (SIGUSR2) |
@@ -87,7 +88,7 @@ fdb launch --device <device_id> --project <path> [--flavor <flavor>] [--target <
 
 Output: `APP_STARTED`, `VM_SERVICE_URI=...`, `PID=...`, `LOG_FILE=...`
 
-Find device IDs: `flutter devices`
+Find device IDs: `fdb devices`
 
 ### Hot reload / restart
 
@@ -137,16 +138,11 @@ fdb kill      # stop app, clean up temp files
 ## Agent Patterns
 
 ```bash
-# Launch app, inspect it, then kill
-DEVICE=$(flutter devices --machine 2>/dev/null | python3 -c '
-import json, sys
-devices = json.load(sys.stdin)
-skip = {"macos", "linux", "windows", "chrome"}
-for d in devices:
-    if d["id"] not in skip:
-        print(d["id"]); sys.exit(0)
-sys.exit(1)
-')
+# List available devices
+fdb devices
+
+# Pick a device ID from the output and launch
+DEVICE=$(fdb devices 2>/dev/null | grep '^DEVICE_ID=' | head -1 | sed 's/DEVICE_ID=\([^ ]*\).*/\1/')
 fdb launch --device "$DEVICE" --project /path/to/flutter/app
 fdb tree --depth 5 --user-only
 fdb screenshot

--- a/docs/skills/interacting-with-flutter-apps/SKILL.md
+++ b/docs/skills/interacting-with-flutter-apps/SKILL.md
@@ -15,6 +15,19 @@ Verify: `fdb status`
 
 ## Commands
 
+### List devices
+
+```bash
+fdb devices
+```
+
+Output (one line per device):
+```
+DEVICE_ID=<id> NAME=<name> PLATFORM=<targetPlatform> EMULATOR=<true|false>
+```
+
+Lists all devices Flutter can target: physical phones, emulators, simulators, desktop, and web.
+
 ### Launch app
 
 ```bash
@@ -23,7 +36,7 @@ fdb launch --device <device_id> --project <path> [--flavor <flavor>] [--target <
 
 Output: `APP_STARTED`, `VM_SERVICE_URI=...`, `PID=...`, `LOG_FILE=...`
 
-Find device IDs: `flutter devices`
+Find device IDs: `fdb devices`
 
 ### Hot reload / restart
 

--- a/lib/commands/devices.dart
+++ b/lib/commands/devices.dart
@@ -1,0 +1,61 @@
+import 'dart:convert';
+import 'dart:io';
+
+/// Lists connected devices by running `flutter devices --machine` and
+/// emitting one KEY=VALUE line per device.
+Future<int> runDevices(List<String> args) async {
+  final result = await Process.run('flutter', [
+    'devices',
+    '--machine',
+  ]);
+
+  if (result.exitCode != 0) {
+    stderr.writeln('ERROR: flutter devices failed: ${result.stderr}');
+    return 1;
+  }
+
+  final json = _extractJson(result.stdout as String);
+  if (json == null) {
+    stderr.writeln('ERROR: No devices found');
+    return 1;
+  }
+
+  final List<dynamic> devices;
+  try {
+    devices = jsonDecode(json) as List<dynamic>;
+  } catch (e) {
+    stderr.writeln('ERROR: Failed to parse flutter devices output: $e');
+    return 1;
+  }
+
+  if (devices.isEmpty) {
+    stderr.writeln('ERROR: No devices found');
+    return 1;
+  }
+
+  for (final device in devices) {
+    final d = device as Map<String, dynamic>;
+    final id = d['id'] as String;
+    final name = d['name'] as String;
+    final platform = d['targetPlatform'] as String;
+    final emulator = d['emulator'] as bool;
+    stdout.writeln(
+      'DEVICE_ID=$id NAME=$name PLATFORM=$platform EMULATOR=$emulator',
+    );
+  }
+  return 0;
+}
+
+/// Extracts the JSON array from `flutter devices --machine` output.
+///
+/// Flutter may prepend non-JSON text (download progress, upgrade banners)
+/// before the actual JSON array. We scan for the first `[` to find the
+/// array start.
+String? _extractJson(String output) {
+  final start = output.indexOf('[');
+  if (start == -1) return null;
+  // Find the matching closing bracket from the end
+  final end = output.lastIndexOf(']');
+  if (end == -1 || end < start) return null;
+  return output.substring(start, end + 1);
+}


### PR DESCRIPTION
Agents had to shell out to `flutter devices --machine` + Python to discover device IDs before launching. This adds `fdb devices` so they can stay within fdb.

Wraps `flutter devices --machine` rather than reimplementing discovery with `adb`/`xcrun simctl` -- covers all platforms Flutter supports (Android, iOS physical+simulator, macOS, Linux, Windows, Chrome) with zero maintenance. Parses JSON defensively to handle known Flutter stdout pollution bugs.

Also replaces the Python-based `detect-device` Taskfile task with `fdb devices` and updates all docs.

Closes #3