### PR TITLE
feat: all-platform screenshot support and session directory migration

### DIFF
--- a/.agents/skills/testing-fdb/SKILL.md
+++ b/.agents/skills/testing-fdb/SKILL.md
@@ -67,7 +67,7 @@ task test:unit    # dart test (when tests exist)
 ### Cleanup
 
 ```bash
-task cleanup    # kill app, remove /tmp/fdb_* files
+task cleanup    # kill app, remove ~/.fdb/sessions/ state files
 ```
 
 ## Test output conventions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Guide for AI coding agents working in this repository.
 **fdb (Flutter Debug Bridge)** — a pure Dart CLI tool that lets AI agents interact
 with running Flutter apps on physical devices and simulators. It launches Flutter apps
 as detached processes, communicates via POSIX signals and the VM Service Protocol
-over WebSocket, and stores all state in `/tmp/fdb_*` files.
+over WebSocket, and stores all state in `~/.fdb/sessions/<hash>/` directories.
 
 - **Language:** Dart 3.x (SDK `>=3.0.0 <4.0.0`)
 - **Runtime:** Dart VM (standalone — not a Flutter app)
@@ -24,6 +24,7 @@ lib/
   process_utils.dart          # PID/process helper functions
   vm_service.dart             # WebSocket JSON-RPC to Flutter VM service
   commands/
+    deeplink.dart             # Open deep link in app
     devices.dart              # List connected devices
     input.dart                # Enter text into a widget
     kill.dart                 # Stop running app
@@ -31,7 +32,7 @@ lib/
     logs.dart                 # Filtered log viewing + follow mode
     reload.dart               # Hot reload via SIGUSR1
     restart.dart              # Hot restart via SIGUSR2
-    screenshot.dart           # Device screenshot (adb / xcrun)
+    screenshot.dart           # Screenshot (all platforms)
     scroll.dart               # Scroll / swipe gesture
     select.dart               # Toggle widget selection mode
     selected.dart             # Get selected widget info
@@ -40,6 +41,14 @@ lib/
     tree.dart                 # Widget tree inspection
 packages/
   fdb_helper/                 # Flutter package — registers VM service extensions
+~/.fdb/
+  sessions/<hash>/
+    session.json              # Active session state (PID, VM URI, device, project)
+    logs.txt                  # Tee'd flutter run output
+    screenshot.png            # Last screenshot
+    launcher.sh               # Generated bash script that runs flutter run
+    flutter.pid               # PID written by flutter run via --pid-file
+  devices.json                # Cached device list
 ```
 
 ## Build Commands

--- a/CODE-STYLE.md
+++ b/CODE-STYLE.md
@@ -111,4 +111,8 @@ import 'package:fdb/process_utils.dart';
 2. Write errors to `stderr` prefixed with `ERROR: `, status tokens to `stdout`.
 3. Add a `case` to the `switch` in `bin/fdb.dart:_runCommand`.
 4. Add the command to the `usage` string in `bin/fdb.dart`.
-5. Update `README.md` commands table.
+5. Add a `test:your-command` task to `Taskfile.yml`.
+6. Add `test:your-command` to the `smoke` task sequence in `Taskfile.yml`.
+7. Update `README.md` commands table.
+8. Update `docs/skills/interacting-with-flutter-apps/SKILL.md` commands reference.
+9. Update `docs/README.agents.md` commands reference.

--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ fdb kill
 |---------|-------------|
 | `fdb devices` | List connected devices |
 | `fdb deeplink <url>` | Open deep link on device |
-| `fdb launch --device <id> --project <path>` | Launch app, wait for start |
+| `fdb launch --device <id> --project <path>` | Launch app on device, wait for start |
 | `fdb reload` | Hot reload |
 | `fdb restart` | Hot restart |
-| `fdb screenshot [--output <path>]` | Device screenshot |
+| `fdb screenshot [--output <path>]` | Screenshot (all platforms) |
 | `fdb logs --tag <tag> --last <n>` | Filtered logs |
 | `fdb tree --depth <n> [--user-only]` | Widget tree |
 | `fdb select on/off` | Widget selection mode |
@@ -104,7 +104,7 @@ sequenceDiagram
 
     Agent->>fdb: fdb launch
     fdb->>Device: flutter run (detached)
-    fdb-->>fdb: save PID & VM URI to /tmp
+    fdb-->>fdb: save PID & VM URI to ~/.fdb/sessions/<hash>/session.json
     fdb-->>Agent: APP_STARTED
 
     Agent->>fdb: fdb reload
@@ -112,8 +112,8 @@ sequenceDiagram
     fdb-->>Agent: RELOADED
 
     Agent->>fdb: fdb screenshot
-    fdb->>Device: adb screencap / xcrun simctl
-    fdb-->>Agent: SCREENSHOT_SAVED=/tmp/fdb_screenshot.png
+    fdb->>Device: adb / xcrun / screencapture / CDP / fdb_helper
+    fdb-->>Agent: SCREENSHOT_SAVED=~/.fdb/sessions/<hash>/screenshot.png
 
     Agent->>fdb: fdb tree
     fdb->>Device: VM Service (WebSocket)
@@ -124,8 +124,8 @@ sequenceDiagram
     fdb-->>Agent: APP_KILLED
 ```
 
-- All state in `/tmp/fdb_*` files -- no config, no database, no daemon
-- Screenshots auto-detect Android (`adb`) vs iOS (`xcrun`)
+- All state in `~/.fdb/sessions/<hash>/` -- no config, no database, no daemon
+- Screenshots support all platforms: Android (`adb`), iOS sim (`xcrun`), macOS (`screencapture`), Linux X11 (`xdotool`+`import`), Web/Chrome (CDP), and physical iOS / Windows / Linux Wayland via `fdb_helper`
 - Widget inspection via VM Service Protocol over WebSocket
 
 ### Widget Interaction (tap, input, scroll)

--- a/TESTING.md
+++ b/TESTING.md
@@ -31,7 +31,9 @@ task test:logs
 task test:logs-tag
 task test:tree
 task test:screenshot
+task test:deeplink
 task test:select
+task test:selected
 task test:tap
 task test:input
 task test:scroll

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -192,7 +192,12 @@ tasks:
           exit 1
         fi
         if echo "$OUTPUT" | grep -q "SCREENSHOT_SAVED"; then
-          echo "PASS: fdb screenshot"
+          if [ -f /tmp/fdb_test_screenshot.png ]; then
+            echo "PASS: fdb screenshot"
+          else
+            echo "FAIL: fdb screenshot - SCREENSHOT_SAVED in output but file does not exist" >&2
+            exit 1
+          fi
         else
           echo "FAIL: fdb screenshot - SCREENSHOT_SAVED not found" >&2
           exit 1
@@ -248,6 +253,25 @@ tasks:
           echo "PASS: fdb select off"
         else
           echo "FAIL: fdb select off - SELECTION_MODE=OFF not found" >&2
+          exit 1
+        fi
+
+  test:selected:
+    desc: Get the currently selected widget info
+    cmds:
+      - |
+        echo "==> Getting selected widget info"
+        OUTPUT=$({{.FDB}} selected 2>&1)
+        EXIT_CODE=$?
+        echo "$OUTPUT"
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "FAIL: fdb selected exited with code $EXIT_CODE" >&2
+          exit 1
+        fi
+        if echo "$OUTPUT" | grep -qE "^SELECTED:|^NO_WIDGET_SELECTED$"; then
+          echo "PASS: fdb selected"
+        else
+          echo "FAIL: fdb selected - expected SELECTED: or NO_WIDGET_SELECTED in output" >&2
           exit 1
         fi
 
@@ -345,13 +369,13 @@ tasks:
   # Cleanup
   # ---------------------------------------------------------------------------
   cleanup:
-    desc: Force-kill any running fdb app and clean up temp files
+    desc: Force-kill any running fdb app and clean up session directories
     cmds:
-      - |
-        {{.FDB}} kill 2>/dev/null || true
-        rm -f /tmp/fdb.pid /tmp/fdb_logs.txt /tmp/fdb_vm_uri.txt /tmp/fdb_launcher.sh
-        rm -f /tmp/fdb_screenshot.png /tmp/fdb_test_screenshot.png
-        echo "Cleanup done"
+      - '{{.FDB}} kill{{if .DEVICE}} --device {{.DEVICE}}{{end}} 2>/dev/null || true'
+      - rm -rf ~/.fdb/sessions/
+      - rm -f ~/.fdb/devices.json
+      - rm -f /tmp/fdb_test_screenshot.png
+      - echo "Cleanup done"
 
   # ---------------------------------------------------------------------------
   # Full smoke test — runs all commands in sequence
@@ -363,6 +387,8 @@ tasks:
         sh: '{{if .DEVICE}}echo "{{.DEVICE}}"{{else}}task detect-device{{end}}'
     cmds:
       - task: cleanup
+        vars:
+          DEVICE: '{{.DEVICE}}'
       - task: setup
       - defer:
           task: cleanup
@@ -379,6 +405,7 @@ tasks:
       - task: test:screenshot
       - task: test:deeplink
       - task: test:select
+      - task: test:selected
       - task: test:tap
       - task: test:input
       - task: test:scroll

--- a/bin/fdb.dart
+++ b/bin/fdb.dart
@@ -17,24 +17,30 @@ import 'package:fdb/commands/tap.dart';
 import 'package:fdb/commands/tree.dart';
 
 const usage = '''
-Usage: fdb <command> [args]
+Usage: fdb <command> [options]
 
 Commands:
-  devices     List connected devices
-  deeplink    Open a deep link URL on the device
-  launch      Launch a Flutter app
-  reload      Hot reload the running app
-  restart     Hot restart the running app
-  screenshot  Take a device screenshot
-  logs        Get filtered app logs
-  tree        Get the widget tree
-  tap         Tap a widget by selector
-  input       Enter text into a field
-  scroll      Scroll in a direction
-  select      Toggle widget selection mode
-  selected    Get the currently selected widget
-  status      Check if the app is running
-  kill        Stop the running app
+  devices      List connected Flutter devices
+  launch       Launch a Flutter app (--device, --project required)
+  kill         Stop a running app
+  status       Check if app is running
+  reload       Hot reload
+  restart      Hot restart
+  logs         View app logs (--last N, --follow, --tag TAG)
+  screenshot   Take a screenshot (--output PATH)
+  tree         Dump widget tree
+  tap          Tap a widget (--text, --key, --type, --x/--y)
+  input        Enter text into a focused field
+  scroll       Scroll/swipe gesture
+  select       Toggle widget selection mode
+  selected     Get info about selected widget
+  deeplink     Open a deep link in the app
+
+Global options:
+  --device ID  Target a specific device session (auto-detected if only one)
+
+Session state is stored in ~/.fdb/sessions/<device-hash>/
+Device cache is stored in ~/.fdb/devices.json
 ''';
 
 Future<void> main(List<String> args) async {

--- a/docs/README.agents.md
+++ b/docs/README.agents.md
@@ -62,13 +62,17 @@ curl -fsSL https://raw.githubusercontent.com/andrzejchm/fdb/main/docs/skills/int
 - Dart SDK >= 3.0.0
 - Flutter SDK (for `flutter devices`, `flutter run`)
 - A running iOS Simulator or Android emulator (or physical device)
-- `adb` for Android screenshots, `xcrun` for iOS simulator screenshots
+- `adb` for Android screenshots
+- `xcrun` (Xcode Command Line Tools) for iOS simulator screenshots
+- `screencapture` (Xcode CLT, macOS only) for macOS desktop screenshots
+- `xdotool` + `import` (ImageMagick) for Linux X11 screenshots
+- Physical iOS, Windows, and Linux Wayland screenshots use `fdb_helper` fallback (requires `fdb_helper` in the app)
 
 ## Commands Reference
 
 | Command | Description |
 |---------|-------------|
-| `fdb devices` | List connected devices |
+| `fdb devices` | List connected devices (one `DEVICE_ID=<id> NAME=<name> PLATFORM=<platform> EMULATOR=<true\|false>` line per device) |
 | `fdb deeplink <url>` | Open deep link on device |
 | `fdb launch --device <id> --project <path>` | Launch app, wait for start |
 | `fdb reload` | Hot reload (SIGUSR1) |
@@ -90,7 +94,16 @@ curl -fsSL https://raw.githubusercontent.com/andrzejchm/fdb/main/docs/skills/int
 fdb launch --device <device_id> --project <path> [--flavor <flavor>] [--target <target>]
 ```
 
-Output: `APP_STARTED`, `VM_SERVICE_URI=...`, `PID=...`, `LOG_FILE=...`
+Output tokens:
+```
+WAITING...          (repeated heartbeat while waiting for the app to start)
+APP_STARTED
+VM_SERVICE_URI=<uri>
+PID=<pid>
+LOG_FILE=<path>
+```
+
+On failure: `ERROR: Launch timed out after N seconds` (stderr).
 
 Find device IDs: `fdb devices`
 
@@ -101,13 +114,31 @@ fdb reload    # SIGUSR1 - preserves state
 fdb restart   # SIGUSR2 - resets state
 ```
 
+Output tokens on success: `RELOADED in <ms>ms` / `RESTARTED in <ms>ms`
+
+On failure: `ERROR: RELOAD_FAILED` / `ERROR: RESTART_FAILED` (stderr).
+
 ### Screenshot
 
 ```bash
 fdb screenshot [--output <path>]
 ```
 
-Auto-detects Android (`adb screencap`) vs iOS simulator (`xcrun simctl io screenshot`). Default output: `/tmp/fdb_screenshot.png`.
+Auto-detects the platform and uses the appropriate native tool:
+- Android: `adb screencap`
+- iOS simulator: `xcrun simctl io screenshot`
+- macOS desktop: `screencapture`
+- Linux X11: `xdotool` + `import`
+- Web/Chrome: Chrome DevTools Protocol (CDP)
+- Physical iOS, Windows, Linux Wayland: `fdb_helper` VM service extension (requires `fdb_helper` in the app)
+
+Default output: `~/.fdb/sessions/<hash>/screenshot.png`.
+
+Output tokens on success:
+```
+SCREENSHOT_SAVED=<path>
+SIZE=<size>
+```
 
 ### Logs
 
@@ -130,6 +161,13 @@ fdb tree --depth 3 --user-only
 fdb select on     # enable tap-to-select overlay on device
 fdb select off    # disable overlay
 fdb selected      # get what widget was tapped
+```
+
+`fdb selected` output tokens:
+```
+SELECTED: <widget description> (<file>:<line>)   # when creation location is known
+SELECTED: <widget description>                    # when creation location is unknown
+NO_WIDGET_SELECTED                                # when no widget has been tapped yet
 ```
 
 ### Widget interaction (tap, input, scroll)
@@ -179,8 +217,10 @@ Output tokens: `TAPPED=<type> X=<x> Y=<y>`, `INPUT=<type> VALUE=<text>`, `SCROLL
 
 ```bash
 fdb status    # RUNNING=true/false, PID, VM_SERVICE_URI
-fdb kill      # stop app, clean up temp files
+fdb kill      # stop app, clean up session files
 ```
+
+Session state is stored in `~/.fdb/sessions/<hash>/session.json`. The device list cache is stored in `~/.fdb/devices.json`.
 
 ## Agent Patterns
 
@@ -225,6 +265,6 @@ fdb logs --tag "fdb_test" --last 20       # check logs after interaction
 
 **Empty widget tree** -- Fall back to raw websocat commands (see the skill file for details).
 
-**Screenshot fails** -- Ensure `adb` (Android) or `xcrun` (iOS) is available and the device is connected.
+**Screenshot fails** -- Ensure the required tool is available for your platform: `adb` (Android), `xcrun` (iOS simulator / macOS), `xdotool`+`import` (Linux X11). For physical iOS, Windows, or Linux Wayland, ensure `fdb_helper` is added to the app.
 
 **Status shows RUNNING=false after launch** -- The Flutter process may have crashed. Check `fdb logs --last 50` for errors.

--- a/docs/skills/interacting-with-flutter-apps/SKILL.md
+++ b/docs/skills/interacting-with-flutter-apps/SKILL.md
@@ -62,9 +62,20 @@ Lists all devices Flutter can target: physical phones, emulators, simulators, de
 fdb launch --device <device_id> --project <path> [--flavor <flavor>] [--target <target>]
 ```
 
-Output: `APP_STARTED`, `VM_SERVICE_URI=...`, `PID=...`, `LOG_FILE=...`
+Output tokens:
+```
+WAITING...          (repeated heartbeat while waiting for the app to start)
+APP_STARTED
+VM_SERVICE_URI=<uri>
+PID=<pid>
+LOG_FILE=<path>
+```
+
+On failure: `ERROR: Launch timed out after N seconds` (stderr).
 
 Find device IDs: `fdb devices`
+
+The `--device` flag is accepted by all commands that need to identify the active session. When only one session is active it can be omitted.
 
 ### Hot reload / restart
 
@@ -73,13 +84,31 @@ fdb reload    # SIGUSR1 - preserves state
 fdb restart   # SIGUSR2 - resets state
 ```
 
+Output tokens on success: `RELOADED in <ms>ms` / `RESTARTED in <ms>ms`
+
+On failure: `ERROR: RELOAD_FAILED` / `ERROR: RESTART_FAILED` (stderr).
+
 ### Screenshot
 
 ```bash
 fdb screenshot [--output <path>]
 ```
 
-Auto-detects Android (`adb screencap`) vs iOS simulator (`xcrun simctl io screenshot`). Default output: `/tmp/fdb_screenshot.png`. Read the file with the Read tool to view it.
+Auto-detects the platform and uses the appropriate native tool:
+- Android: `adb screencap`
+- iOS simulator: `xcrun simctl io screenshot`
+- macOS desktop: `screencapture`
+- Linux X11: `xdotool` + `import`
+- Web/Chrome: Chrome DevTools Protocol (CDP)
+- Physical iOS, Windows, Linux Wayland: `fdb_helper` VM service extension (requires `fdb_helper` in the app)
+
+Default output: `~/.fdb/sessions/<hash>/screenshot.png`. Read the file with the Read tool to view it.
+
+Output tokens on success:
+```
+SCREENSHOT_SAVED=<path>
+SIZE=<size>
+```
 
 ### Logs
 
@@ -107,6 +136,13 @@ NOTE: If this returns empty/unknown, fall back to raw websocat (see Fallback sec
 fdb select on     # enable tap-to-select overlay on device
 fdb select off    # disable overlay
 fdb selected      # get what widget was tapped
+```
+
+`fdb selected` output tokens:
+```
+SELECTED: <widget description> (<file>:<line>)   # when creation location is known
+SELECTED: <widget description>                    # when creation location is unknown
+NO_WIDGET_SELECTED                                # when no widget has been tapped yet
 ```
 
 ### Tap a widget
@@ -151,7 +187,7 @@ Output: `SCROLLED=<DIR> DISTANCE=<n>`
 
 ```bash
 fdb status    # RUNNING=true/false, PID, VM_SERVICE_URI
-fdb kill      # stop app, clean up temp files
+fdb kill      # stop app, clean up session files
 ```
 
 ## Deep links
@@ -174,7 +210,6 @@ Output on success: `DEEPLINK_OPENED=<url>`
 
 **Limitations:**
 - Physical iOS devices are not supported (Apple does not expose a CLI for opening URLs on physical devices)
-- Desktop and web targets are not supported
 - On iOS simulator, Universal Links (`https://`) may open Safari instead of the app. Use a custom URL scheme for reliable testing
 
 ## Adding investigative logging
@@ -250,8 +285,8 @@ fdb screenshot
 
 ## State files
 
-All state lives in `/tmp/`:
-- `/tmp/fdb.pid` - flutter run process ID
-- `/tmp/fdb_logs.txt` - full app output
-- `/tmp/fdb_vm_uri.txt` - VM service websocket URI
-- `/tmp/fdb_screenshot.png` - last screenshot
+All state lives in `~/.fdb/`:
+- `~/.fdb/sessions/<hash>/session.json` - active session state (PID, VM URI, device, project)
+- `~/.fdb/sessions/<hash>/logs.txt` - full app output
+- `~/.fdb/sessions/<hash>/screenshot.png` - last screenshot
+- `~/.fdb/devices.json` - cached device list

--- a/lib/commands/deeplink.dart
+++ b/lib/commands/deeplink.dart
@@ -1,13 +1,21 @@
 import 'dart:io';
 
+import 'package:fdb/process_utils.dart';
+
 /// Opens a deep link URL on the connected device (Android or iOS simulator).
 Future<int> runDeeplink(List<String> args) async {
+  String? deviceId;
   String? url;
 
   for (var i = 0; i < args.length; i++) {
-    // First positional argument is the URL
-    if (!args[i].startsWith('-')) {
-      url = args[i];
+    switch (args[i]) {
+      case '--device':
+        deviceId = args[++i];
+      default:
+        // First positional argument is the URL
+        if (!args[i].startsWith('-')) {
+          url = args[i];
+        }
     }
   }
 
@@ -16,24 +24,42 @@ Future<int> runDeeplink(List<String> args) async {
     return 1;
   }
 
-  // Detect platform: Android first, then iOS simulator, else unsupported
-  final isAndroid = await _isAndroidDevice();
-  if (isAndroid) {
-    return _openAndroid(url);
+  final session = resolveSession(deviceId);
+  if (session == null) return 1;
+
+  final platform = session['platform'] as String?;
+  final resolvedDeviceId = session['deviceId'] as String;
+  final emulator = session['emulator'] as bool? ?? false;
+
+  if (platform != null && platform.startsWith('android')) {
+    return _openAndroid(url, resolvedDeviceId);
   }
 
-  final isIos = await _isIosSimulatorBooted();
-  if (isIos) {
-    return _openIos(url);
+  // Physical iOS devices are not supported for deep links.
+  if (platform != null && platform.startsWith('ios') && !emulator) {
+    stderr.writeln(
+      'ERROR: Physical iOS devices not supported for deep links.',
+    );
+    return 1;
+  }
+
+  if (platform != null && platform.startsWith('ios')) {
+    return _openIos(url, resolvedDeviceId);
+  }
+
+  if (platform != null && platform.startsWith('darwin')) {
+    return _openDarwin(url);
   }
 
   stderr.writeln(
-      'ERROR: Deep links are only supported on Android devices and iOS simulators');
+      'ERROR: Deep links are only supported on Android devices, iOS simulators, and macOS desktop');
   return 1;
 }
 
-Future<int> _openAndroid(String url) async {
+Future<int> _openAndroid(String url, String deviceId) async {
   final result = await Process.run('adb', [
+    '-s',
+    deviceId,
     'shell',
     'am',
     'start',
@@ -59,7 +85,7 @@ Future<int> _openAndroid(String url) async {
   return 0;
 }
 
-Future<int> _openIos(String url) async {
+Future<int> _openIos(String url, String deviceId) async {
   // Warn about Universal Links potentially opening Safari
   if (url.startsWith('http://') || url.startsWith('https://')) {
     stderr.writeln(
@@ -68,7 +94,7 @@ Future<int> _openIos(String url) async {
   }
 
   final result =
-      await Process.run('xcrun', ['simctl', 'openurl', 'booted', url]);
+      await Process.run('xcrun', ['simctl', 'openurl', deviceId, url]);
 
   if (result.exitCode != 0) {
     final details = (result.stderr as String).trim();
@@ -80,28 +106,15 @@ Future<int> _openIos(String url) async {
   return 0;
 }
 
-Future<bool> _isAndroidDevice() async {
-  try {
-    final result = await Process.run('adb', ['devices']);
-    final output = result.stdout as String;
-    // Check if there's at least one device listed (beyond the header line)
-    final lines =
-        output.split('\n').where((l) => l.contains('\tdevice')).toList();
-    return lines.isNotEmpty;
-  } catch (_) {
-    return false;
-  }
-}
+Future<int> _openDarwin(String url) async {
+  final result = await Process.run('open', [url]);
 
-/// Returns true if at least one iOS simulator is currently booted.
-Future<bool> _isIosSimulatorBooted() async {
-  try {
-    final result =
-        await Process.run('xcrun', ['simctl', 'list', 'devices', 'booted']);
-    final output = result.stdout as String;
-    // A booted device entry contains a UUID in parentheses, e.g. (A1B2C3D4-...)
-    return RegExp(r'\([\dA-F-]{36}\)').hasMatch(output);
-  } catch (_) {
-    return false;
+  if (result.exitCode != 0) {
+    final details = (result.stderr as String).trim();
+    stderr.writeln('ERROR: Failed to open deep link: $details');
+    return 1;
   }
+
+  stdout.writeln('DEEPLINK_OPENED=$url');
+  return 0;
 }

--- a/lib/commands/devices.dart
+++ b/lib/commands/devices.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:fdb/process_utils.dart';
+
 /// Lists connected devices by running `flutter devices --machine` and
 /// emitting one KEY=VALUE line per device.
 Future<int> runDevices(List<String> args) async {
@@ -14,7 +16,7 @@ Future<int> runDevices(List<String> args) async {
     return 1;
   }
 
-  final json = _extractJson(result.stdout as String);
+  final json = _extractDevicesJson(result.stdout as String);
   if (json == null) {
     stderr.writeln('ERROR: No devices found');
     return 1;
@@ -43,6 +45,14 @@ Future<int> runDevices(List<String> args) async {
       'DEVICE_ID=$id NAME=$name PLATFORM=$platform EMULATOR=$emulator',
     );
   }
+
+  // Write device cache as a secondary concern — failure does not affect exit code.
+  try {
+    writeDeviceCache(devices);
+  } catch (e) {
+    stderr.writeln('WARNING: Failed to write device cache: $e');
+  }
+
   return 0;
 }
 
@@ -51,7 +61,8 @@ Future<int> runDevices(List<String> args) async {
 /// Flutter may prepend non-JSON text (download progress, upgrade banners)
 /// before the actual JSON array. We scan for the first `[` to find the
 /// array start.
-String? _extractJson(String output) {
+// NOTE: duplicated in process_utils.dart to avoid circular import.
+String? _extractDevicesJson(String output) {
   final start = output.indexOf('[');
   if (start == -1) return null;
   // Find the matching closing bracket from the end

--- a/lib/commands/input.dart
+++ b/lib/commands/input.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:fdb/process_utils.dart';
 import 'package:fdb/vm_service.dart';
 
 /// Enters text into a field identified by selector or the currently focused field.
@@ -10,6 +11,7 @@ import 'package:fdb/vm_service.dart';
 ///   fdb input --key "email_field" "hello@example.com"
 ///   fdb input --type TextField "hello@example.com"
 Future<int> runInput(List<String> args) async {
+  String? deviceId;
   String? text;
   String? key;
   String? type;
@@ -18,6 +20,8 @@ Future<int> runInput(List<String> args) async {
 
   for (var i = 0; i < args.length; i++) {
     switch (args[i]) {
+      case '--device':
+        deviceId = args[++i];
       case '--text':
         text = args[++i];
       case '--key':
@@ -44,8 +48,17 @@ Future<int> runInput(List<String> args) async {
     return 1;
   }
 
+  final session = resolveSession(deviceId);
+  if (session == null) return 1;
+
+  final vmUri = session['vmServiceUri'] as String?;
+  if (vmUri == null) {
+    stderr.writeln('ERROR: No VM service URI in session. Is the app running?');
+    return 1;
+  }
+
   try {
-    final isolateId = await checkFdbHelper();
+    final isolateId = await checkFdbHelper(vmUri);
     if (isolateId == null) {
       stderr.writeln(
         'ERROR: fdb_helper not detected in running app. '
@@ -69,7 +82,8 @@ Future<int> runInput(List<String> args) async {
     if (type != null) params['type'] = type;
     if (index != null) params['index'] = index.toString();
 
-    final response = await vmServiceCall('ext.fdb.enterText', params: params);
+    final response =
+        await vmServiceCall(vmUri, 'ext.fdb.enterText', params: params);
     final result = unwrapRawExtensionResult(response);
 
     if (result is Map<String, dynamic>) {

--- a/lib/commands/kill.dart
+++ b/lib/commands/kill.dart
@@ -4,15 +4,30 @@ import 'package:fdb/constants.dart';
 import 'package:fdb/process_utils.dart';
 
 Future<int> runKill(List<String> args) async {
-  final pid = readPid();
+  String? deviceId;
+
+  for (var i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--device':
+        deviceId = args[++i];
+    }
+  }
+
+  final session = resolveSession(deviceId);
+  if (session == null) return 1;
+  final device = session['deviceId'] as String;
+
+  final pidRaw = session['pid'];
+  final pid =
+      pidRaw is int ? pidRaw : (pidRaw is String ? int.tryParse(pidRaw) : null);
   if (pid == null) {
-    stderr.writeln('ERROR: No PID file found. Is the app running?');
+    stderr.writeln('ERROR: No PID found in session. Is the app running?');
     return 1;
   }
 
   if (!isProcessAlive(pid)) {
     stdout.writeln('APP_KILLED');
-    cleanupTempFiles();
+    cleanupSession(device);
     return 0;
   }
 
@@ -24,7 +39,7 @@ Future<int> runKill(List<String> args) async {
   while (stopwatch.elapsed.inSeconds < killTimeoutSeconds) {
     await Future<void>.delayed(const Duration(milliseconds: 500));
     if (!isProcessAlive(pid)) {
-      cleanupTempFiles();
+      cleanupSession(device);
       stdout.writeln('APP_KILLED');
       return 0;
     }
@@ -37,10 +52,10 @@ Future<int> runKill(List<String> args) async {
     // Process may have already exited
   }
 
-  cleanupTempFiles();
+  cleanupSession(device);
 
   if (isProcessAlive(pid)) {
-    stderr.writeln('KILL_FAILED');
+    stderr.writeln('ERROR: KILL_FAILED');
     return 1;
   }
 

--- a/lib/commands/launch.dart
+++ b/lib/commands/launch.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:fdb/constants.dart';
+import 'package:fdb/process_utils.dart';
 
 Future<int> runLaunch(List<String> args) async {
   String? device;
@@ -26,20 +27,55 @@ Future<int> runLaunch(List<String> args) async {
     return 1;
   }
 
-  // Clean up previous state
-  for (final path in [
-    pidFile,
-    logFile,
-    vmUriFile,
-    launcherScript,
-    deviceFile
-  ]) {
-    final f = File(path);
-    if (f.existsSync()) f.deleteSync();
+  // Ensure ~/.fdb/ directory structure exists
+  ensureFdbHome();
+
+  // Look up platform and emulator status from device cache
+  var platform = lookupPlatform(device);
+  var emulator = lookupEmulator(device);
+
+  if (platform == null) {
+    // Cache miss — refresh and try again
+    await refreshDeviceCache();
+    platform = lookupPlatform(device);
+    emulator = lookupEmulator(device);
+    if (platform == null) {
+      stderr.writeln(
+        'WARNING: Device $device not found in device cache. '
+        'Platform will be unknown — screenshot may fail.',
+      );
+    }
   }
 
-  // Persist device ID for other commands to use
-  File(deviceFile).writeAsStringSync(device);
+  // Determine CDP port for web targets.
+  // NOTE: There is an inherent TOCTOU race here — we bind a socket to find a
+  // free port, close it, then pass the port number to flutter run.  Another
+  // process could claim the port in the window between close() and flutter
+  // binding it.  This is a known limitation of the find-free-port pattern and
+  // is acceptable for a debug-only tool.
+  int? cdpPort;
+  if (platform == 'web-javascript') {
+    final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+    cdpPort = server.port;
+    await server.close();
+  }
+
+  // Wipe any previous session for this device
+  cleanupSession(device);
+
+  // Write initial session state (pid and vmServiceUri filled in after launch)
+  writeSession(device, {
+    'deviceId': device,
+    'platform': platform,
+    'emulator': emulator,
+    'launchedAt': DateTime.now().toUtc().toIso8601String(),
+    'pid': null,
+    'vmServiceUri': null,
+    'cdpPort': cdpPort,
+  });
+
+  // Path for flutter's --pid-file inside the session directory
+  final pidFilePath = '${sessionDir(device)}/flutter.pid';
 
   // Build the flutter run command string
   final flutterArgs = [
@@ -49,18 +85,21 @@ Future<int> runLaunch(List<String> args) async {
     device,
     '--debug',
     '--pid-file',
-    pidFile,
+    pidFilePath,
     if (flavor != null) ...['--flavor', flavor],
     if (target != null) ...['--target', target],
+    if (cdpPort != null) '--web-browser-debug-port=$cdpPort',
   ];
-  final flutterCmd = flutterArgs.map(_shellEscape).join(' ');
+  final flutterCmd = flutterArgs.map(shellEscape).join(' ');
 
   // Write a launcher script that runs flutter in the foreground (nohup keeps
   // it alive after the parent exits, and & backgrounds it from our perspective)
+  final logFile = logPath(device);
+  final launcherScript = launcherPath(device);
   final script = '''
 #!/bin/bash
-cd ${_shellEscape(project)}
-exec $flutterCmd > $logFile 2>&1
+cd ${shellEscape(project)}
+exec $flutterCmd > ${shellEscape(logFile)} 2>&1
 ''';
   File(launcherScript).writeAsStringSync(script);
   Process.runSync('chmod', ['+x', launcherScript]);
@@ -68,7 +107,7 @@ exec $flutterCmd > $logFile 2>&1
   // Launch via nohup + & so the process is fully detached from this parent
   final result = await Process.run('bash', [
     '-c',
-    'nohup bash $launcherScript &\necho \$!',
+    'nohup bash ${shellEscape(launcherScript)} &\necho \$!',
   ]);
 
   if (result.exitCode != 0) {
@@ -98,7 +137,7 @@ exec $flutterCmd > $logFile 2>&1
     }
 
     // Check if the launcher process died unexpectedly
-    if (!_isAlive(launcherPid)) {
+    if (!isProcessAlive(launcherPid)) {
       final logExists = File(logFile).existsSync();
       if (logExists) {
         final lines = File(logFile).readAsLinesSync();
@@ -125,24 +164,29 @@ exec $flutterCmd > $logFile 2>&1
   }
 
   if (vmUri == null) {
-    stdout.writeln('LAUNCH_TIMEOUT');
+    stderr.writeln(
+      'ERROR: Launch timed out after $launchTimeoutSeconds seconds',
+    );
     if (File(logFile).existsSync()) {
       final lines = File(logFile).readAsLinesSync();
       final tail = lines.length > 10 ? lines.sublist(lines.length - 10) : lines;
       for (final line in tail) {
-        stdout.writeln(line);
+        stderr.writeln(line);
       }
     }
     return 1;
   }
 
-  // Save VM service URI
-  File(vmUriFile).writeAsStringSync(vmUri);
-
   // Read PID — flutter writes it via --pid-file, fall back to launcher PID
-  final pid = File(pidFile).existsSync()
-      ? File(pidFile).readAsStringSync().trim()
+  final pid = File(pidFilePath).existsSync()
+      ? File(pidFilePath).readAsStringSync().trim()
       : launcherPid.toString();
+
+  // Persist PID and VM service URI into session.json
+  updateSession(device, {
+    'pid': int.tryParse(pid) ?? pid,
+    'vmServiceUri': vmUri,
+  });
 
   stdout.writeln('APP_STARTED');
   stdout.writeln('VM_SERVICE_URI=$vmUri');
@@ -181,19 +225,4 @@ String _httpToWs(String uri) {
   var wsUri = uri.replaceFirst('http', 'ws');
   if (!wsUri.endsWith('ws')) wsUri = '${wsUri}ws';
   return wsUri;
-}
-
-/// Shell-escape a string for safe embedding in a bash command.
-String _shellEscape(String value) {
-  if (RegExp(r'^[a-zA-Z0-9._/=-]+$').hasMatch(value)) return value;
-  return "'${value.replaceAll("'", r"'\''")}'";
-}
-
-bool _isAlive(int pid) {
-  try {
-    final result = Process.runSync('kill', ['-0', pid.toString()]);
-    return result.exitCode == 0;
-  } catch (_) {
-    return false;
-  }
 }

--- a/lib/commands/logs.dart
+++ b/lib/commands/logs.dart
@@ -1,24 +1,38 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:fdb/constants.dart';
+import 'package:fdb/process_utils.dart';
 
 Future<int> runLogs(List<String> args) async {
+  String? deviceId;
   String? tag;
   var last = 50;
   var follow = false;
 
   for (var i = 0; i < args.length; i++) {
     switch (args[i]) {
+      case '--device':
+        deviceId = args[++i];
       case '--tag':
         tag = args[++i];
       case '--last':
-        last = int.parse(args[++i]);
+        final parsed = int.tryParse(args[++i]);
+        if (parsed == null) {
+          stderr.writeln('ERROR: --last requires an integer value');
+          return 1;
+        }
+        last = parsed;
       case '--follow':
         follow = true;
     }
   }
 
-  final file = File(logFile);
+  final session = resolveSession(deviceId);
+  if (session == null) return 1;
+  final device = session['deviceId'] as String;
+
+  final file = File(logPath(device));
   if (!file.existsSync()) {
     stderr.writeln('ERROR: Log file not found. Is the app running?');
     return 1;
@@ -47,9 +61,7 @@ Future<int> runLogs(List<String> args) async {
 }
 
 Future<int> _followLogs(File file, String? tag) async {
-  var offset = file.lengthSync();
-
-  // Print existing content first
+  // Print existing content first, then set offset to the actual bytes read
   final existing = file.readAsStringSync();
   if (existing.isNotEmpty) {
     final lines = existing.split('\n');
@@ -59,6 +71,7 @@ Future<int> _followLogs(File file, String? tag) async {
       }
     }
   }
+  var offset = utf8.encode(existing).length;
 
   // Then follow new content
   while (true) {
@@ -67,11 +80,15 @@ Future<int> _followLogs(File file, String? tag) async {
     final currentSize = file.lengthSync();
     if (currentSize > offset) {
       final raf = file.openSync();
-      raf.setPositionSync(offset);
-      final newBytes = raf.readSync(currentSize - offset);
-      raf.closeSync();
+      final List<int> newBytes;
+      try {
+        raf.setPositionSync(offset);
+        newBytes = raf.readSync(currentSize - offset);
+      } finally {
+        raf.closeSync();
+      }
 
-      final newContent = String.fromCharCodes(newBytes);
+      final newContent = utf8.decode(newBytes, allowMalformed: true);
       final lines = newContent.split('\n');
       for (final line in lines) {
         if (line.isEmpty) continue;

--- a/lib/commands/reload.dart
+++ b/lib/commands/reload.dart
@@ -4,9 +4,24 @@ import 'package:fdb/constants.dart';
 import 'package:fdb/process_utils.dart';
 
 Future<int> runReload(List<String> args) async {
-  final pid = readPid();
+  String? deviceId;
+
+  for (var i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--device':
+        deviceId = args[++i];
+    }
+  }
+
+  final session = resolveSession(deviceId);
+  if (session == null) return 1;
+  final device = session['deviceId'] as String;
+
+  final pidRaw = session['pid'];
+  final pid =
+      pidRaw is int ? pidRaw : (pidRaw is String ? int.tryParse(pidRaw) : null);
   if (pid == null) {
-    stderr.writeln('ERROR: No PID file found. Is the app running?');
+    stderr.writeln('ERROR: No PID found in session. Is the app running?');
     return 1;
   }
 
@@ -15,8 +30,8 @@ Future<int> runReload(List<String> args) async {
     return 1;
   }
 
-  final logBefore =
-      File(logFile).existsSync() ? File(logFile).readAsStringSync() : '';
+  final log = logPath(device);
+  var logBefore = File(log).existsSync() ? File(log).readAsStringSync() : '';
 
   final stopwatch = Stopwatch()..start();
 
@@ -26,7 +41,17 @@ Future<int> runReload(List<String> args) async {
   // Wait for "Reloaded" in log
   while (stopwatch.elapsed.inSeconds < reloadTimeoutSeconds) {
     await Future<void>.delayed(const Duration(milliseconds: 500));
-    final logContent = File(logFile).readAsStringSync();
+    // Guard the file read against FileSystemException (e.g. log rotated away).
+    final String logContent;
+    try {
+      logContent = File(log).readAsStringSync();
+    } on FileSystemException {
+      break;
+    }
+    // If log was rotated, reset baseline and proceed with new content.
+    if (logContent.length < logBefore.length) {
+      logBefore = '';
+    }
     final newContent = logContent.substring(logBefore.length);
     if (newContent.contains('Reloaded')) {
       stdout.writeln('RELOADED in ${stopwatch.elapsedMilliseconds}ms');
@@ -34,6 +59,6 @@ Future<int> runReload(List<String> args) async {
     }
   }
 
-  stderr.writeln('RELOAD_FAILED');
+  stderr.writeln('ERROR: RELOAD_FAILED');
   return 1;
 }

--- a/lib/commands/restart.dart
+++ b/lib/commands/restart.dart
@@ -4,9 +4,24 @@ import 'package:fdb/constants.dart';
 import 'package:fdb/process_utils.dart';
 
 Future<int> runRestart(List<String> args) async {
-  final pid = readPid();
+  String? deviceId;
+
+  for (var i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--device':
+        deviceId = args[++i];
+    }
+  }
+
+  final session = resolveSession(deviceId);
+  if (session == null) return 1;
+  final device = session['deviceId'] as String;
+
+  final pidRaw = session['pid'];
+  final pid =
+      pidRaw is int ? pidRaw : (pidRaw is String ? int.tryParse(pidRaw) : null);
   if (pid == null) {
-    stderr.writeln('ERROR: No PID file found. Is the app running?');
+    stderr.writeln('ERROR: No PID found in session. Is the app running?');
     return 1;
   }
 
@@ -15,8 +30,8 @@ Future<int> runRestart(List<String> args) async {
     return 1;
   }
 
-  final logBefore =
-      File(logFile).existsSync() ? File(logFile).readAsStringSync() : '';
+  final log = logPath(device);
+  var logBefore = File(log).existsSync() ? File(log).readAsStringSync() : '';
 
   final stopwatch = Stopwatch()..start();
 
@@ -26,7 +41,17 @@ Future<int> runRestart(List<String> args) async {
   // Wait for "Restarted" in log
   while (stopwatch.elapsed.inSeconds < restartTimeoutSeconds) {
     await Future<void>.delayed(const Duration(milliseconds: 500));
-    final logContent = File(logFile).readAsStringSync();
+    // Guard the file read against FileSystemException (e.g. log rotated away).
+    final String logContent;
+    try {
+      logContent = File(log).readAsStringSync();
+    } on FileSystemException {
+      break;
+    }
+    // If log was rotated, reset baseline and proceed with new content.
+    if (logContent.length < logBefore.length) {
+      logBefore = '';
+    }
     final newContent = logContent.substring(logBefore.length);
     if (newContent.contains('Restarted')) {
       stdout.writeln('RESTARTED in ${stopwatch.elapsedMilliseconds}ms');
@@ -34,6 +59,6 @@ Future<int> runRestart(List<String> args) async {
     }
   }
 
-  stderr.writeln('RESTART_FAILED');
+  stderr.writeln('ERROR: RESTART_FAILED');
   return 1;
 }

--- a/lib/commands/screenshot.dart
+++ b/lib/commands/screenshot.dart
@@ -211,8 +211,8 @@ Future<int?> _getMacWindowId(int pid) async {
     '-e',
     '''
 import Cocoa
-let pid = Int32(CommandLine.arguments[1])!
-let list = CGWindowListCopyWindowInfo(.optionOnScreenOnly, kCGNullWindowID)! as [NSDictionary]
+guard CommandLine.arguments.count > 1, let pid = Int32(CommandLine.arguments[1]) else { exit(1) }
+guard let list = CGWindowListCopyWindowInfo(.optionOnScreenOnly, kCGNullWindowID) as? [NSDictionary] else { exit(0) }
 for w in list where w[kCGWindowOwnerPID] as? Int32 == pid {
   if let num = w[kCGWindowNumber] as? Int { print(num); break }
 }
@@ -251,12 +251,13 @@ Future<int> _screenshotLinuxNative(int pid, String output) async {
   try {
     final xdoResult = await Process.run('xdotool', [
       'search',
+      '--onlyvisible',
       '--pid',
       pid.toString(),
     ]);
     if (xdoResult.exitCode != 0) return -1;
 
-    final windowId = (xdoResult.stdout as String).trim().split('\n').first;
+    final windowId = (xdoResult.stdout as String).trim().split('\n').last;
     if (windowId.isEmpty) return -1;
 
     final importResult = await Process.run('import', [

--- a/lib/commands/screenshot.dart
+++ b/lib/commands/screenshot.dart
@@ -195,8 +195,11 @@ Future<int> _screenshotMacOs(
       output,
     ]);
     if (result.exitCode != 0) {
-      stderr.writeln('ERROR: screencapture failed: ${result.stderr}');
-      return 1;
+      stderr.writeln(
+        'WARNING: screencapture failed (Screen Recording permission may '
+        'be needed). Falling back to fdb_helper.',
+      );
+      return _screenshotViaFdbHelper(vmServiceUri, output);
     }
     return 0;
   } catch (e) {
@@ -205,19 +208,38 @@ Future<int> _screenshotMacOs(
   }
 }
 
-/// Returns the CGWindowID for the on-screen window owned by [pid], or null.
+/// Returns the CGWindowID for the on-screen window owned by [pid] or any of
+/// its child processes. On macOS, `flutter run` (the stored PID) spawns the
+/// actual .app as a child process, so we need to walk the process tree.
 Future<int?> _getMacWindowId(int pid) async {
+  // Collect the stored PID plus all descendant PIDs.
+  final pids = <int>[pid];
+  try {
+    final pgrepResult = await Process.run('pgrep', ['-P', pid.toString()]);
+    if (pgrepResult.exitCode == 0) {
+      for (final line in (pgrepResult.stdout as String).trim().split('\n')) {
+        final childPid = int.tryParse(line.trim());
+        if (childPid != null) pids.add(childPid);
+      }
+    }
+  } catch (_) {
+    // pgrep not available — fall through with just the original PID.
+  }
+
+  final pidsArg = pids.join(',');
   final result = await Process.run('swift', [
     '-e',
     '''
 import Cocoa
-guard CommandLine.arguments.count > 1, let pid = Int32(CommandLine.arguments[1]) else { exit(1) }
+let pidStrs = CommandLine.arguments[1].split(separator: ",")
+let pids = pidStrs.compactMap { Int32(\$0) }
 guard let list = CGWindowListCopyWindowInfo(.optionOnScreenOnly, kCGNullWindowID) as? [NSDictionary] else { exit(0) }
-for w in list where w[kCGWindowOwnerPID] as? Int32 == pid {
+for w in list {
+  guard let ownerPid = w[kCGWindowOwnerPID] as? Int32, pids.contains(ownerPid) else { continue }
   if let num = w[kCGWindowNumber] as? Int { print(num); break }
 }
 ''',
-    pid.toString(),
+    pidsArg,
   ]);
   if (result.exitCode != 0) return null;
   return int.tryParse((result.stdout as String).trim());

--- a/lib/commands/screenshot.dart
+++ b/lib/commands/screenshot.dart
@@ -1,66 +1,430 @@
+import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:fdb/constants.dart';
+import 'package:fdb/process_utils.dart';
+import 'package:fdb/vm_service.dart';
 
 Future<int> runScreenshot(List<String> args) async {
-  var output = defaultScreenshotPath;
+  String? deviceId;
+  String? output;
 
   for (var i = 0; i < args.length; i++) {
-    if (args[i] == '--output') {
-      output = args[++i];
+    switch (args[i]) {
+      case '--device':
+        deviceId = args[++i];
+      case '--output':
+        output = args[++i];
     }
   }
 
-  // Detect platform by checking adb devices
-  final isAndroid = await _isAndroidDevice();
+  final session = resolveSession(deviceId);
+  if (session == null) return 1;
 
-  ProcessResult result;
+  final resolvedDeviceId = session['deviceId'] as String? ?? deviceId ?? '';
+  final platform = session['platform'] as String?;
+  final pid = session['pid'];
+  final vmServiceUri = session['vmServiceUri'] as String?;
+  final cdpPort = session['cdpPort'] as int?;
+  final emulator = session['emulator'] as bool? ?? false;
 
-  if (isAndroid) {
-    result = await Process.run('bash', [
-      '-c',
-      'adb exec-out screencap -p > $output',
-    ]);
-  } else {
-    // Assume iOS simulator
-    result = await Process.run('xcrun', [
-      'simctl',
-      'io',
-      'booted',
-      'screenshot',
-      output,
-    ]);
-  }
+  final resolvedOutput = output ?? screenshotPath(resolvedDeviceId);
 
-  if (result.exitCode != 0) {
-    stderr.writeln('ERROR: Screenshot failed: ${result.stderr}');
+  if (platform == null) {
+    stderr.writeln('ERROR: No platform found in session. Re-launch the app.');
     return 1;
   }
 
-  final file = File(output);
+  // Ensure the output directory exists
+  Directory(File(resolvedOutput).parent.path).createSync(recursive: true);
+
+  final exitCode = await _dispatchScreenshot(
+    platform: platform,
+    deviceId: resolvedDeviceId,
+    pid: pid is int ? pid : (pid is String ? int.tryParse(pid) : null),
+    vmServiceUri: vmServiceUri,
+    cdpPort: cdpPort,
+    emulator: emulator,
+    output: resolvedOutput,
+  );
+
+  if (exitCode != 0) return exitCode;
+
+  final file = File(resolvedOutput);
   if (!file.existsSync()) {
-    stderr.writeln('ERROR: Screenshot file not created');
+    stderr.writeln('ERROR: Screenshot file was not created at $resolvedOutput');
     return 1;
   }
 
   final sizeBytes = file.lengthSync();
-  stdout.writeln('SCREENSHOT_SAVED=$output');
+  stdout.writeln('SCREENSHOT_SAVED=$resolvedOutput');
   stdout.writeln('SIZE=${_formatSize(sizeBytes)}');
   return 0;
 }
 
-Future<bool> _isAndroidDevice() async {
+Future<int> _dispatchScreenshot({
+  required String platform,
+  required String deviceId,
+  required int? pid,
+  required String? vmServiceUri,
+  required int? cdpPort,
+  required bool emulator,
+  required String output,
+}) async {
+  if (platform.startsWith('android')) {
+    return _screenshotAndroid(deviceId, output);
+  }
+
+  if (platform.startsWith('ios') && emulator) {
+    return _screenshotIosSimulator(deviceId, output);
+  }
+
+  if (platform.startsWith('ios') && !emulator) {
+    stderr.writeln(
+      'WARNING: No native screenshot tool available for physical iOS devices. '
+      'Falling back to fdb_helper.',
+    );
+    return _screenshotViaFdbHelper(vmServiceUri, output);
+  }
+
+  if (platform.startsWith('darwin')) {
+    return _screenshotMacOs(pid, vmServiceUri, output);
+  }
+
+  if (platform.startsWith('linux')) {
+    return _screenshotLinux(pid, vmServiceUri, output);
+  }
+
+  if (platform.startsWith('windows')) {
+    stderr.writeln(
+      'WARNING: No native screenshot CLI available for Windows. '
+      'Falling back to fdb_helper.',
+    );
+    return _screenshotViaFdbHelper(vmServiceUri, output);
+  }
+
+  if (platform == 'web-javascript') {
+    if (cdpPort == null) {
+      stderr.writeln('ERROR: No CDP port found in session for web platform.');
+      return 1;
+    }
+    return _screenshotViaCdp(cdpPort, output);
+  }
+
+  stderr.writeln('ERROR: Unsupported platform: $platform');
+  return 1;
+}
+
+// ---------------------------------------------------------------------------
+// Android
+// ---------------------------------------------------------------------------
+
+Future<int> _screenshotAndroid(String deviceId, String output) async {
   try {
-    final result = await Process.run('adb', ['devices']);
-    final output = result.stdout as String;
-    // Check if there's at least one device listed (beyond the header line)
-    final lines =
-        output.split('\n').where((l) => l.contains('\tdevice')).toList();
-    return lines.isNotEmpty;
-  } catch (_) {
-    return false;
+    final result = await Process.run('bash', [
+      '-c',
+      'adb -s ${shellEscape(deviceId)} exec-out screencap -p > ${shellEscape(output)}',
+    ]);
+    if (result.exitCode != 0) {
+      stderr.writeln('ERROR: adb screencap failed: ${result.stderr}');
+      return 1;
+    }
+    return 0;
+  } catch (e) {
+    stderr.writeln('ERROR: Failed to run adb: $e');
+    return 1;
   }
 }
+
+// ---------------------------------------------------------------------------
+// iOS Simulator
+// ---------------------------------------------------------------------------
+
+Future<int> _screenshotIosSimulator(String deviceId, String output) async {
+  try {
+    final result = await Process.run('xcrun', [
+      'simctl',
+      'io',
+      deviceId,
+      'screenshot',
+      output,
+    ]);
+    if (result.exitCode != 0) {
+      stderr.writeln('ERROR: xcrun simctl screenshot failed: ${result.stderr}');
+      return 1;
+    }
+    return 0;
+  } catch (e) {
+    stderr.writeln('ERROR: Failed to run xcrun: $e');
+    return 1;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// macOS desktop
+// ---------------------------------------------------------------------------
+
+Future<int> _screenshotMacOs(
+  int? pid,
+  String? vmServiceUri,
+  String output,
+) async {
+  if (pid == null) {
+    stderr.writeln(
+      'ERROR: No PID in session — cannot locate macOS window. '
+      'Re-launch the app.',
+    );
+    return 1;
+  }
+
+  try {
+    final windowId = await _getMacWindowId(pid);
+    if (windowId == null) {
+      stderr.writeln(
+        'WARNING: Could not find macOS window for PID $pid. '
+        'Falling back to fdb_helper.',
+      );
+      return _screenshotViaFdbHelper(vmServiceUri, output);
+    }
+
+    final result = await Process.run('screencapture', [
+      '-l',
+      windowId.toString(),
+      '-o',
+      output,
+    ]);
+    if (result.exitCode != 0) {
+      stderr.writeln('ERROR: screencapture failed: ${result.stderr}');
+      return 1;
+    }
+    return 0;
+  } catch (e) {
+    stderr.writeln('ERROR: macOS screenshot failed: $e');
+    return 1;
+  }
+}
+
+/// Returns the CGWindowID for the on-screen window owned by [pid], or null.
+Future<int?> _getMacWindowId(int pid) async {
+  final result = await Process.run('swift', [
+    '-e',
+    '''
+import Cocoa
+let pid = Int32(CommandLine.arguments[1])!
+let list = CGWindowListCopyWindowInfo(.optionOnScreenOnly, kCGNullWindowID)! as [NSDictionary]
+for w in list where w[kCGWindowOwnerPID] as? Int32 == pid {
+  if let num = w[kCGWindowNumber] as? Int { print(num); break }
+}
+''',
+    pid.toString(),
+  ]);
+  if (result.exitCode != 0) return null;
+  return int.tryParse((result.stdout as String).trim());
+}
+
+// ---------------------------------------------------------------------------
+// Linux
+// ---------------------------------------------------------------------------
+
+Future<int> _screenshotLinux(
+  int? pid,
+  String? vmServiceUri,
+  String output,
+) async {
+  if (pid != null) {
+    final nativeResult = await _screenshotLinuxNative(pid, output);
+    if (nativeResult == 0) return 0;
+    // nativeResult == -1 means native capture failed — fall through to fdb_helper
+  }
+
+  final reason = pid == null
+      ? 'No PID in session'
+      : 'Native Linux screenshot (xdotool/import) failed';
+  stderr.writeln('WARNING: $reason. Falling back to fdb_helper.');
+  return _screenshotViaFdbHelper(vmServiceUri, output);
+}
+
+/// Tries xdotool + ImageMagick import to capture the window.
+/// Returns 0 on success, -1 to signal that the caller should try the fallback.
+Future<int> _screenshotLinuxNative(int pid, String output) async {
+  try {
+    final xdoResult = await Process.run('xdotool', [
+      'search',
+      '--pid',
+      pid.toString(),
+    ]);
+    if (xdoResult.exitCode != 0) return -1;
+
+    final windowId = (xdoResult.stdout as String).trim().split('\n').first;
+    if (windowId.isEmpty) return -1;
+
+    final importResult = await Process.run('import', [
+      '-window',
+      windowId,
+      output,
+    ]);
+    return importResult.exitCode == 0 ? 0 : -1;
+  } catch (_) {
+    return -1;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Web (CDP)
+// ---------------------------------------------------------------------------
+
+Future<int> _screenshotViaCdp(int cdpPort, String output) async {
+  // 1. Fetch the page list from the CDP HTTP endpoint
+  final String wsUrl;
+  try {
+    final client = HttpClient();
+    try {
+      final request = await client.getUrl(
+        Uri.parse('http://localhost:$cdpPort/json'),
+      );
+      final response = await request.close();
+      final body = await response.transform(utf8.decoder).join();
+
+      final pages = jsonDecode(body) as List<dynamic>;
+      if (pages.isEmpty) {
+        stderr.writeln('ERROR: No Chrome pages found on CDP port $cdpPort');
+        return 1;
+      }
+
+      // Prefer a page-type tab over devtools panels
+      final page = pages.firstWhere(
+        (p) => (p as Map<String, dynamic>)['type'] == 'page',
+        orElse: () => pages.first,
+      ) as Map<String, dynamic>;
+
+      final url = page['webSocketDebuggerUrl'] as String?;
+      if (url == null) {
+        stderr.writeln('ERROR: No WebSocket URL for Chrome page');
+        return 1;
+      }
+      wsUrl = url;
+    } finally {
+      client.close();
+    }
+  } catch (e) {
+    stderr.writeln('ERROR: Failed to connect to CDP on port $cdpPort: $e');
+    return 1;
+  }
+
+  // 2. Connect via WebSocket and capture screenshot
+  WebSocket? ws;
+  try {
+    ws = await WebSocket.connect(wsUrl);
+    final completer = Completer<Map<String, dynamic>>();
+
+    ws.listen(
+      (data) {
+        final json = jsonDecode(data as String) as Map<String, dynamic>;
+        if (json['id'] == 1 && !completer.isCompleted) {
+          completer.complete(json);
+        }
+      },
+      onError: (Object error) {
+        if (!completer.isCompleted) completer.completeError(error);
+      },
+      onDone: () {
+        if (!completer.isCompleted) {
+          completer.completeError(
+            StateError('WebSocket closed before CDP response'),
+          );
+        }
+      },
+    );
+
+    ws.add(jsonEncode({
+      'id': 1,
+      'method': 'Page.captureScreenshot',
+      'params': {'format': 'png'},
+    }));
+
+    final cdpResponse = await completer.future.timeout(
+      const Duration(seconds: 10),
+    );
+
+    final resultData =
+        (cdpResponse['result'] as Map<String, dynamic>?)?['data'] as String?;
+    if (resultData == null) {
+      stderr.writeln('ERROR: CDP screenshot returned no data');
+      return 1;
+    }
+
+    final bytes = base64Decode(resultData);
+    File(output).writeAsBytesSync(bytes);
+    return 0;
+  } on TimeoutException {
+    stderr.writeln('ERROR: CDP screenshot timed out');
+    return 1;
+  } catch (e) {
+    stderr.writeln('ERROR: CDP screenshot failed: $e');
+    return 1;
+  } finally {
+    await ws?.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// fdb_helper fallback
+// ---------------------------------------------------------------------------
+
+Future<int> _screenshotViaFdbHelper(
+  String? vmServiceUri,
+  String output,
+) async {
+  if (vmServiceUri == null) {
+    stderr.writeln(
+      'ERROR: No VM service URI in session and no native screenshot tool '
+      'available. Re-launch the app.',
+    );
+    return 1;
+  }
+
+  try {
+    final isolateId = await checkFdbHelper(vmServiceUri);
+    if (isolateId == null) {
+      stderr.writeln(
+        'ERROR: fdb_helper not found in app and no native screenshot tool '
+        'available. Add fdb_helper to your Flutter app.',
+      );
+      return 1;
+    }
+
+    final response = await vmServiceCall(
+      vmServiceUri,
+      'ext.fdb.screenshot',
+      params: {'isolateId': isolateId},
+    );
+
+    final result = unwrapRawExtensionResult(response);
+    if (result is Map && result.containsKey('error')) {
+      stderr.writeln('ERROR: Screenshot failed: ${result['error']}');
+      return 1;
+    }
+
+    final base64Data =
+        (result as Map<String, dynamic>?)?['screenshot'] as String?;
+    if (base64Data == null) {
+      stderr.writeln('ERROR: No screenshot data in fdb_helper response');
+      return 1;
+    }
+
+    final bytes = base64Decode(base64Data);
+    File(output).writeAsBytesSync(bytes);
+    return 0;
+  } catch (e) {
+    stderr.writeln('ERROR: fdb_helper screenshot failed: $e');
+    return 1;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 String _formatSize(int bytes) {
   if (bytes < 1024) return '${bytes}B';

--- a/lib/commands/screenshot.dart
+++ b/lib/commands/screenshot.dart
@@ -82,8 +82,10 @@ Future<int> _dispatchScreenshot({
 
   if (platform.startsWith('ios') && !emulator) {
     stderr.writeln(
-      'WARNING: No native screenshot tool available for physical iOS devices. '
-      'Falling back to fdb_helper.',
+      'WARNING: No native screenshot tool for physical iOS devices.\n'
+      '  Using fdb_helper fallback (captures Flutter surface only, '
+      'no status bar or home indicator).\n'
+      '  Ensure your app includes the fdb_helper package.',
     );
     return _screenshotViaFdbHelper(vmServiceUri, output);
   }
@@ -98,8 +100,10 @@ Future<int> _dispatchScreenshot({
 
   if (platform.startsWith('windows')) {
     stderr.writeln(
-      'WARNING: No native screenshot CLI available for Windows. '
-      'Falling back to fdb_helper.',
+      'WARNING: No native screenshot CLI for Windows.\n'
+      '  Using fdb_helper fallback (captures Flutter surface only, '
+      'no window chrome).\n'
+      '  Ensure your app includes the fdb_helper package.',
     );
     return _screenshotViaFdbHelper(vmServiceUri, output);
   }
@@ -182,8 +186,9 @@ Future<int> _screenshotMacOs(
     final windowId = await _getMacWindowId(pid);
     if (windowId == null) {
       stderr.writeln(
-        'WARNING: Could not find macOS window for PID $pid. '
-        'Falling back to fdb_helper.',
+        'WARNING: Could not find macOS window for PID $pid.\n'
+        '  Using fdb_helper fallback (captures Flutter surface only, '
+        'no title bar).',
       );
       return _screenshotViaFdbHelper(vmServiceUri, output);
     }
@@ -196,8 +201,12 @@ Future<int> _screenshotMacOs(
     ]);
     if (result.exitCode != 0) {
       stderr.writeln(
-        'WARNING: screencapture failed (Screen Recording permission may '
-        'be needed). Falling back to fdb_helper.',
+        'WARNING: screencapture failed — Screen Recording permission '
+        'likely required.\n'
+        '  Grant permission: System Settings > Privacy & Security > '
+        'Screen Recording > enable your terminal app.\n'
+        '  Using fdb_helper fallback (captures Flutter surface only, '
+        'no title bar).',
       );
       return _screenshotViaFdbHelper(vmServiceUri, output);
     }
@@ -262,8 +271,16 @@ Future<int> _screenshotLinux(
 
   final reason = pid == null
       ? 'No PID in session'
-      : 'Native Linux screenshot (xdotool/import) failed';
-  stderr.writeln('WARNING: $reason. Falling back to fdb_helper.');
+      : 'Native Linux screenshot (xdotool/import) failed.\n'
+          '  For X11: install xdotool and ImageMagick '
+          '(e.g. sudo apt install xdotool imagemagick).\n'
+          '  Wayland: native capture not supported';
+  stderr.writeln(
+    'WARNING: $reason.\n'
+    '  Using fdb_helper fallback (captures Flutter surface only, '
+    'no window chrome).\n'
+    '  Ensure your app includes the fdb_helper package.',
+  );
   return _screenshotViaFdbHelper(vmServiceUri, output);
 }
 
@@ -412,7 +429,12 @@ Future<int> _screenshotViaFdbHelper(
     if (isolateId == null) {
       stderr.writeln(
         'ERROR: fdb_helper not found in app and no native screenshot tool '
-        'available. Add fdb_helper to your Flutter app.',
+        'available.\n'
+        '  Add fdb_helper to your app\'s pubspec.yaml:\n'
+        '    dependencies:\n'
+        '      fdb_helper:\n'
+        '        path: <path-to-fdb>/packages/fdb_helper\n'
+        '  Then call FdbBinding.ensureInitialized() in main().',
       );
       return 1;
     }

--- a/lib/commands/scroll.dart
+++ b/lib/commands/scroll.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:fdb/process_utils.dart';
 import 'package:fdb/vm_service.dart';
 
 /// Scrolls in a direction on the device screen.
@@ -12,26 +13,15 @@ import 'package:fdb/vm_service.dart';
 ///   fdb scroll down --at 200,400
 ///   fdb scroll down --distance 500
 Future<int> runScroll(List<String> args) async {
-  if (args.isEmpty) {
-    stderr.writeln(
-        'ERROR: Usage: fdb scroll <up|down|left|right> [--at x,y] [--distance pixels]');
-    return 1;
-  }
-
-  final direction = args[0].toLowerCase();
-  if (direction != 'up' &&
-      direction != 'down' &&
-      direction != 'left' &&
-      direction != 'right') {
-    stderr.writeln('ERROR: Direction must be one of: up, down, left, right');
-    return 1;
-  }
-
+  String? deviceId;
+  String? direction;
   String? at;
   var distance = 200;
 
-  for (var i = 1; i < args.length; i++) {
+  for (var i = 0; i < args.length; i++) {
     switch (args[i]) {
+      case '--device':
+        deviceId = args[++i];
       case '--at':
         at = args[++i];
       case '--distance':
@@ -42,11 +32,38 @@ Future<int> runScroll(List<String> args) async {
           return 1;
         }
         distance = parsed;
+      default:
+        if (!args[i].startsWith('--')) {
+          direction = args[i].toLowerCase();
+        }
     }
   }
 
+  if (direction == null) {
+    stderr.writeln(
+        'ERROR: Usage: fdb scroll <up|down|left|right> [--at x,y] [--distance pixels]');
+    return 1;
+  }
+
+  if (direction != 'up' &&
+      direction != 'down' &&
+      direction != 'left' &&
+      direction != 'right') {
+    stderr.writeln('ERROR: Direction must be one of: up, down, left, right');
+    return 1;
+  }
+
+  final session = resolveSession(deviceId);
+  if (session == null) return 1;
+
+  final vmUri = session['vmServiceUri'] as String?;
+  if (vmUri == null) {
+    stderr.writeln('ERROR: No VM service URI in session. Is the app running?');
+    return 1;
+  }
+
   try {
-    final isolateId = await checkFdbHelper();
+    final isolateId = await checkFdbHelper(vmUri);
     if (isolateId == null) {
       stderr.writeln(
         'ERROR: fdb_helper not detected in running app. '
@@ -63,7 +80,8 @@ Future<int> runScroll(List<String> args) async {
     };
     if (at != null) params['at'] = at;
 
-    final response = await vmServiceCall('ext.fdb.scroll', params: params);
+    final response =
+        await vmServiceCall(vmUri, 'ext.fdb.scroll', params: params);
     final result = unwrapRawExtensionResult(response);
 
     if (result is Map<String, dynamic>) {

--- a/lib/commands/select.dart
+++ b/lib/commands/select.dart
@@ -1,14 +1,28 @@
 import 'dart:io';
 
+import 'package:fdb/process_utils.dart';
 import 'package:fdb/vm_service.dart';
 
 Future<int> runSelect(List<String> args) async {
-  if (args.isEmpty) {
+  String? deviceId;
+  String? mode;
+
+  for (var i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--device':
+        deviceId = args[++i];
+      default:
+        if (!args[i].startsWith('--')) {
+          mode = args[i].toLowerCase();
+        }
+    }
+  }
+
+  if (mode == null) {
     stderr.writeln('ERROR: Usage: fdb select on|off');
     return 1;
   }
 
-  final mode = args[0].toLowerCase();
   if (mode != 'on' && mode != 'off') {
     stderr.writeln('ERROR: Usage: fdb select on|off');
     return 1;
@@ -16,14 +30,24 @@ Future<int> runSelect(List<String> args) async {
 
   final enabled = mode == 'on';
 
+  final session = resolveSession(deviceId);
+  if (session == null) return 1;
+
+  final vmUri = session['vmServiceUri'] as String?;
+  if (vmUri == null) {
+    stderr.writeln('ERROR: No VM service URI in session. Is the app running?');
+    return 1;
+  }
+
   try {
-    final isolateId = await findFlutterIsolateId();
+    final isolateId = await findFlutterIsolateId(vmUri);
     if (isolateId == null) {
       stderr.writeln('ERROR: No Flutter isolate found');
       return 1;
     }
 
     await vmServiceCall(
+      vmUri,
       'ext.flutter.inspector.show',
       params: {'isolateId': isolateId, 'enabled': enabled.toString()},
     );

--- a/lib/commands/selected.dart
+++ b/lib/commands/selected.dart
@@ -1,16 +1,36 @@
 import 'dart:io';
 
+import 'package:fdb/process_utils.dart';
 import 'package:fdb/vm_service.dart';
 
 Future<int> runSelected(List<String> args) async {
+  String? deviceId;
+
+  for (var i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--device':
+        deviceId = args[++i];
+    }
+  }
+
+  final session = resolveSession(deviceId);
+  if (session == null) return 1;
+
+  final vmUri = session['vmServiceUri'] as String?;
+  if (vmUri == null) {
+    stderr.writeln('ERROR: No VM service URI in session. Is the app running?');
+    return 1;
+  }
+
   try {
-    final isolateId = await findFlutterIsolateId();
+    final isolateId = await findFlutterIsolateId(vmUri);
     if (isolateId == null) {
       stderr.writeln('ERROR: No Flutter isolate found');
       return 1;
     }
 
     final response = await vmServiceCall(
+      vmUri,
       'ext.flutter.inspector.getSelectedSummaryWidget',
       params: {'isolateId': isolateId, 'objectGroup': 'fdb_selected'},
     );

--- a/lib/commands/status.dart
+++ b/lib/commands/status.dart
@@ -2,9 +2,43 @@ import 'dart:io';
 
 import 'package:fdb/process_utils.dart';
 
+/// Reports whether the Flutter app is running for a given device.
+///
+/// Unlike other commands, this intentionally does NOT use [resolveSession].
+/// Status must never error — it always reports RUNNING=true or RUNNING=false,
+/// even when no session exists or multiple sessions are active. Using
+/// [resolveSession] would write errors to stderr and return null for those
+/// cases, which would break callers that poll status to detect app state.
 Future<int> runStatus(List<String> args) async {
-  final pid = readPid();
-  final vmUri = readVmUri();
+  String? deviceId;
+
+  for (var i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--device':
+        deviceId = args[++i];
+    }
+  }
+
+  final Map<String, dynamic>? session;
+  if (deviceId != null) {
+    // Specific device requested — read that session directly (may be null).
+    session = readSession(deviceId);
+  } else {
+    // No device specified — pick the single active session, if any.
+    final active = findActiveSessions();
+    session = active.length == 1 ? active.first : null;
+  }
+
+  if (session == null) {
+    // No session found — app is not running.
+    stdout.writeln('RUNNING=false');
+    return 0;
+  }
+
+  final pidRaw = session['pid'];
+  final pid =
+      pidRaw is int ? pidRaw : (pidRaw is String ? int.tryParse(pidRaw) : null);
+  final vmUri = session['vmServiceUri'] as String?;
   final running = pid != null && isProcessAlive(pid);
 
   stdout.writeln('RUNNING=$running');

--- a/lib/commands/tap.dart
+++ b/lib/commands/tap.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:fdb/process_utils.dart';
 import 'package:fdb/vm_service.dart';
 
 /// Taps a widget identified by selector or absolute coordinates.
@@ -11,6 +12,7 @@ import 'package:fdb/vm_service.dart';
 ///   fdb tap --x 195 --y 842
 ///   fdb tap --text "Submit" --timeout 5
 Future<int> runTap(List<String> args) async {
+  String? deviceId;
   String? text;
   String? key;
   String? type;
@@ -21,6 +23,8 @@ Future<int> runTap(List<String> args) async {
 
   for (var i = 0; i < args.length; i++) {
     switch (args[i]) {
+      case '--device':
+        deviceId = args[++i];
       case '--text':
         text = args[++i];
       case '--key':
@@ -72,8 +76,17 @@ Future<int> runTap(List<String> args) async {
     return 1;
   }
 
+  final session = resolveSession(deviceId);
+  if (session == null) return 1;
+
+  final vmUri = session['vmServiceUri'] as String?;
+  if (vmUri == null) {
+    stderr.writeln('ERROR: No VM service URI in session. Is the app running?');
+    return 1;
+  }
+
   try {
-    final isolateId = await checkFdbHelper();
+    final isolateId = await checkFdbHelper(vmUri);
     if (isolateId == null) {
       stderr.writeln(
         'ERROR: fdb_helper not detected in running app. '
@@ -94,7 +107,8 @@ Future<int> runTap(List<String> args) async {
       if (x != null) params['x'] = x.toString();
       if (y != null) params['y'] = y.toString();
 
-      final response = await vmServiceCall('ext.fdb.tap', params: params);
+      final response =
+          await vmServiceCall(vmUri, 'ext.fdb.tap', params: params);
       final result = unwrapRawExtensionResult(response);
 
       if (result is Map<String, dynamic>) {

--- a/lib/commands/tree.dart
+++ b/lib/commands/tree.dart
@@ -1,28 +1,47 @@
 import 'dart:io';
 
+import 'package:fdb/process_utils.dart';
 import 'package:fdb/vm_service.dart';
 
 Future<int> runTree(List<String> args) async {
+  String? deviceId;
   var maxDepth = 10;
   var userOnly = false;
 
   for (var i = 0; i < args.length; i++) {
     switch (args[i]) {
+      case '--device':
+        deviceId = args[++i];
       case '--depth':
-        maxDepth = int.parse(args[++i]);
+        final parsed = int.tryParse(args[++i]);
+        if (parsed == null) {
+          stderr.writeln('ERROR: --depth requires an integer value');
+          return 1;
+        }
+        maxDepth = parsed;
       case '--user-only':
         userOnly = true;
     }
   }
 
+  final session = resolveSession(deviceId);
+  if (session == null) return 1;
+
+  final vmUri = session['vmServiceUri'] as String?;
+  if (vmUri == null) {
+    stderr.writeln('ERROR: No VM service URI in session. Is the app running?');
+    return 1;
+  }
+
   try {
-    final isolateId = await findFlutterIsolateId();
+    final isolateId = await findFlutterIsolateId(vmUri);
     if (isolateId == null) {
       stderr.writeln('ERROR: No Flutter isolate found');
       return 1;
     }
 
     final response = await vmServiceCall(
+      vmUri,
       'ext.flutter.inspector.getRootWidgetSummaryTree',
       params: {'isolateId': isolateId, 'objectGroup': 'fdb_tree'},
       timeout: const Duration(seconds: 60),

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -1,13 +1,52 @@
-const pidFile = '/tmp/fdb.pid';
-const logFile = '/tmp/fdb_logs.txt';
-const vmUriFile = '/tmp/fdb_vm_uri.txt';
-const launcherScript = '/tmp/fdb_launcher.sh';
-const deviceFile = '/tmp/fdb_device.txt';
-const defaultScreenshotPath = '/tmp/fdb_screenshot.png';
+import 'dart:io';
 
-const launchTimeoutSeconds = 300; // 5 minutes
+/// Base directory for all fdb state
+String get fdbHome {
+  final home = Platform.environment['HOME'] ??
+      Platform.environment['USERPROFILE'] ??
+      '.';
+  return '$home/.fdb';
+}
+
+/// Device cache file path
+String get deviceCachePath => '$fdbHome/devices.json';
+
+/// Session directory for a given device ID
+String sessionDir(String deviceId) {
+  final hash = _shortHash(deviceId);
+  return '$fdbHome/sessions/$hash';
+}
+
+/// Session state file for a given device ID
+String sessionFile(String deviceId) => '${sessionDir(deviceId)}/session.json';
+
+/// Log file for a given device ID
+String logPath(String deviceId) => '${sessionDir(deviceId)}/logs.txt';
+
+/// Launcher script for a given device ID
+String launcherPath(String deviceId) => '${sessionDir(deviceId)}/launcher.sh';
+
+/// Default screenshot path for a given device ID
+String screenshotPath(String deviceId) =>
+    '${sessionDir(deviceId)}/screenshot.png';
+
+const launchTimeoutSeconds = 300;
 const reloadTimeoutSeconds = 10;
 const restartTimeoutSeconds = 10;
 const killTimeoutSeconds = 10;
 const pollIntervalMs = 3000;
 const heartbeatIntervalSeconds = 15;
+
+/// Deterministic hash of [input] — same input always produces same output.
+/// Uses two rounds of djb2 with different seeds combined for 16 hex digits.
+String _shortHash(String input) {
+  var h1 = 5381;
+  var h2 = 0x811c9dc5;
+  for (var i = 0; i < input.length; i++) {
+    final c = input.codeUnitAt(i);
+    h1 = ((h1 << 5) + h1 + c) & 0xFFFFFFFF;
+    h2 = ((h2 ^ c) * 0x01000193) & 0xFFFFFFFF;
+  }
+  return h1.toRadixString(16).padLeft(8, '0') +
+      h2.toRadixString(16).padLeft(8, '0');
+}

--- a/lib/process_utils.dart
+++ b/lib/process_utils.dart
@@ -1,27 +1,64 @@
+import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:fdb/constants.dart';
 
-int? readPid() {
-  final file = File(pidFile);
+/// Reads and parses session.json for [deviceId].
+/// Returns null if the file does not exist or cannot be parsed.
+Map<String, dynamic>? readSession(String deviceId) {
+  final file = File(sessionFile(deviceId));
   if (!file.existsSync()) return null;
-  final content = file.readAsStringSync().trim();
-  return int.tryParse(content);
+  try {
+    final content = file.readAsStringSync();
+    return jsonDecode(content) as Map<String, dynamic>;
+  } catch (_) {
+    return null;
+  }
 }
 
-String? readVmUri() {
-  final file = File(vmUriFile);
-  if (!file.existsSync()) return null;
-  return file.readAsStringSync().trim();
+/// Writes [data] to session.json for [deviceId] atomically
+/// (write to .tmp then rename). Creates the session directory if needed.
+void writeSession(String deviceId, Map<String, dynamic> data) {
+  ensureFdbHome();
+  final dir = sessionDir(deviceId);
+  Directory(dir).createSync(recursive: true);
+  final path = sessionFile(deviceId);
+  final tmp = '$path.tmp';
+  File(tmp).writeAsStringSync(jsonEncode(data));
+  File(tmp).renameSync(path);
 }
 
-String? readDevice() {
-  final file = File(deviceFile);
-  if (!file.existsSync()) return null;
-  final content = file.readAsStringSync().trim();
-  return content.isEmpty ? null : content;
+/// Reads the existing session for [deviceId], merges [updates], and writes back.
+/// Creates the session if it does not exist.
+void updateSession(String deviceId, Map<String, dynamic> updates) {
+  final existing = readSession(deviceId) ?? {};
+  writeSession(deviceId, {...existing, ...updates});
 }
 
+/// Reads the session for [deviceId] and returns the pid field, or null.
+int? readPidFromSession(String deviceId) {
+  final session = readSession(deviceId);
+  if (session == null) return null;
+  final pid = session['pid'];
+  if (pid is int) return pid;
+  if (pid is String) return int.tryParse(pid);
+  return null;
+}
+
+/// Reads the session for [deviceId] and returns the vmServiceUri field, or null.
+String? readVmUriFromSession(String deviceId) {
+  final session = readSession(deviceId);
+  return session?['vmServiceUri'] as String?;
+}
+
+/// Reads the session for [deviceId] and returns the deviceId field, or null.
+String? readDeviceFromSession(String deviceId) {
+  final session = readSession(deviceId);
+  return session?['deviceId'] as String?;
+}
+
+/// Returns true if the process with [pid] is alive (via kill -0).
 bool isProcessAlive(int pid) {
   try {
     final result = Process.runSync('kill', ['-0', pid.toString()]);
@@ -31,17 +68,212 @@ bool isProcessAlive(int pid) {
   }
 }
 
-void cleanupTempFiles() {
-  for (final path in [
-    pidFile,
-    logFile,
-    vmUriFile,
-    launcherScript,
-    deviceFile
-  ]) {
-    final file = File(path);
-    if (file.existsSync()) {
-      file.deleteSync();
+/// Deletes the entire session directory for [deviceId].
+void cleanupSession(String deviceId) {
+  final dir = Directory(sessionDir(deviceId));
+  if (dir.existsSync()) {
+    dir.deleteSync(recursive: true);
+  }
+}
+
+/// Creates ~/.fdb/ and ~/.fdb/sessions/ if they do not exist.
+void ensureFdbHome() {
+  Directory('$fdbHome/sessions').createSync(recursive: true);
+}
+
+/// Scans all session directories, reads session.json, and returns only those
+/// with a live PID (verified via kill -0). Each entry includes the full session data.
+List<Map<String, dynamic>> findActiveSessions() {
+  final sessionsDir = Directory('$fdbHome/sessions');
+  if (!sessionsDir.existsSync()) return [];
+
+  final active = <Map<String, dynamic>>[];
+  for (final entry in sessionsDir.listSync()) {
+    if (entry is! Directory) continue;
+    final sessionJsonFile = File('${entry.path}/session.json');
+    if (!sessionJsonFile.existsSync()) continue;
+    try {
+      final data = jsonDecode(sessionJsonFile.readAsStringSync())
+          as Map<String, dynamic>;
+      final pidRaw = data['pid'];
+      final int? pid;
+      if (pidRaw is int) {
+        pid = pidRaw;
+      } else if (pidRaw is String) {
+        pid = int.tryParse(pidRaw);
+      } else {
+        pid = null;
+      }
+      if (pid == null) continue;
+      if (isProcessAlive(pid)) {
+        active.add(data);
+      }
+    } catch (_) {
+      // Skip unreadable or malformed session files
     }
   }
+  return active;
+}
+
+/// Resolves a session by [deviceId].
+///
+/// If [deviceId] is provided, reads that session directly.
+/// If null, auto-selects from active sessions:
+/// - exactly one active session → returns it
+/// - zero active sessions → writes error to stderr, returns null
+/// - multiple active sessions → writes error listing them to stderr, returns null
+///
+/// The returned map always includes the deviceId under the 'deviceId' key.
+Map<String, dynamic>? resolveSession(String? deviceId) {
+  if (deviceId != null) {
+    final session = readSession(deviceId);
+    if (session == null) {
+      stderr.writeln('ERROR: No session found for device: $deviceId');
+      return null;
+    }
+    return {...session, 'deviceId': deviceId};
+  }
+
+  final active = findActiveSessions();
+  if (active.isEmpty) {
+    stderr.writeln('ERROR: No active sessions found. Is the app running?');
+    return null;
+  }
+  if (active.length > 1) {
+    final ids =
+        active.map((s) => s['deviceId'] as String? ?? '<unknown>').join(', ');
+    stderr.writeln(
+      'ERROR: Multiple active sessions found: $ids. '
+      'Specify a device with --device.',
+    );
+    return null;
+  }
+  return active.first;
+}
+
+// ---------------------------------------------------------------------------
+// Shell escaping
+// ---------------------------------------------------------------------------
+
+/// Shell-escapes [value] for safe embedding in a bash command string.
+///
+/// Uses a permissive safe-character set that includes `:` and `@` so that
+/// device IDs and VM service URIs are not unnecessarily quoted.
+String shellEscape(String value) {
+  if (RegExp(r'^[a-zA-Z0-9._/=:@-]+$').hasMatch(value)) return value;
+  return "'${value.replaceAll("'", r"'\''")}'";
+}
+
+// ---------------------------------------------------------------------------
+// Device cache
+// ---------------------------------------------------------------------------
+
+/// Writes [devices] (raw list from `flutter devices --machine`) to the device
+/// cache at [deviceCachePath].
+///
+/// Each entry is normalised to `{id, name, platform, emulator}`.
+/// Calls [ensureFdbHome] before writing.
+void writeDeviceCache(List<dynamic> devices) {
+  ensureFdbHome();
+  final entries = devices.map((d) {
+    final m = d as Map<String, dynamic>;
+    return {
+      'id': m['id'] as String,
+      'name': m['name'] as String,
+      'platform': m['targetPlatform'] as String,
+      'emulator': m['emulator'] as bool? ?? false,
+    };
+  }).toList();
+
+  final payload = jsonEncode({
+    'updatedAt': DateTime.now().toUtc().toIso8601String(),
+    'devices': entries,
+  });
+
+  final path = deviceCachePath;
+  final tmp = '$path.tmp';
+  File(tmp).writeAsStringSync(payload);
+  File(tmp).renameSync(path);
+}
+
+/// Reads the device cache from [deviceCachePath].
+/// Returns null if the file does not exist or cannot be parsed.
+Map<String, dynamic>? _readDeviceCache() {
+  final file = File(deviceCachePath);
+  if (!file.existsSync()) return null;
+  try {
+    return jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+  } catch (_) {
+    return null;
+  }
+}
+
+/// Looks up the platform for [deviceId] from the device cache.
+/// Returns null if the device is not found or the cache does not exist.
+String? lookupPlatform(String deviceId) {
+  final cache = _readDeviceCache();
+  if (cache == null) return null;
+  final devices = cache['devices'] as List<dynamic>?;
+  if (devices == null) return null;
+  for (final d in devices) {
+    final m = d as Map<String, dynamic>;
+    if (m['id'] == deviceId) return m['platform'] as String?;
+  }
+  return null;
+}
+
+/// Looks up whether [deviceId] is an emulator from the device cache.
+/// Returns null if the device is not found or the cache does not exist.
+bool? lookupEmulator(String deviceId) {
+  final cache = _readDeviceCache();
+  if (cache == null) return null;
+  final devices = cache['devices'] as List<dynamic>?;
+  if (devices == null) return null;
+  for (final d in devices) {
+    final m = d as Map<String, dynamic>;
+    if (m['id'] == deviceId) return m['emulator'] as bool?;
+  }
+  return null;
+}
+
+/// Refreshes the device cache by running `flutter devices --machine`.
+///
+/// Parses the output and writes to [deviceCachePath].
+/// Returns true on success, false if the command fails or output cannot be
+/// parsed. This is intended for callers (e.g. launch) that need an up-to-date
+/// cache when a device is not found in the existing one.
+Future<bool> refreshDeviceCache() async {
+  try {
+    final result = await Process.run('flutter', ['devices', '--machine']);
+    if (result.exitCode != 0) return false;
+
+    final json = _extractDevicesJson(result.stdout as String);
+    if (json == null) return false;
+
+    final List<dynamic> devices;
+    try {
+      devices = jsonDecode(json) as List<dynamic>;
+    } catch (_) {
+      return false;
+    }
+
+    writeDeviceCache(devices);
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+/// Extracts the JSON array from `flutter devices --machine` output.
+///
+/// Flutter may prepend non-JSON text (download progress, upgrade banners)
+/// before the actual JSON array. We scan for the first `[` to find the
+/// array start.
+// NOTE: duplicated in devices.dart to avoid circular import.
+String? _extractDevicesJson(String output) {
+  final start = output.indexOf('[');
+  if (start == -1) return null;
+  final end = output.lastIndexOf(']');
+  if (end == -1 || end < start) return null;
+  return output.substring(start, end + 1);
 }

--- a/lib/vm_service.dart
+++ b/lib/vm_service.dart
@@ -2,28 +2,20 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:fdb/process_utils.dart';
-
 /// Sends a JSON-RPC request to the Flutter VM service over websocket.
 /// Returns the parsed JSON response.
 /// Throws on connection failure or timeout.
 Future<Map<String, dynamic>> vmServiceCall(
+  String uri,
   String method, {
   Map<String, dynamic> params = const {},
   Duration timeout = const Duration(seconds: 30),
 }) async {
-  final uri = readVmUri();
-  if (uri == null || uri.isEmpty) {
-    throw StateError('VM service URI not found. Is the app running?');
-  }
-
   final wsUri =
       uri.replaceFirst('http://', 'ws://').replaceFirst('https://', 'wss://');
 
-  final ws = await WebSocket.connect(
-    wsUri,
-    customClient: HttpClient()..maxConnectionsPerHost = 1,
-  );
+  final httpClient = HttpClient()..maxConnectionsPerHost = 1;
+  final ws = await WebSocket.connect(wsUri, customClient: httpClient);
 
   // Widget trees can be 500KB+, no built-in buffer size limit on dart:io WebSocket
   // but we need to handle large responses properly.
@@ -60,18 +52,16 @@ Future<Map<String, dynamic>> vmServiceCall(
   ws.add(request);
 
   try {
-    final response = await completer.future.timeout(timeout);
+    return await completer.future.timeout(timeout);
+  } finally {
     await ws.close();
-    return response;
-  } on TimeoutException {
-    await ws.close();
-    rethrow;
+    httpClient.close();
   }
 }
 
 /// Returns all isolate IDs from the VM service.
-Future<List<String>> findAllIsolateIds() async {
-  final vmResponse = await vmServiceCall('getVM');
+Future<List<String>> findAllIsolateIds(String uri) async {
+  final vmResponse = await vmServiceCall(uri, 'getVM');
   final result = vmResponse['result'] as Map<String, dynamic>?;
   if (result == null) return [];
 
@@ -87,11 +77,12 @@ Future<List<String>> findAllIsolateIds() async {
 
 /// Finds the Flutter UI isolate by trying each isolate until one returns
 /// a non-null widget tree. Returns the isolate ID or null.
-Future<String?> findFlutterIsolateId() async {
-  final ids = await findAllIsolateIds();
+Future<String?> findFlutterIsolateId(String uri) async {
+  final ids = await findAllIsolateIds(uri);
   for (final id in ids) {
     try {
       final response = await vmServiceCall(
+        uri,
         'ext.flutter.inspector.isWidgetTreeReady',
         params: {'isolateId': id},
         timeout: const Duration(seconds: 5),
@@ -160,11 +151,12 @@ dynamic unwrapRawExtensionResult(Map<String, dynamic> response) {
 ///
 /// Returns the Flutter isolate ID if fdb_helper is available, or null if not.
 /// Callers can reuse the returned isolate ID to avoid a second round-trip.
-Future<String?> checkFdbHelper() async {
+Future<String?> checkFdbHelper(String uri) async {
   try {
-    final isolateId = await findFlutterIsolateId();
+    final isolateId = await findFlutterIsolateId(uri);
     if (isolateId == null) return null;
     await vmServiceCall(
+      uri,
       'ext.fdb.elements',
       params: {'isolateId': isolateId},
       timeout: const Duration(seconds: 3),

--- a/packages/fdb_helper/lib/src/fdb_binding.dart
+++ b/packages/fdb_helper/lib/src/fdb_binding.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:developer' as developer;
+import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
@@ -19,11 +20,12 @@ import 'widget_matcher.dart';
 /// }
 /// ```
 ///
-/// This registers four VM service extensions (in debug and profile mode only):
+/// This registers five VM service extensions (in all modes except release, i.e., debug and profile):
 /// - `ext.fdb.elements` — list all interactive elements with bounds
 /// - `ext.fdb.tap` — tap a widget by key, text, type, or coordinates
 /// - `ext.fdb.enterText` — enter text into a text field
 /// - `ext.fdb.scroll` — perform a swipe/scroll gesture
+/// - `ext.fdb.screenshot` — capture the current Flutter rendering surface as base64 PNG
 class FdbBinding extends WidgetsFlutterBinding {
   FdbBinding._();
 
@@ -53,6 +55,7 @@ class FdbBinding extends WidgetsFlutterBinding {
     _registerExtension('ext.fdb.tap', _handleTap);
     _registerExtension('ext.fdb.enterText', _handleEnterText);
     _registerExtension('ext.fdb.scroll', _handleScroll);
+    _registerExtension('ext.fdb.screenshot', _handleScreenshot);
   }
 
   /// Registers a VM service extension, silently ignoring double-registration
@@ -320,6 +323,68 @@ class FdbBinding extends WidgetsFlutterBinding {
       );
     } catch (e) {
       return _errorResponse('Scroll failed: $e');
+    }
+  }
+
+  Future<developer.ServiceExtensionResponse> _handleScreenshot(
+    String method,
+    Map<String, String> params,
+  ) async {
+    ui.Scene? scene;
+    ui.Image? image;
+    try {
+      final renderViews = WidgetsBinding.instance.renderViews;
+      if (renderViews.isEmpty) {
+        return _errorResponse('No render views available');
+      }
+
+      final view = renderViews.first;
+      final flutterView = view.flutterView;
+
+      // Wait for paint if needed.
+      // ignore: invalid_use_of_protected_member
+      if (view.debugNeedsPaint || view.layer == null) {
+        WidgetsBinding.instance.scheduleFrame();
+        await Future.delayed(const Duration(milliseconds: 100));
+      }
+
+      // ignore: invalid_use_of_protected_member
+      final layer = view.layer;
+      if (layer == null) {
+        return _errorResponse('Render view layer is null');
+      }
+
+      // Capture at device pixel ratio (exact screen pixels).
+      final size = flutterView.physicalSize;
+      final width = size.width.ceil();
+      final height = size.height.ceil();
+
+      if (width <= 0 || height <= 0) {
+        return _errorResponse('Invalid view size: ${width}x$height');
+      }
+
+      final builder = ui.SceneBuilder();
+      layer.addToScene(builder);
+      scene = builder.build();
+      image = await scene.toImage(width, height);
+
+      final byteData = await image.toByteData(
+        format: ui.ImageByteFormat.png,
+      );
+      if (byteData == null) {
+        return _errorResponse('Failed to encode image as PNG');
+      }
+
+      final base64 = base64Encode(byteData.buffer.asUint8List());
+
+      return developer.ServiceExtensionResponse.result(
+        jsonEncode({'screenshot': base64}),
+      );
+    } catch (e) {
+      return _errorResponse('Screenshot failed: $e');
+    } finally {
+      scene?.dispose();
+      image?.dispose();
     }
   }
 

--- a/packages/fdb_helper/lib/src/fdb_binding.dart
+++ b/packages/fdb_helper/lib/src/fdb_binding.dart
@@ -345,7 +345,7 @@ class FdbBinding extends WidgetsFlutterBinding {
       // ignore: invalid_use_of_protected_member
       if (view.debugNeedsPaint || view.layer == null) {
         WidgetsBinding.instance.scheduleFrame();
-        await Future.delayed(const Duration(milliseconds: 100));
+        await WidgetsBinding.instance.endOfFrame;
       }
 
       // ignore: invalid_use_of_protected_member


### PR DESCRIPTION
Screenshot only worked on Android (adb) and iOS simulator (xcrun simctl), and all fdb state lived in /tmp as flat files — meaning two simultaneous sessions would stomp on each other.

This migrates state to ~/.fdb/sessions/<device-hash>/session.json (one directory per device, cleared on next launch) and rewrites screenshot to dispatch per-platform: adb for Android, xcrun simctl for iOS sim, screencapture for macOS desktop, xdotool+import for Linux X11, CDP Page.captureScreenshot for Chrome/web, and a new ext.fdb.screenshot VM service extension in fdb_helper as fallback for physical iOS, Windows, and Linux Wayland. Every command now accepts --device for multi-session targeting (auto-selects if only one session is active). Device platform is auto-discovered from a cache written by fdb devices and refreshed on cache miss during launch.

Note: physical iOS and Windows use fdb_helper (renders Flutter surface only, no OS chrome) since no native CLI screenshot tool exists for those platforms.