### PR TITLE
feat: Add release skill and publish CI workflow

### DIFF
--- a/.agents/skills/releasing-fdb/SKILL.md
+++ b/.agents/skills/releasing-fdb/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: releasing-fdb
+description: Prepares and publishes new fdb releases. Covers version bumping (fdb + fdb_helper lockstep), pre-release verification (smoke tests, analysis), pub.dev publishing, git tagging, and GitHub release creation. Use when bumping the version, preparing a release, publishing to pub.dev, creating a GitHub release, or tagging a new version.
+metadata:
+  internal: true
+---
+
+## Semver
+
+Follow [Semantic Versioning](https://semver.org):
+- **Patch** (0.1.x): bug fixes, no API/CLI changes
+- **Minor** (0.x.0): new commands, new flags, backward-compatible changes
+- **Major** (x.0.0): breaking changes to CLI interface, fdb_helper API, or file contracts
+
+## One-time Setup
+
+Required before the first automated release. Skip if already done.
+
+### pub.dev
+
+1. Authenticate: `dart pub login`
+2. Publish the first version interactively (automated publishing requires at least one manual publish):
+   ```bash
+   dart pub publish --dry-run   # verify, fix any issues
+   dart pub publish              # interactive confirmation
+   ```
+3. Go to <https://pub.dev/packages/fdb/admin> and enable **Automated publishing**:
+   - Provider: GitHub Actions
+   - Repository: `andrzejchm/fdb`
+   - Tag pattern: `v{{version}}`
+
+### GitHub CLI
+
+Verify `gh` is authenticated: `gh auth status`
+
+## Release Checklist
+
+Copy and track progress:
+
+```
+- [ ] Pre-release verification (analyze, unit tests, smoke tests)
+- [ ] Determine version bump type (major / minor / patch)
+- [ ] Update version in all 4 files (lockstep)
+- [ ] Commit: `chore: bump version to X.Y.Z`
+- [ ] Tag: `git tag vX.Y.Z`
+- [ ] Push: `git push origin main --tags`
+- [ ] Verify CI workflow passes (analyze, unit tests, pub.dev publish, GitHub release)
+- [ ] Post-release verification
+```
+
+## Pre-release Verification
+
+**All checks must pass before proceeding. Do not skip any step.**
+
+```bash
+task analyze                  # dart analyze + dart format --set-exit-if-changed
+task test:unit                # unit tests
+task smoke                    # full integration smoke test (requires device/simulator)
+```
+
+If `task smoke` fails, fix the issue and re-run before continuing. A connected iOS Simulator or Android emulator is required.
+
+Ensure `main` is clean:
+```bash
+git status                    # no uncommitted changes
+git pull origin main          # up to date with remote
+```
+
+## Version Bump
+
+fdb and fdb_helper are versioned in **lockstep** — always bump both to the same version.
+
+Update the version string in all 4 files:
+
+| # | File | What to change |
+|---|------|----------------|
+| 1 | `lib/constants.dart` | `const version = 'X.Y.Z';` |
+| 2 | `pubspec.yaml` | `version: X.Y.Z` |
+| 3 | `packages/fdb_helper/pubspec.yaml` | `version: X.Y.Z` |
+| 4 | `skills/interacting-with-flutter-apps/SKILL.md` | Version in `## Overview` heading and in the version check blockquote |
+
+### Verify consistency
+
+After editing, confirm all 4 files show the same version:
+```bash
+grep -r "OLD_VERSION" lib/constants.dart pubspec.yaml packages/fdb_helper/pubspec.yaml skills/interacting-with-flutter-apps/SKILL.md
+```
+Replace `OLD_VERSION` with the **previous** version to confirm no stale references remain.
+
+## Commit, Tag, Push
+
+```bash
+git add -A
+git commit -m "chore: bump version to X.Y.Z"
+git tag vX.Y.Z
+git push origin main --tags
+```
+
+The tag push triggers `.github/workflows/publish.yml` which:
+1. Runs `dart analyze` and `dart format --set-exit-if-changed`
+2. Runs `dart test`
+3. Publishes to pub.dev (`dart pub publish --force`)
+4. Generates release notes from conventional commits since the previous tag
+5. Creates a GitHub release with the generated notes
+
+## Post-release Verification
+
+After CI completes:
+
+1. **pub.dev**: Check <https://pub.dev/packages/fdb> shows the new version
+2. **Install from pub.dev**:
+   ```bash
+   dart pub global activate fdb
+   fdb --version                 # should print: fdb X.Y.Z
+   ```
+3. **GitHub release**: Check <https://github.com/andrzejchm/fdb/releases> for the new release with auto-generated notes
+4. **Git install still works** (for users pinning to a tag):
+   ```bash
+   dart pub global activate --source git https://github.com/andrzejchm/fdb.git --git-ref vX.Y.Z
+   ```
+
+## Troubleshooting
+
+### pub.dev publish fails in CI
+
+- Verify automated publishing is enabled on <https://pub.dev/packages/fdb/admin>
+- Verify tag pattern matches `v{{version}}`
+- Verify `pubspec.yaml` version matches the tag (tag `v0.2.0` requires `version: 0.2.0`)
+- Check the `id-token: write` permission is set on the publish job
+
+### GitHub release not created
+
+- Verify `contents: write` permission is set on the publish job
+- Check `gh` auth in the workflow (uses `github.token` automatically)
+
+### Version mismatch
+
+If any of the 4 version files are out of sync, pub.dev publish may succeed with the wrong version. Always verify with the grep command in the Version Bump section.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,137 @@
+name: Publish to pub.dev
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  ci:
+    name: Analyze & test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+
+      - name: Install dependencies
+        run: dart pub get
+
+      - name: Check formatting
+        run: dart format --set-exit-if-changed .
+
+      - name: Analyze
+        run: dart analyze --fatal-infos
+
+      - name: Run unit tests
+        run: dart test
+
+  publish:
+    name: Publish to pub.dev & create GitHub release
+    needs: ci
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+
+      - name: Install dependencies
+        run: dart pub get
+
+      - name: Dry run
+        run: dart pub publish --dry-run
+
+      - name: Publish to pub.dev
+        run: dart pub publish --force
+
+      - name: Generate release notes
+        id: changelog
+        run: |
+          CURRENT_TAG="${GITHUB_REF_NAME}"
+          PREV_TAG=$(git tag --sort=-version:refname | grep -v "^${CURRENT_TAG}$" | head -1)
+
+          if [ -z "$PREV_TAG" ]; then
+            COMMITS=$(git log --pretty=format:"%s" HEAD)
+          else
+            COMMITS=$(git log --pretty=format:"%s" "${PREV_TAG}..HEAD")
+          fi
+
+          OUT=/tmp/release-notes.md
+          > "$OUT"
+
+          write_section() {
+            local header="$1" type="$2"
+            local lines
+            lines=$(echo "$COMMITS" | grep -E "^${type}(\(.+\))?(!)?:" | sed "s/^${type}[^:]*: /- /" || true)
+            if [ -n "$lines" ]; then
+              echo "$header" >> "$OUT"
+              echo "$lines" >> "$OUT"
+              echo "" >> "$OUT"
+            fi
+          }
+
+          write_section "### Features"      feat
+          write_section "### Bug Fixes"     fix
+          write_section "### Performance"   perf
+          write_section "### Refactoring"   refactor
+          write_section "### Documentation" docs
+          write_section "### Chores"        chore
+          write_section "### CI"            ci
+          write_section "### Tests"         test
+
+          # Uncategorized commits
+          UNCATEGORIZED=$(echo "$COMMITS" | grep -vE "^(feat|fix|perf|refactor|docs|chore|ci|test)(\(.+\))?(!)?:" || true)
+          if [ -n "$UNCATEGORIZED" ]; then
+            echo "### Other" >> "$OUT"
+            echo "$UNCATEGORIZED" | sed 's/^/- /' >> "$OUT"
+            echo "" >> "$OUT"
+          fi
+
+          if [ ! -s "$OUT" ]; then
+            echo "No notable changes." >> "$OUT"
+          fi
+
+          # Contributors (exclude repo owner and bots)
+          OWNER="${{ github.repository_owner }}"
+          if [ -n "$PREV_TAG" ]; then
+            CONTRIBUTORS=$(curl -sf -H "Authorization: token ${{ github.token }}" \
+              "https://api.github.com/repos/${{ github.repository }}/compare/${PREV_TAG}...${CURRENT_TAG}" \
+              | jq -r "[.commits[].author.login // empty] | unique | .[]" 2>/dev/null \
+              | grep -v '^\s*$' \
+              | grep -vi '\[bot\]' \
+              | grep -vi 'dependabot' \
+              | grep -vi 'github-actions' \
+              | grep -vi "^${OWNER}$" \
+              | sed 's/^/@/' \
+              | sort -u || true)
+          fi
+
+          if [ -n "$CONTRIBUTORS" ]; then
+            echo "### Contributors" >> "$OUT"
+            echo "Thanks to $(echo "$CONTRIBUTORS" | paste -sd, - | sed 's/,/, /g; s/, \([^,]*\)$/ and \1/') for contributing to this release! :tada:" >> "$OUT"
+            echo "" >> "$OUT"
+          fi
+
+          if [ -n "$PREV_TAG" ]; then
+            COMPARE_URL="https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${CURRENT_TAG}"
+            echo "**Full diff:** ${COMPARE_URL}" >> "$OUT"
+          fi
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file /tmp/release-notes.md


### PR DESCRIPTION
Establishes a repeatable release process for fdb. Until now there were no tags, no GitHub releases, no pub.dev publishing, and no documented procedure for cutting a version.

The internal skill (.agents/skills/releasing-fdb/) documents the full flow an agent should follow: run smoke tests on device, bump the version in all 4 lockstep locations (constants.dart, both pubspec.yaml files, and the public-facing skill), tag, and push. The CI workflow (.github/workflows/publish.yml) takes over from there -- it runs analysis and unit tests, publishes to pub.dev via OIDC, generates conventional-commit-based release notes, and creates a GitHub release.

One-time setup (pub.dev first interactive publish + enabling automated publishing) still needs to happen before the first tag-triggered release.