### PR TITLE
feat: all-platform screenshot support

### DIFF
--- a/.agents/skills/testing-fdb/SKILL.md
+++ b/.agents/skills/testing-fdb/SKILL.md
@@ -69,7 +69,7 @@ task test:unit    # dart test (when tests exist)
 ### Cleanup
 
 ```bash
-task cleanup    # kill app, remove /tmp/fdb_* files
+task cleanup    # kill app, remove .fdb/ session directory
 ```
 
 ## Test output conventions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ lib/
     logs.dart                 # Filtered log viewing + follow mode
     reload.dart               # Hot reload via SIGUSR1
     restart.dart              # Hot restart via SIGUSR2
-    screenshot.dart           # Device screenshot (adb / xcrun)
+    screenshot.dart           # Screenshot (all platforms: adb, xcrun, screencapture, CDP, fdb_helper)
     scroll.dart               # Scroll / swipe gesture
     select.dart               # Toggle widget selection mode
     selected.dart             # Get selected widget info

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ fdb kill
 
 | Command | Description |
 |---------|-------------|
-| `fdb screenshot [--output <path>]` | Device screenshot |
+| `fdb screenshot [--output <path>] [--full]` | Screenshot (all platforms; `--full` skips downscaling) |
 | `fdb logs --tag <tag> --last <n>` | Filtered logs |
 | `fdb tree --depth <n> [--user-only]` | Widget tree |
 | `fdb describe` | Compact screen snapshot: interactive elements + visible text *(requires `fdb_helper`)* |
@@ -176,7 +176,7 @@ void main() {
 
 **Launch hangs** - Check the device ID (`fdb devices`) and the project path.
 
-**Screenshot fails** - `adb` (Android) or `xcrun` (iOS) must be on your PATH.
+**Screenshot fails** - check the tool for your platform is on PATH: `adb` (Android), `xcrun` (iOS simulator), `screencapture` (macOS), `xdotool` + `import` (Linux X11). Physical iOS, Windows, and Linux Wayland use `fdb_helper` — add it to your app and call `FdbBinding.ensureInitialized()`.
 
 **Empty widget tree** - App may still be starting. Retry, or use `fdb describe` instead.
 

--- a/doc/README.agents.md
+++ b/doc/README.agents.md
@@ -64,7 +64,9 @@ curl -fsSL https://raw.githubusercontent.com/andrzejchm/fdb/main/skills/using-fd
 - Dart SDK >= 3.0.0
 - Flutter SDK (for `flutter devices`, `flutter run`)
 - A running iOS Simulator or Android emulator (or physical device)
-- `adb` for Android screenshots, `xcrun` for iOS simulator screenshots
+- `adb` (Android), `xcrun` (iOS simulator), `screencapture` (macOS) on PATH for screenshots
+- `xdotool` + ImageMagick `import` for Linux X11 screenshots (optional)
+- Physical iOS / Windows / Linux Wayland screenshots use `fdb_helper` (no extra tool needed)
 
 ## Commands Reference
 
@@ -75,7 +77,7 @@ curl -fsSL https://raw.githubusercontent.com/andrzejchm/fdb/main/skills/using-fd
 | `fdb launch --device <id> --project <path>` | Launch app, wait for start |
 | `fdb reload` | Hot reload (SIGUSR1) |
 | `fdb restart` | Hot restart (SIGUSR2) |
-| `fdb screenshot [--output <path>]` | Device screenshot |
+| `fdb screenshot [--output <path>] [--full]` | Screenshot (all platforms; `--full` skips downscaling) |
 | `fdb logs --tag <tag> --last <n>` | Filtered logs |
 | `fdb tree --depth <n> [--user-only]` | Widget tree |
 | `fdb describe` | Compact screen snapshot: interactive elements + visible text |
@@ -112,10 +114,10 @@ fdb restart   # SIGUSR2 - resets state
 ### Screenshot
 
 ```bash
-fdb screenshot [--output <path>]
+fdb screenshot [--output <path>] [--full]
 ```
 
-Auto-detects Android (`adb screencap`) vs iOS simulator (`xcrun simctl io screenshot`). Default output: `<project>/.fdb/screenshot.png`.
+Dispatches to the right tool per platform: `adb` (Android), `xcrun simctl` (iOS simulator), `screencapture` (macOS), `xdotool`+`import` (Linux X11), Chrome DevTools Protocol (web), or `fdb_helper` VM extension (physical iOS, Windows, Wayland). Output is downscaled so the longest side fits within 1200px — pass `--full` to get native resolution. Default output: `<project>/.fdb/screenshot.png`.
 
 ### Logs
 
@@ -261,6 +263,6 @@ fdb logs --tag "fdb_test" --last 20       # check logs after interaction
 
 **Empty widget tree** -- Fall back to raw websocat commands (see the skill file for details).
 
-**Screenshot fails** -- Ensure `adb` (Android) or `xcrun` (iOS) is available and the device is connected.
+**Screenshot fails** -- Check the tool for your platform is on PATH: `adb` (Android), `xcrun` (iOS simulator), `screencapture` (macOS), `xdotool`+`import` (Linux X11). Physical iOS, Windows, and Wayland use `fdb_helper` — add it to your app and call `FdbBinding.ensureInitialized()`.
 
 **Status shows RUNNING=false after launch** -- The Flutter process may have crashed. Check `fdb logs --last 50` for errors.

--- a/example/test_app/lib/benchmark_screens.dart
+++ b/example/test_app/lib/benchmark_screens.dart
@@ -21,9 +21,18 @@ class BenchmarkMenuPage extends StatelessWidget {
     const scenarios = [
       ('Baseline (~8 interactable)', benchmarkBaselineRoute),
       ('Medium (~50 interactable)', benchmarkMediumRoute),
-      ('Stress List (200 ListTiles, mostly off-screen)', benchmarkStressListRoute),
-      ('Stress Grid (100 cards × 2 buttons, all visible)', benchmarkStressGridRoute),
-      ('Pathological (300+ interactable, all visible)', benchmarkPathologicalRoute),
+      (
+        'Stress List (200 ListTiles, mostly off-screen)',
+        benchmarkStressListRoute,
+      ),
+      (
+        'Stress Grid (100 cards × 2 buttons, all visible)',
+        benchmarkStressGridRoute,
+      ),
+      (
+        'Pathological (300+ interactable, all visible)',
+        benchmarkPathologicalRoute,
+      ),
     ];
     return Scaffold(
       appBar: AppBar(title: const Text('Benchmarks')),
@@ -211,8 +220,16 @@ class _BenchmarkMediumPageState extends State<BenchmarkMediumPage> {
       appBar: AppBar(
         title: const Text('Medium Screen'),
         actions: [
-          IconButton(icon: const Icon(Icons.search), onPressed: () {}, tooltip: 'Search'),
-          IconButton(icon: const Icon(Icons.filter_list), onPressed: () {}, tooltip: 'Filter'),
+          IconButton(
+            icon: const Icon(Icons.search),
+            onPressed: () {},
+            tooltip: 'Search',
+          ),
+          IconButton(
+            icon: const Icon(Icons.filter_list),
+            onPressed: () {},
+            tooltip: 'Filter',
+          ),
         ],
       ),
       body: ListView(
@@ -231,7 +248,10 @@ class _BenchmarkMediumPageState extends State<BenchmarkMediumPage> {
           for (var g = 0; g < 6; g++) ...[
             Padding(
               padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
-              child: Text('Group ${g + 1}', style: const TextStyle(fontWeight: FontWeight.w600)),
+              child: Text(
+                'Group ${g + 1}',
+                style: const TextStyle(fontWeight: FontWeight.w600),
+              ),
             ),
             RadioGroup<int>(
               groupValue: _radios[g],
@@ -279,7 +299,8 @@ class BenchmarkStressListPage extends StatefulWidget {
   const BenchmarkStressListPage({super.key});
 
   @override
-  State<BenchmarkStressListPage> createState() => _BenchmarkStressListPageState();
+  State<BenchmarkStressListPage> createState() =>
+      _BenchmarkStressListPageState();
 }
 
 class _BenchmarkStressListPageState extends State<BenchmarkStressListPage> {
@@ -350,7 +371,10 @@ class BenchmarkStressGridPage extends StatelessWidget {
                 children: [
                   Text(
                     'Card ${index + 1}',
-                    style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 13),
+                    style: const TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 13,
+                    ),
                   ),
                   Row(
                     mainAxisAlignment: MainAxisAlignment.center,
@@ -394,7 +418,8 @@ class BenchmarkPathologicalPage extends StatefulWidget {
   const BenchmarkPathologicalPage({super.key});
 
   @override
-  State<BenchmarkPathologicalPage> createState() => _BenchmarkPathologicalPageState();
+  State<BenchmarkPathologicalPage> createState() =>
+      _BenchmarkPathologicalPageState();
 }
 
 class _BenchmarkPathologicalPageState extends State<BenchmarkPathologicalPage> {
@@ -440,7 +465,10 @@ class _BenchmarkPathologicalPageState extends State<BenchmarkPathologicalPage> {
             const SizedBox(height: 16),
             const Padding(
               padding: EdgeInsets.all(8),
-              child: Text('GestureDetector rows', style: TextStyle(fontWeight: FontWeight.bold)),
+              child: Text(
+                'GestureDetector rows',
+                style: TextStyle(fontWeight: FontWeight.bold),
+              ),
             ),
             // 50 GestureDetectors with text labels
             for (var i = 0; i < 50; i++)
@@ -449,7 +477,10 @@ class _BenchmarkPathologicalPageState extends State<BenchmarkPathologicalPage> {
                 onTap: () {},
                 onLongPress: () {},
                 child: Container(
-                  margin: const EdgeInsets.symmetric(vertical: 2, horizontal: 8),
+                  margin: const EdgeInsets.symmetric(
+                    vertical: 2,
+                    horizontal: 8,
+                  ),
                   padding: const EdgeInsets.all(10),
                   decoration: BoxDecoration(
                     color: Colors.blue.shade50,

--- a/example/test_app/lib/benchmark_screens.dart
+++ b/example/test_app/lib/benchmark_screens.dart
@@ -21,18 +21,9 @@ class BenchmarkMenuPage extends StatelessWidget {
     const scenarios = [
       ('Baseline (~8 interactable)', benchmarkBaselineRoute),
       ('Medium (~50 interactable)', benchmarkMediumRoute),
-      (
-        'Stress List (200 ListTiles, mostly off-screen)',
-        benchmarkStressListRoute,
-      ),
-      (
-        'Stress Grid (100 cards × 2 buttons, all visible)',
-        benchmarkStressGridRoute,
-      ),
-      (
-        'Pathological (300+ interactable, all visible)',
-        benchmarkPathologicalRoute,
-      ),
+      ('Stress List (200 ListTiles, mostly off-screen)', benchmarkStressListRoute),
+      ('Stress Grid (100 cards × 2 buttons, all visible)', benchmarkStressGridRoute),
+      ('Pathological (300+ interactable, all visible)', benchmarkPathologicalRoute),
     ];
     return Scaffold(
       appBar: AppBar(title: const Text('Benchmarks')),
@@ -220,16 +211,8 @@ class _BenchmarkMediumPageState extends State<BenchmarkMediumPage> {
       appBar: AppBar(
         title: const Text('Medium Screen'),
         actions: [
-          IconButton(
-            icon: const Icon(Icons.search),
-            onPressed: () {},
-            tooltip: 'Search',
-          ),
-          IconButton(
-            icon: const Icon(Icons.filter_list),
-            onPressed: () {},
-            tooltip: 'Filter',
-          ),
+          IconButton(icon: const Icon(Icons.search), onPressed: () {}, tooltip: 'Search'),
+          IconButton(icon: const Icon(Icons.filter_list), onPressed: () {}, tooltip: 'Filter'),
         ],
       ),
       body: ListView(
@@ -248,10 +231,7 @@ class _BenchmarkMediumPageState extends State<BenchmarkMediumPage> {
           for (var g = 0; g < 6; g++) ...[
             Padding(
               padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
-              child: Text(
-                'Group ${g + 1}',
-                style: const TextStyle(fontWeight: FontWeight.w600),
-              ),
+              child: Text('Group ${g + 1}', style: const TextStyle(fontWeight: FontWeight.w600)),
             ),
             RadioGroup<int>(
               groupValue: _radios[g],
@@ -299,8 +279,7 @@ class BenchmarkStressListPage extends StatefulWidget {
   const BenchmarkStressListPage({super.key});
 
   @override
-  State<BenchmarkStressListPage> createState() =>
-      _BenchmarkStressListPageState();
+  State<BenchmarkStressListPage> createState() => _BenchmarkStressListPageState();
 }
 
 class _BenchmarkStressListPageState extends State<BenchmarkStressListPage> {
@@ -371,10 +350,7 @@ class BenchmarkStressGridPage extends StatelessWidget {
                 children: [
                   Text(
                     'Card ${index + 1}',
-                    style: const TextStyle(
-                      fontWeight: FontWeight.bold,
-                      fontSize: 13,
-                    ),
+                    style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 13),
                   ),
                   Row(
                     mainAxisAlignment: MainAxisAlignment.center,
@@ -418,8 +394,7 @@ class BenchmarkPathologicalPage extends StatefulWidget {
   const BenchmarkPathologicalPage({super.key});
 
   @override
-  State<BenchmarkPathologicalPage> createState() =>
-      _BenchmarkPathologicalPageState();
+  State<BenchmarkPathologicalPage> createState() => _BenchmarkPathologicalPageState();
 }
 
 class _BenchmarkPathologicalPageState extends State<BenchmarkPathologicalPage> {
@@ -465,10 +440,7 @@ class _BenchmarkPathologicalPageState extends State<BenchmarkPathologicalPage> {
             const SizedBox(height: 16),
             const Padding(
               padding: EdgeInsets.all(8),
-              child: Text(
-                'GestureDetector rows',
-                style: TextStyle(fontWeight: FontWeight.bold),
-              ),
+              child: Text('GestureDetector rows', style: TextStyle(fontWeight: FontWeight.bold)),
             ),
             // 50 GestureDetectors with text labels
             for (var i = 0; i < 50; i++)
@@ -477,10 +449,7 @@ class _BenchmarkPathologicalPageState extends State<BenchmarkPathologicalPage> {
                 onTap: () {},
                 onLongPress: () {},
                 child: Container(
-                  margin: const EdgeInsets.symmetric(
-                    vertical: 2,
-                    horizontal: 8,
-                  ),
+                  margin: const EdgeInsets.symmetric(vertical: 2, horizontal: 8),
                   padding: const EdgeInsets.all(10),
                   decoration: BoxDecoration(
                     color: Colors.blue.shade50,

--- a/lib/commands/devices.dart
+++ b/lib/commands/devices.dart
@@ -40,7 +40,7 @@ Future<int> runDevices(List<String> args) async {
     final id = d['id'] as String;
     final name = d['name'] as String;
     final platform = d['targetPlatform'] as String;
-    final emulator = d['emulator'] as bool;
+    final emulator = d['emulator'] as bool? ?? false;
     stdout.writeln(
       'DEVICE_ID=$id NAME=$name PLATFORM=$platform EMULATOR=$emulator',
     );

--- a/lib/commands/devices.dart
+++ b/lib/commands/devices.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:fdb/process_utils.dart';
+
 /// Lists connected devices by running `flutter devices --machine` and
 /// emitting one KEY=VALUE line per device.
 Future<int> runDevices(List<String> args) async {
@@ -14,7 +16,7 @@ Future<int> runDevices(List<String> args) async {
     return 1;
   }
 
-  final json = _extractJson(result.stdout as String);
+  final json = extractDevicesJson(result.stdout as String);
   if (json == null) {
     stderr.writeln('ERROR: No devices found');
     return 1;
@@ -46,16 +48,4 @@ Future<int> runDevices(List<String> args) async {
   return 0;
 }
 
-/// Extracts the JSON array from `flutter devices --machine` output.
-///
-/// Flutter may prepend non-JSON text (download progress, upgrade banners)
-/// before the actual JSON array. We scan for the first `[` to find the
-/// array start.
-String? _extractJson(String output) {
-  final start = output.indexOf('[');
-  if (start == -1) return null;
-  // Find the matching closing bracket from the end
-  final end = output.lastIndexOf(']');
-  if (end == -1 || end < start) return null;
-  return output.substring(start, end + 1);
-}
+

--- a/lib/commands/devices.dart
+++ b/lib/commands/devices.dart
@@ -37,9 +37,15 @@ Future<int> runDevices(List<String> args) async {
 
   for (final device in devices) {
     final d = device as Map<String, dynamic>;
-    final id = d['id'] as String;
-    final name = d['name'] as String;
-    final platform = d['targetPlatform'] as String;
+    final id = d['id'] as String?;
+    final name = d['name'] as String?;
+    final platform = d['targetPlatform'] as String?;
+    if (id == null || name == null || platform == null) {
+      stderr.writeln(
+        'WARNING: Skipping device with missing required fields: $d',
+      );
+      continue;
+    }
     final emulator = d['emulator'] as bool? ?? false;
     stdout.writeln(
       'DEVICE_ID=$id NAME=$name PLATFORM=$platform EMULATOR=$emulator',
@@ -47,5 +53,3 @@ Future<int> runDevices(List<String> args) async {
   }
   return 0;
 }
-
-

--- a/lib/commands/launch.dart
+++ b/lib/commands/launch.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -412,9 +413,9 @@ Future<void> _writePlatformInfo(String device, String flutter) async {
         return;
       }
     }
+  } on TimeoutException {
+    rethrow;
   } catch (_) {
     // Non-fatal: screenshot will work without platform info.
   }
 }
-
-

--- a/lib/commands/launch.dart
+++ b/lib/commands/launch.dart
@@ -393,7 +393,7 @@ Future<void> _writePlatformInfo(String device, String flutter) async {
     final result = await Process.run(flutter, ['devices', '--machine']);
     if (result.exitCode != 0) return;
 
-    final json = _extractDevicesJson(result.stdout as String);
+    final json = extractDevicesJson(result.stdout as String);
     if (json == null) return;
 
     final List<dynamic> devices;
@@ -417,12 +417,4 @@ Future<void> _writePlatformInfo(String device, String flutter) async {
   }
 }
 
-/// Extracts the JSON array from `flutter devices --machine` output.
-/// Flutter may prepend non-JSON text before the array.
-String? _extractDevicesJson(String output) {
-  final start = output.indexOf('[');
-  if (start == -1) return null;
-  final end = output.lastIndexOf(']');
-  if (end == -1 || end < start) return null;
-  return output.substring(start, end + 1);
-}
+

--- a/lib/commands/launch.dart
+++ b/lib/commands/launch.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:fdb/constants.dart';
@@ -53,6 +54,7 @@ Future<int> runLaunch(List<String> args) async {
     vmUriFile,
     launcherScript,
     deviceFile,
+    platformFile,
   ]) {
     final f = File(path);
     if (f.existsSync()) f.deleteSync();
@@ -65,6 +67,11 @@ Future<int> runLaunch(List<String> args) async {
 
   // Resolve the flutter binary: explicit --flutter-sdk, FVM auto-detect, or PATH.
   final flutter = _resolveFlutter(project, flutterSdk);
+
+  // Resolve and persist the target platform + emulator flag for this device.
+  // Used by `fdb screenshot` to dispatch to the correct capture backend.
+  // Non-fatal: screenshot falls back to the old heuristic if this fails.
+  await _writePlatformInfo(device, flutter);
 
   // Build the flutter run command string
   final flutterArgs = [
@@ -374,4 +381,48 @@ bool _isAlive(int pid) {
   } catch (_) {
     return false;
   }
+}
+
+/// Queries `flutter devices --machine` to find the targetPlatform and emulator
+/// flag for [device], then writes them to [platformFile] via [writePlatformInfo].
+///
+/// Silently no-ops on any failure — screenshot falls back gracefully if the
+/// platform file is absent.
+Future<void> _writePlatformInfo(String device, String flutter) async {
+  try {
+    final result = await Process.run(flutter, ['devices', '--machine']);
+    if (result.exitCode != 0) return;
+
+    final json = _extractDevicesJson(result.stdout as String);
+    if (json == null) return;
+
+    final List<dynamic> devices;
+    try {
+      devices = (jsonDecode(json) as List<dynamic>);
+    } catch (_) {
+      return;
+    }
+
+    for (final d in devices) {
+      final map = d as Map<String, dynamic>;
+      if (map['id'] == device) {
+        final platform = map['targetPlatform'] as String?;
+        final emulator = map['emulator'] as bool? ?? false;
+        if (platform != null) writePlatformInfo(platform, emulator);
+        return;
+      }
+    }
+  } catch (_) {
+    // Non-fatal: screenshot will work without platform info.
+  }
+}
+
+/// Extracts the JSON array from `flutter devices --machine` output.
+/// Flutter may prepend non-JSON text before the array.
+String? _extractDevicesJson(String output) {
+  final start = output.indexOf('[');
+  if (start == -1) return null;
+  final end = output.lastIndexOf(']');
+  if (end == -1 || end < start) return null;
+  return output.substring(start, end + 1);
 }

--- a/lib/commands/screenshot.dart
+++ b/lib/commands/screenshot.dart
@@ -630,16 +630,43 @@ String? _parseBootedDeviceTypeId(String json) {
 
 /// Parses the `bundlePath` for [deviceTypeId] from
 /// `xcrun simctl list devicetypes --json` output.
+///
+/// Searches for the JSON object whose `identifier` field exactly matches
+/// [deviceTypeId], then extracts `bundlePath` from that same object.
+/// This avoids false matches when one identifier is a prefix of another
+/// (e.g. "iPhone-17-Pro" vs "iPhone-17-Pro-Max").
 String? _parseDeviceTypeBundlePath(String json, String deviceTypeId) {
   final escaped = RegExp.escape(deviceTypeId);
+  // Match the identifier value with a closing quote so "iPhone-17-Pro" does
+  // not accidentally match "iPhone-17-Pro-Max".
   final identifierMatch =
       RegExp('"identifier"\\s*:\\s*"$escaped"').firstMatch(json);
   if (identifierMatch == null) return null;
 
-  final afterIdentifier = json.substring(identifierMatch.end);
+  // Walk backward to find the opening brace of this JSON object so we stay
+  // within the same object when searching for bundlePath.
+  final objectStart = json.lastIndexOf('{', identifierMatch.start);
+  if (objectStart == -1) return null;
+
+  // Find the closing brace of this object.
+  var depth = 0;
+  var objectEnd = objectStart;
+  for (var i = objectStart; i < json.length; i++) {
+    if (json[i] == '{') depth++;
+    if (json[i] == '}') {
+      depth--;
+      if (depth == 0) {
+        objectEnd = i;
+        break;
+      }
+    }
+  }
+
+  final objectJson = json.substring(objectStart, objectEnd + 1);
   final bundleMatch =
-      RegExp(r'"bundlePath"\s*:\s*"([^"]+)"').firstMatch(afterIdentifier);
-  return bundleMatch?.group(1);
+      RegExp(r'"bundlePath"\s*:\s*"([^"]+)"').firstMatch(objectJson);
+  // simctl JSON uses escaped forward slashes (\/); unescape them.
+  return bundleMatch?.group(1)?.replaceAll(r'\/', '/');
 }
 
 /// Parses the effective display density from `adb shell wm density` output.

--- a/lib/commands/screenshot.dart
+++ b/lib/commands/screenshot.dart
@@ -51,8 +51,7 @@ Future<int> runScreenshot(List<String> args) async {
   }
 
   if (!fullResolution) {
-    final resizeResult =
-        await _resizeToLogicalResolution(output, platformInfo, deviceId);
+    final resizeResult = await _resizeToMaxDimension(output);
     if (resizeResult != 0) return resizeResult;
   }
 
@@ -477,56 +476,41 @@ Future<int> _captureViaFdbHelper(String output) async {
 }
 
 // ---------------------------------------------------------------------------
-// Downscaling to logical (1x) resolution
+// Downscaling
 // ---------------------------------------------------------------------------
 
-/// Reads the pixel width of [path] via `sips`, queries the true device pixel
-/// ratio for the platform, and downscales to logical resolution in-place.
+const _maxScreenshotDimension = 1200;
+
+/// Downscales [path] in-place so its longest side does not exceed
+/// [_maxScreenshotDimension] pixels, preserving aspect ratio.
+///
+/// Uses `sips` (macOS built-in) for both measurement and resampling.
+/// No-ops if the image already fits within the limit.
 /// Returns 0 on success, 1 on failure.
-Future<int> _resizeToLogicalResolution(
-  String path,
-  ({String platform, bool emulator})? platformInfo,
-  String? deviceId,
-) async {
-  final queryResult = await Process.run('sips', ['-g', 'pixelWidth', path]);
+Future<int> _resizeToMaxDimension(String path) async {
+  final queryResult =
+      await Process.run('sips', ['-g', 'pixelWidth', '-g', 'pixelHeight', path]);
   if (queryResult.exitCode != 0) {
     stderr.writeln(
         'ERROR: Could not read image dimensions: ${queryResult.stderr}');
     return 1;
   }
 
-  final pixelWidth = _parsePixelWidth(queryResult.stdout as String);
-  if (pixelWidth == null) {
-    stderr.writeln('ERROR: Could not parse image width from sips output');
+  final width = _parseSipsDimension(queryResult.stdout as String, 'pixelWidth');
+  final height =
+      _parseSipsDimension(queryResult.stdout as String, 'pixelHeight');
+  if (width == null || height == null) {
+    stderr.writeln('ERROR: Could not parse image dimensions from sips output');
     return 1;
   }
 
-  final int logicalWidth;
-  if (platformInfo != null && platformInfo.platform.startsWith('android')) {
-    logicalWidth = await _androidLogicalWidth(pixelWidth);
-  } else if (platformInfo == null ||
-      platformInfo.platform.startsWith('ios') ||
-      platformInfo.platform.startsWith('darwin')) {
-    // iOS simulator and macOS both use sips-friendly scale detection.
-    // For macOS the screencapture tool already captures at logical resolution
-    // on Retina displays (it honours the display's backing scale factor), so
-    // sips will report pixelWidth == logicalWidth and no resize happens.
-    //
-    // Pass the stored device UDID so we look up the correct simulator's scale
-    // factor even when multiple simulators are booted simultaneously.
-    logicalWidth = await _iosLogicalWidth(pixelWidth, deviceId);
-  } else {
-    // Linux / Windows / Web: fdb_helper already captures at physical pixels;
-    // we don't have a reliable cross-platform way to get the DPR from the CLI
-    // so skip downscaling for these platforms.
-    return 0;
-  }
+  final maxSide = width > height ? width : height;
+  if (maxSide <= _maxScreenshotDimension) return 0; // already small enough
 
-  if (logicalWidth == pixelWidth) return 0; // already 1x, nothing to do
-
+  // sips --resampleHeightWidthMax scales the longest side to the given value.
   final resizeResult = await Process.run('sips', [
-    '--resampleWidth',
-    '$logicalWidth',
+    '--resampleHeightWidthMax',
+    '$_maxScreenshotDimension',
     path,
     '--out',
     path,
@@ -539,193 +523,10 @@ Future<int> _resizeToLogicalResolution(
   return 0;
 }
 
-/// Returns the logical width for an iOS Simulator (or macOS) screenshot by
-/// reading the true scale factor from the device's `.simdevicetype` bundle.
-///
-/// Steps:
-///   1. `xcrun simctl list devices booted --json` → deviceTypeIdentifier
-///      (matched by [deviceUdid] when provided, otherwise first booted device)
-///   2. `xcrun simctl list devicetypes --json` → bundlePath for that identifier
-///   3. `plutil -extract capabilities.ArtworkTraits.ArtworkDeviceScaleFactor`
-///      → exact scale factor (e.g. `3.000000`)
-///
-/// [deviceUdid] should be the simulator UDID stored in `device.txt` so the
-/// correct scale is used even when multiple simulators are booted.
-///
-/// Falls back to [pixelWidth] (no downscale) if any step fails.
-Future<int> _iosLogicalWidth(int pixelWidth, String? deviceUdid) async {
-  try {
-    final devicesResult = await Process.run(
-      'xcrun',
-      ['simctl', 'list', 'devices', 'booted', '--json'],
-    );
-    if (devicesResult.exitCode != 0) return pixelWidth;
-
-    final deviceTypeId = _parseBootedDeviceTypeId(
-      devicesResult.stdout as String,
-      deviceUdid,
-    );
-    if (deviceTypeId == null) return pixelWidth;
-
-    final typesResult = await Process.run(
-      'xcrun',
-      ['simctl', 'list', 'devicetypes', '--json'],
-    );
-    if (typesResult.exitCode != 0) return pixelWidth;
-
-    final bundlePath =
-        _parseDeviceTypeBundlePath(typesResult.stdout as String, deviceTypeId);
-    if (bundlePath == null) return pixelWidth;
-
-    final capsPlist = '$bundlePath/Contents/Resources/capabilities.plist';
-    final plutilResult = await Process.run('plutil', [
-      '-extract',
-      'capabilities.ArtworkTraits.ArtworkDeviceScaleFactor',
-      'raw',
-      '-o',
-      '-',
-      capsPlist,
-    ]);
-    if (plutilResult.exitCode != 0) return pixelWidth;
-
-    final scale =
-        double.tryParse((plutilResult.stdout as String).trim()) ?? 0.0;
-    if (scale <= 0) return pixelWidth;
-
-    return (pixelWidth / scale).round();
-  } catch (_) {
-    return pixelWidth;
-  }
-}
-
-/// Returns the logical width for an Android screenshot using `adb shell wm density`.
-///
-/// The effective display density in dpi is divided into the mdpi baseline
-/// (160 dpi = 1x):
-///   logical_width = pixel_width * 160 / density
-///
-/// Respects any user-set display-size override (`Override density` line).
-/// Falls back to [pixelWidth] (no downscale) if detection fails.
-Future<int> _androidLogicalWidth(int pixelWidth) async {
-  try {
-    final result = await Process.run('adb', ['shell', 'wm', 'density']);
-    if (result.exitCode != 0) return pixelWidth;
-
-    final density = _parseAndroidDensity(result.stdout as String);
-    if (density == null || density <= 0) return pixelWidth;
-
-    return pixelWidth * 160 ~/ density;
-  } catch (_) {
-    return pixelWidth;
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Parsers
-// ---------------------------------------------------------------------------
-
-int? _parsePixelWidth(String sipsOutput) {
-  final match = RegExp(r'pixelWidth:\s*(\d+)').firstMatch(sipsOutput);
+int? _parseSipsDimension(String sipsOutput, String key) {
+  final match = RegExp('$key:\\s*(\\d+)').firstMatch(sipsOutput);
   if (match == null) return null;
   return int.tryParse(match.group(1)!);
-}
-
-/// Parses the `deviceTypeIdentifier` for the booted simulator matching
-/// [deviceUdid] from `xcrun simctl list devices booted --json` output.
-///
-/// When [deviceUdid] is provided, finds the object whose `udid` field matches
-/// and returns its `deviceTypeIdentifier`. Falls back to the first booted
-/// device if no match is found or [deviceUdid] is null.
-String? _parseBootedDeviceTypeId(String json, String? deviceUdid) {
-  if (deviceUdid != null) {
-    // Find the JSON object for this specific UDID and extract its
-    // deviceTypeIdentifier from the same object.
-    final escapedUdid = RegExp.escape(deviceUdid);
-    final udidMatch =
-        RegExp('"udid"\\s*:\\s*"$escapedUdid"').firstMatch(json);
-    if (udidMatch != null) {
-      final objectStart = json.lastIndexOf('{', udidMatch.start);
-      if (objectStart != -1) {
-        var depth = 0;
-        var objectEnd = objectStart;
-        for (var i = objectStart; i < json.length; i++) {
-          if (json[i] == '{') depth++;
-          if (json[i] == '}') {
-            depth--;
-            if (depth == 0) {
-              objectEnd = i;
-              break;
-            }
-          }
-        }
-        final objectJson = json.substring(objectStart, objectEnd + 1);
-        final typeMatch =
-            RegExp(r'"deviceTypeIdentifier"\s*:\s*"([^"]+)"')
-                .firstMatch(objectJson);
-        if (typeMatch != null) return typeMatch.group(1);
-      }
-    }
-  }
-  // Fallback: first booted device
-  final match =
-      RegExp(r'"deviceTypeIdentifier"\s*:\s*"([^"]+)"').firstMatch(json);
-  return match?.group(1);
-}
-
-/// Parses the `bundlePath` for [deviceTypeId] from
-/// `xcrun simctl list devicetypes --json` output.
-///
-/// Searches for the JSON object whose `identifier` field exactly matches
-/// [deviceTypeId], then extracts `bundlePath` from that same object.
-/// This avoids false matches when one identifier is a prefix of another
-/// (e.g. "iPhone-17-Pro" vs "iPhone-17-Pro-Max").
-String? _parseDeviceTypeBundlePath(String json, String deviceTypeId) {
-  final escaped = RegExp.escape(deviceTypeId);
-  // Match the identifier value with a closing quote so "iPhone-17-Pro" does
-  // not accidentally match "iPhone-17-Pro-Max".
-  final identifierMatch =
-      RegExp('"identifier"\\s*:\\s*"$escaped"').firstMatch(json);
-  if (identifierMatch == null) return null;
-
-  // Walk backward to find the opening brace of this JSON object so we stay
-  // within the same object when searching for bundlePath.
-  final objectStart = json.lastIndexOf('{', identifierMatch.start);
-  if (objectStart == -1) return null;
-
-  // Find the closing brace of this object.
-  var depth = 0;
-  var objectEnd = objectStart;
-  for (var i = objectStart; i < json.length; i++) {
-    if (json[i] == '{') depth++;
-    if (json[i] == '}') {
-      depth--;
-      if (depth == 0) {
-        objectEnd = i;
-        break;
-      }
-    }
-  }
-
-  final objectJson = json.substring(objectStart, objectEnd + 1);
-  final bundleMatch =
-      RegExp(r'"bundlePath"\s*:\s*"([^"]+)"').firstMatch(objectJson);
-  // simctl JSON uses escaped forward slashes (\/); unescape them.
-  return bundleMatch?.group(1)?.replaceAll(r'\/', '/');
-}
-
-/// Parses the effective display density from `adb shell wm density` output.
-///
-/// Prefers `Override density` (user-set display size) over `Physical density`.
-int? _parseAndroidDensity(String wmDensityOutput) {
-  final overrideMatch =
-      RegExp(r'Override density:\s*(\d+)').firstMatch(wmDensityOutput);
-  if (overrideMatch != null) return int.tryParse(overrideMatch.group(1)!);
-
-  final physicalMatch =
-      RegExp(r'Physical density:\s*(\d+)').firstMatch(wmDensityOutput);
-  if (physicalMatch != null) return int.tryParse(physicalMatch.group(1)!);
-
-  return null;
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/commands/screenshot.dart
+++ b/lib/commands/screenshot.dart
@@ -201,8 +201,7 @@ Future<int> _captureMacOs(String output) async {
   final pid = readPid();
   if (pid == null) {
     stderr.writeln(
-      'ERROR: No PID in session — cannot locate macOS window.\n'
-      '  Re-launch the app, or use --full to skip downscaling.',
+      'ERROR: No PID in session — cannot locate macOS window. Re-launch the app.',
     );
     return 1;
   }
@@ -344,7 +343,7 @@ Future<int> _captureWeb(String output) async {
   // Fetch the page list from the CDP HTTP endpoint.
   final String wsUrl;
   try {
-    final client = HttpClient();
+    final client = HttpClient()..connectionTimeout = const Duration(seconds: 5);
     try {
       final req =
           await client.getUrl(Uri.parse('http://localhost:$port/json'));

--- a/lib/commands/screenshot.dart
+++ b/lib/commands/screenshot.dart
@@ -1,6 +1,10 @@
+import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:fdb/constants.dart';
+import 'package:fdb/process_utils.dart';
+import 'package:fdb/vm_service.dart';
 
 Future<int> runScreenshot(List<String> args) async {
   var output = defaultScreenshotPath;
@@ -20,34 +24,25 @@ Future<int> runScreenshot(List<String> args) async {
     }
   }
 
-  // Detect platform by checking adb devices
-  final isAndroid = await _isAndroidDevice();
+  // Read session state
+  final platformInfo = readPlatformInfo();
+  final deviceId = readDevice();
 
-  if (isAndroid) {
-    final result = await Process.run(
-      'adb',
-      ['exec-out', 'screencap', '-p'],
-      stdoutEncoding: null,
+  // Dispatch to the correct capture backend based on the stored platform.
+  // Falls back to the legacy adb/xcrun heuristic when no platform file exists
+  // (e.g. sessions launched before this change).
+  final int captureResult;
+  if (platformInfo != null) {
+    captureResult = await _dispatchScreenshot(
+      platform: platformInfo.platform,
+      emulator: platformInfo.emulator,
+      deviceId: deviceId,
+      output: output,
     );
-    if (result.exitCode != 0) {
-      stderr.writeln('ERROR: Screenshot failed: ${result.stderr}');
-      return 1;
-    }
-    File(output).writeAsBytesSync(result.stdout as List<int>);
   } else {
-    // Assume iOS simulator
-    final result = await Process.run('xcrun', [
-      'simctl',
-      'io',
-      'booted',
-      'screenshot',
-      output,
-    ]);
-    if (result.exitCode != 0) {
-      stderr.writeln('ERROR: Screenshot failed: ${result.stderr}');
-      return 1;
-    }
+    captureResult = await _legacyCapture(output);
   }
+  if (captureResult != 0) return captureResult;
 
   final file = File(output);
   if (!file.existsSync()) {
@@ -56,7 +51,7 @@ Future<int> runScreenshot(List<String> args) async {
   }
 
   if (!fullResolution) {
-    final resizeResult = await _resizeToLogicalResolution(output);
+    final resizeResult = await _resizeToLogicalResolution(output, platformInfo);
     if (resizeResult != 0) return resizeResult;
   }
 
@@ -66,9 +61,431 @@ Future<int> runScreenshot(List<String> args) async {
   return 0;
 }
 
-/// Reads the pixel width of [path] via `sips` and downscales to logical
-/// resolution (1x) in-place. Returns 0 on success, 1 on failure.
-Future<int> _resizeToLogicalResolution(String path) async {
+// ---------------------------------------------------------------------------
+// Platform dispatch
+// ---------------------------------------------------------------------------
+
+Future<int> _dispatchScreenshot({
+  required String platform,
+  required bool emulator,
+  required String? deviceId,
+  required String output,
+}) async {
+  if (platform.startsWith('android')) {
+    return _captureAndroid(deviceId, output);
+  }
+
+  if (platform.startsWith('ios') && emulator) {
+    return _captureIosSimulator(deviceId, output);
+  }
+
+  if (platform.startsWith('ios') && !emulator) {
+    // Physical iOS: no native CLI screenshot tool available.
+    // Fall through to fdb_helper VM extension.
+    stderr.writeln(
+      'WARNING: No native screenshot tool for physical iOS.\n'
+      '  Falling back to fdb_helper (Flutter surface only, no status bar).\n'
+      '  Ensure your app includes fdb_helper and calls '
+      'FdbBinding.ensureInitialized().',
+    );
+    return _captureViaFdbHelper(output);
+  }
+
+  if (platform.startsWith('darwin')) {
+    return _captureMacOs(output);
+  }
+
+  if (platform.startsWith('linux')) {
+    return _captureLinux(output);
+  }
+
+  if (platform.startsWith('windows')) {
+    stderr.writeln(
+      'WARNING: No native screenshot CLI for Windows.\n'
+      '  Falling back to fdb_helper (Flutter surface only, no window chrome).\n'
+      '  Ensure your app includes fdb_helper and calls '
+      'FdbBinding.ensureInitialized().',
+    );
+    return _captureViaFdbHelper(output);
+  }
+
+  if (platform == 'web-javascript') {
+    return _captureWeb(output);
+  }
+
+  // Unknown platform — try fdb_helper as last resort.
+  stderr.writeln(
+    'WARNING: Unsupported platform "$platform".\n'
+    '  Attempting fdb_helper fallback.',
+  );
+  return _captureViaFdbHelper(output);
+}
+
+// ---------------------------------------------------------------------------
+// Legacy capture (no platform.txt — sessions before this change)
+// ---------------------------------------------------------------------------
+
+/// Heuristic capture used when no platform file exists:
+/// checks adb for Android, otherwise assumes iOS simulator.
+Future<int> _legacyCapture(String output) async {
+  if (await _isAndroidConnected()) {
+    return _captureAndroid(null, output);
+  }
+  return _captureIosSimulator(null, output);
+}
+
+// ---------------------------------------------------------------------------
+// Android
+// ---------------------------------------------------------------------------
+
+Future<int> _captureAndroid(String? deviceId, String output) async {
+  try {
+    final args = deviceId != null ? ['-s', deviceId] : <String>[];
+    final result = await Process.run(
+      'adb',
+      [...args, 'exec-out', 'screencap', '-p'],
+      stdoutEncoding: null,
+    );
+    if (result.exitCode != 0) {
+      stderr.writeln('ERROR: adb screencap failed: ${result.stderr}');
+      return 1;
+    }
+    File(output).writeAsBytesSync(result.stdout as List<int>);
+    return 0;
+  } catch (e) {
+    stderr.writeln('ERROR: Failed to run adb: $e');
+    return 1;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// iOS Simulator
+// ---------------------------------------------------------------------------
+
+Future<int> _captureIosSimulator(String? deviceId, String output) async {
+  try {
+    // Use the stored device ID (simulator UDID) when available so we target
+    // the correct simulator even if multiple are booted.
+    final target = deviceId ?? 'booted';
+    final result = await Process.run('xcrun', [
+      'simctl',
+      'io',
+      target,
+      'screenshot',
+      output,
+    ]);
+    if (result.exitCode != 0) {
+      stderr.writeln(
+          'ERROR: xcrun simctl screenshot failed: ${result.stderr}');
+      return 1;
+    }
+    return 0;
+  } catch (e) {
+    stderr.writeln('ERROR: Failed to run xcrun: $e');
+    return 1;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// macOS desktop
+// ---------------------------------------------------------------------------
+
+/// Captures the macOS Flutter app window using `screencapture -l <windowId>`.
+///
+/// Looks up the window by walking the process tree rooted at the stored PID
+/// (the flutter run launcher PID). Falls back to fdb_helper if the window
+/// cannot be found or `screencapture` lacks Screen Recording permission.
+Future<int> _captureMacOs(String output) async {
+  final pid = readPid();
+  if (pid == null) {
+    stderr.writeln(
+      'ERROR: No PID in session — cannot locate macOS window.\n'
+      '  Re-launch the app, or use --full to skip downscaling.',
+    );
+    return 1;
+  }
+
+  try {
+    final windowId = await _macWindowId(pid);
+    if (windowId == null) {
+      stderr.writeln(
+        'WARNING: Could not find macOS window for PID $pid.\n'
+        '  Falling back to fdb_helper (Flutter surface only, no title bar).',
+      );
+      return _captureViaFdbHelper(output);
+    }
+
+    final result = await Process.run('screencapture', [
+      '-l',
+      windowId.toString(),
+      '-o', // omit window shadow
+      output,
+    ]);
+    if (result.exitCode != 0) {
+      stderr.writeln(
+        'WARNING: screencapture failed — Screen Recording permission may be\n'
+        '  required: System Settings > Privacy & Security > Screen Recording.\n'
+        '  Falling back to fdb_helper (Flutter surface only, no title bar).',
+      );
+      return _captureViaFdbHelper(output);
+    }
+    return 0;
+  } catch (e) {
+    stderr.writeln('ERROR: macOS screenshot failed: $e');
+    return 1;
+  }
+}
+
+/// Returns the CGWindowID for the on-screen window owned by [pid] or any of
+/// its child processes.
+///
+/// `flutter run` (the stored PID) spawns the actual .app as a child, so we
+/// walk one level of the process tree via `pgrep -P`.
+Future<int?> _macWindowId(int pid) async {
+  // Collect stored PID plus immediate children.
+  final pids = <int>[pid];
+  try {
+    final pg = await Process.run('pgrep', ['-P', '$pid']);
+    if (pg.exitCode == 0) {
+      for (final line in (pg.stdout as String).trim().split('\n')) {
+        final child = int.tryParse(line.trim());
+        if (child != null) pids.add(child);
+      }
+    }
+  } catch (_) {}
+
+  final pidsArg = pids.join(',');
+  final result = await Process.run('swift', [
+    '-e',
+    r'''
+import Cocoa
+let pidStrs = CommandLine.arguments[1].split(separator: ",")
+let pids = pidStrs.compactMap { Int32($0) }
+guard let list = CGWindowListCopyWindowInfo(.optionOnScreenOnly, kCGNullWindowID) as? [NSDictionary] else { exit(0) }
+for w in list {
+  guard let ownerPid = w[kCGWindowOwnerPID] as? Int32, pids.contains(ownerPid) else { continue }
+  if let num = w[kCGWindowNumber] as? Int { print(num); break }
+}
+''',
+    pidsArg,
+  ]);
+  if (result.exitCode != 0) return null;
+  return int.tryParse((result.stdout as String).trim());
+}
+
+// ---------------------------------------------------------------------------
+// Linux
+// ---------------------------------------------------------------------------
+
+/// Captures the Linux Flutter app window.
+///
+/// On X11: uses `xdotool` + ImageMagick `import` to capture the window.
+/// On Wayland (or if xdotool is unavailable): falls back to fdb_helper.
+Future<int> _captureLinux(String output) async {
+  final pid = readPid();
+  if (pid != null) {
+    final result = await _captureLinuxNative(pid, output);
+    if (result == 0) return 0;
+    // -1 means native attempt failed — fall through to fdb_helper.
+  }
+
+  final reason = pid == null
+      ? 'No PID in session'
+      : 'xdotool/import not available or Wayland display (native capture not '
+          'supported on Wayland).\n'
+          '  For X11: install xdotool and ImageMagick '
+          '(e.g. sudo apt install xdotool imagemagick)';
+  stderr.writeln(
+    'WARNING: $reason.\n'
+    '  Falling back to fdb_helper (Flutter surface only, no window chrome).\n'
+    '  Ensure your app includes fdb_helper and calls '
+    'FdbBinding.ensureInitialized().',
+  );
+  return _captureViaFdbHelper(output);
+}
+
+/// Tries `xdotool search --pid` + `import -window` to capture the window.
+/// Returns 0 on success, -1 to signal the caller should try the fallback.
+Future<int> _captureLinuxNative(int pid, String output) async {
+  try {
+    final xdo = await Process.run('xdotool', [
+      'search',
+      '--onlyvisible',
+      '--pid',
+      '$pid',
+    ]);
+    if (xdo.exitCode != 0) return -1;
+
+    final windowId = (xdo.stdout as String).trim().split('\n').last.trim();
+    if (windowId.isEmpty) return -1;
+
+    final imp = await Process.run('import', ['-window', windowId, output]);
+    return imp.exitCode == 0 ? 0 : -1;
+  } catch (_) {
+    return -1;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Web (Chrome DevTools Protocol)
+// ---------------------------------------------------------------------------
+
+/// Captures a Flutter Web app screenshot via CDP `Page.captureScreenshot`.
+///
+/// Requires the app to be running in Chrome with `--remote-debugging-port`
+/// set. fdb does not yet plumb the CDP port through session state, so this
+/// checks a fixed default port (9222) and the CHROME_CDP_PORT env variable.
+Future<int> _captureWeb(String output) async {
+  final portStr = Platform.environment['CHROME_CDP_PORT'] ?? '9222';
+  final port = int.tryParse(portStr) ?? 9222;
+
+  // Fetch the page list from the CDP HTTP endpoint.
+  final String wsUrl;
+  try {
+    final client = HttpClient();
+    try {
+      final req =
+          await client.getUrl(Uri.parse('http://localhost:$port/json'));
+      final resp = await req.close();
+      final body = await resp.transform(utf8.decoder).join();
+      final pages = jsonDecode(body) as List<dynamic>;
+      if (pages.isEmpty) {
+        stderr.writeln('ERROR: No Chrome pages found on CDP port $port.\n'
+            '  Launch Chrome with --remote-debugging-port=$port.');
+        return 1;
+      }
+      final page = pages.firstWhere(
+        (p) => (p as Map<String, dynamic>)['type'] == 'page',
+        orElse: () => pages.first,
+      ) as Map<String, dynamic>;
+      final url = page['webSocketDebuggerUrl'] as String?;
+      if (url == null) {
+        stderr.writeln('ERROR: No WebSocket debugger URL in CDP page list.');
+        return 1;
+      }
+      wsUrl = url;
+    } finally {
+      client.close();
+    }
+  } catch (e) {
+    stderr.writeln('ERROR: Could not connect to Chrome CDP on port $port: $e');
+    return 1;
+  }
+
+  // Capture via CDP Page.captureScreenshot.
+  WebSocket? ws;
+  try {
+    ws = await WebSocket.connect(wsUrl);
+    final completer = Completer<Map<String, dynamic>>();
+
+    ws.listen(
+      (data) {
+        final msg = jsonDecode(data as String) as Map<String, dynamic>;
+        if (msg['id'] == 1 && !completer.isCompleted) completer.complete(msg);
+      },
+      onError: (Object e) {
+        if (!completer.isCompleted) completer.completeError(e);
+      },
+      onDone: () {
+        if (!completer.isCompleted) {
+          completer.completeError(
+              StateError('WebSocket closed before CDP response'));
+        }
+      },
+    );
+
+    ws.add(jsonEncode(
+        {'id': 1, 'method': 'Page.captureScreenshot', 'params': {}}));
+
+    final response =
+        await completer.future.timeout(const Duration(seconds: 10));
+    final data = (response['result'] as Map<String, dynamic>?)?['data']
+        as String?;
+    if (data == null) {
+      stderr.writeln('ERROR: CDP screenshot returned no image data.');
+      return 1;
+    }
+    File(output).writeAsBytesSync(base64Decode(data));
+    return 0;
+  } on TimeoutException {
+    stderr.writeln('ERROR: CDP screenshot timed out.');
+    return 1;
+  } catch (e) {
+    stderr.writeln('ERROR: CDP screenshot failed: $e');
+    return 1;
+  } finally {
+    await ws?.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// fdb_helper VM extension fallback
+// ---------------------------------------------------------------------------
+
+/// Captures a screenshot via the `ext.fdb.screenshot` VM service extension
+/// registered by `fdb_helper`. Returns the PNG as base64 and writes it to
+/// [output].
+///
+/// Used when no native OS screenshot tool is available (physical iOS, Windows,
+/// Linux Wayland).
+Future<int> _captureViaFdbHelper(String output) async {
+  final vmUri = readVmUri();
+  if (vmUri == null) {
+    stderr.writeln(
+      'ERROR: No VM service URI in session and no native screenshot tool '
+      'available.\n  Re-launch the app.',
+    );
+    return 1;
+  }
+
+  try {
+    final isolateId = await checkFdbHelper();
+    if (isolateId == null) {
+      stderr.writeln(
+        'ERROR: fdb_helper not found in the running app.\n'
+        '  Add fdb_helper to pubspec.yaml and call '
+        'FdbBinding.ensureInitialized() in main().',
+      );
+      return 1;
+    }
+
+    final response = await vmServiceCall(
+      'ext.fdb.screenshot',
+      params: {'isolateId': isolateId},
+    );
+
+    final result = unwrapRawExtensionResult(response);
+    if (result is Map && result.containsKey('error')) {
+      stderr.writeln('ERROR: fdb_helper screenshot: ${result['error']}');
+      return 1;
+    }
+
+    final resultMap = result as Map<String, dynamic>?;
+    final base64Data = resultMap?['screenshot'] as String?;
+    if (base64Data == null) {
+      stderr.writeln('ERROR: No screenshot data in fdb_helper response.');
+      return 1;
+    }
+
+    File(output).writeAsBytesSync(base64Decode(base64Data));
+    return 0;
+  } catch (e) {
+    stderr.writeln('ERROR: fdb_helper screenshot failed: $e');
+    return 1;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Downscaling to logical (1x) resolution
+// ---------------------------------------------------------------------------
+
+/// Reads the pixel width of [path] via `sips`, queries the true device pixel
+/// ratio for the platform, and downscales to logical resolution in-place.
+/// Returns 0 on success, 1 on failure.
+Future<int> _resizeToLogicalResolution(
+  String path,
+  ({String platform, bool emulator})? platformInfo,
+) async {
   final queryResult = await Process.run('sips', ['-g', 'pixelWidth', path]);
   if (queryResult.exitCode != 0) {
     stderr.writeln(
@@ -82,7 +499,24 @@ Future<int> _resizeToLogicalResolution(String path) async {
     return 1;
   }
 
-  final logicalWidth = _logicalWidth(pixelWidth);
+  final int logicalWidth;
+  if (platformInfo != null && platformInfo.platform.startsWith('android')) {
+    logicalWidth = await _androidLogicalWidth(pixelWidth);
+  } else if (platformInfo == null ||
+      platformInfo.platform.startsWith('ios') ||
+      platformInfo.platform.startsWith('darwin')) {
+    // iOS simulator and macOS both use sips-friendly scale detection.
+    // For macOS the screencapture tool already captures at logical resolution
+    // on Retina displays (it honours the display's backing scale factor), so
+    // sips will report pixelWidth == logicalWidth and no resize happens.
+    logicalWidth = await _iosLogicalWidth(pixelWidth);
+  } else {
+    // Linux / Windows / Web: fdb_helper already captures at physical pixels;
+    // we don't have a reliable cross-platform way to get the DPR from the CLI
+    // so skip downscaling for these platforms.
+    return 0;
+  }
+
   if (logicalWidth == pixelWidth) return 0; // already 1x, nothing to do
 
   final resizeResult = await Process.run('sips', [
@@ -100,39 +534,138 @@ Future<int> _resizeToLogicalResolution(String path) async {
   return 0;
 }
 
-/// Parses the pixel width from `sips -g pixelWidth` output.
+/// Returns the logical width for an iOS Simulator (or macOS) screenshot by
+/// reading the true scale factor from the booted device's `.simdevicetype`
+/// bundle.
 ///
-/// Example output:
-/// ```
-///   /tmp/fdb_screenshot.png
-///     pixelWidth: 1170
-/// ```
+/// Steps:
+///   1. `xcrun simctl list devices booted --json` → deviceTypeIdentifier
+///   2. `xcrun simctl list devicetypes --json` → bundlePath for that identifier
+///   3. `plutil -extract capabilities.ArtworkTraits.ArtworkDeviceScaleFactor`
+///      → exact scale factor (e.g. `3.000000`)
+///
+/// Falls back to [pixelWidth] (no downscale) if any step fails.
+Future<int> _iosLogicalWidth(int pixelWidth) async {
+  try {
+    final devicesResult = await Process.run(
+      'xcrun',
+      ['simctl', 'list', 'devices', 'booted', '--json'],
+    );
+    if (devicesResult.exitCode != 0) return pixelWidth;
+
+    final deviceTypeId =
+        _parseBootedDeviceTypeId(devicesResult.stdout as String);
+    if (deviceTypeId == null) return pixelWidth;
+
+    final typesResult = await Process.run(
+      'xcrun',
+      ['simctl', 'list', 'devicetypes', '--json'],
+    );
+    if (typesResult.exitCode != 0) return pixelWidth;
+
+    final bundlePath =
+        _parseDeviceTypeBundlePath(typesResult.stdout as String, deviceTypeId);
+    if (bundlePath == null) return pixelWidth;
+
+    final capsPlist = '$bundlePath/Contents/Resources/capabilities.plist';
+    final plutilResult = await Process.run('plutil', [
+      '-extract',
+      'capabilities.ArtworkTraits.ArtworkDeviceScaleFactor',
+      'raw',
+      '-o',
+      '-',
+      capsPlist,
+    ]);
+    if (plutilResult.exitCode != 0) return pixelWidth;
+
+    final scale =
+        double.tryParse((plutilResult.stdout as String).trim()) ?? 0.0;
+    if (scale <= 0) return pixelWidth;
+
+    return (pixelWidth / scale).round();
+  } catch (_) {
+    return pixelWidth;
+  }
+}
+
+/// Returns the logical width for an Android screenshot using `adb shell wm density`.
+///
+/// The effective display density in dpi is divided into the mdpi baseline
+/// (160 dpi = 1x):
+///   logical_width = pixel_width * 160 / density
+///
+/// Respects any user-set display-size override (`Override density` line).
+/// Falls back to [pixelWidth] (no downscale) if detection fails.
+Future<int> _androidLogicalWidth(int pixelWidth) async {
+  try {
+    final result = await Process.run('adb', ['shell', 'wm', 'density']);
+    if (result.exitCode != 0) return pixelWidth;
+
+    final density = _parseAndroidDensity(result.stdout as String);
+    if (density == null || density <= 0) return pixelWidth;
+
+    return pixelWidth * 160 ~/ density;
+  } catch (_) {
+    return pixelWidth;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Parsers
+// ---------------------------------------------------------------------------
+
 int? _parsePixelWidth(String sipsOutput) {
   final match = RegExp(r'pixelWidth:\s*(\d+)').firstMatch(sipsOutput);
   if (match == null) return null;
   return int.tryParse(match.group(1)!);
 }
 
-/// Returns the logical (1x) width for a given native [pixelWidth].
-///
-/// Heuristic:
-/// - > 1000 px → 3x Retina device → divide by 3
-/// - > 500 px  → 2x Retina device → divide by 2
-/// - otherwise → already 1x
-int _logicalWidth(int pixelWidth) {
-  if (pixelWidth > 1000) return pixelWidth ~/ 3;
-  if (pixelWidth > 500) return pixelWidth ~/ 2;
-  return pixelWidth;
+/// Parses the `deviceTypeIdentifier` for the first booted simulator from
+/// `xcrun simctl list devices booted --json` output.
+String? _parseBootedDeviceTypeId(String json) {
+  final match =
+      RegExp(r'"deviceTypeIdentifier"\s*:\s*"([^"]+)"').firstMatch(json);
+  return match?.group(1);
 }
 
-Future<bool> _isAndroidDevice() async {
+/// Parses the `bundlePath` for [deviceTypeId] from
+/// `xcrun simctl list devicetypes --json` output.
+String? _parseDeviceTypeBundlePath(String json, String deviceTypeId) {
+  final escaped = RegExp.escape(deviceTypeId);
+  final identifierMatch =
+      RegExp('"identifier"\\s*:\\s*"$escaped"').firstMatch(json);
+  if (identifierMatch == null) return null;
+
+  final afterIdentifier = json.substring(identifierMatch.end);
+  final bundleMatch =
+      RegExp(r'"bundlePath"\s*:\s*"([^"]+)"').firstMatch(afterIdentifier);
+  return bundleMatch?.group(1);
+}
+
+/// Parses the effective display density from `adb shell wm density` output.
+///
+/// Prefers `Override density` (user-set display size) over `Physical density`.
+int? _parseAndroidDensity(String wmDensityOutput) {
+  final overrideMatch =
+      RegExp(r'Override density:\s*(\d+)').firstMatch(wmDensityOutput);
+  if (overrideMatch != null) return int.tryParse(overrideMatch.group(1)!);
+
+  final physicalMatch =
+      RegExp(r'Physical density:\s*(\d+)').firstMatch(wmDensityOutput);
+  if (physicalMatch != null) return int.tryParse(physicalMatch.group(1)!);
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+Future<bool> _isAndroidConnected() async {
   try {
     final result = await Process.run('adb', ['devices']);
     final output = result.stdout as String;
-    // Check if there's at least one device listed (beyond the header line)
-    final lines =
-        output.split('\n').where((l) => l.contains('\tdevice')).toList();
-    return lines.isNotEmpty;
+    return output.split('\n').any((l) => l.contains('\tdevice'));
   } catch (_) {
     return false;
   }

--- a/lib/commands/screenshot.dart
+++ b/lib/commands/screenshot.dart
@@ -111,7 +111,7 @@ Future<int> _dispatchScreenshot({
     return _captureViaFdbHelper(output);
   }
 
-  if (platform == 'web-javascript') {
+  if (platform.startsWith('web')) {
     return _captureWeb(output);
   }
 
@@ -317,7 +317,7 @@ Future<int> _captureLinuxNative(int pid, String output) async {
     ]);
     if (xdo.exitCode != 0) return -1;
 
-    final windowId = (xdo.stdout as String).trim().split('\n').last.trim();
+    final windowId = (xdo.stdout as String).trim().split('\n').first.trim();
     if (windowId.isEmpty) return -1;
 
     final imp = await Process.run('import', ['-window', windowId, output]);

--- a/lib/commands/screenshot.dart
+++ b/lib/commands/screenshot.dart
@@ -51,7 +51,8 @@ Future<int> runScreenshot(List<String> args) async {
   }
 
   if (!fullResolution) {
-    final resizeResult = await _resizeToLogicalResolution(output, platformInfo);
+    final resizeResult =
+        await _resizeToLogicalResolution(output, platformInfo, deviceId);
     if (resizeResult != 0) return resizeResult;
   }
 
@@ -485,6 +486,7 @@ Future<int> _captureViaFdbHelper(String output) async {
 Future<int> _resizeToLogicalResolution(
   String path,
   ({String platform, bool emulator})? platformInfo,
+  String? deviceId,
 ) async {
   final queryResult = await Process.run('sips', ['-g', 'pixelWidth', path]);
   if (queryResult.exitCode != 0) {
@@ -509,7 +511,10 @@ Future<int> _resizeToLogicalResolution(
     // For macOS the screencapture tool already captures at logical resolution
     // on Retina displays (it honours the display's backing scale factor), so
     // sips will report pixelWidth == logicalWidth and no resize happens.
-    logicalWidth = await _iosLogicalWidth(pixelWidth);
+    //
+    // Pass the stored device UDID so we look up the correct simulator's scale
+    // factor even when multiple simulators are booted simultaneously.
+    logicalWidth = await _iosLogicalWidth(pixelWidth, deviceId);
   } else {
     // Linux / Windows / Web: fdb_helper already captures at physical pixels;
     // we don't have a reliable cross-platform way to get the DPR from the CLI
@@ -535,17 +540,20 @@ Future<int> _resizeToLogicalResolution(
 }
 
 /// Returns the logical width for an iOS Simulator (or macOS) screenshot by
-/// reading the true scale factor from the booted device's `.simdevicetype`
-/// bundle.
+/// reading the true scale factor from the device's `.simdevicetype` bundle.
 ///
 /// Steps:
 ///   1. `xcrun simctl list devices booted --json` → deviceTypeIdentifier
+///      (matched by [deviceUdid] when provided, otherwise first booted device)
 ///   2. `xcrun simctl list devicetypes --json` → bundlePath for that identifier
 ///   3. `plutil -extract capabilities.ArtworkTraits.ArtworkDeviceScaleFactor`
 ///      → exact scale factor (e.g. `3.000000`)
 ///
+/// [deviceUdid] should be the simulator UDID stored in `device.txt` so the
+/// correct scale is used even when multiple simulators are booted.
+///
 /// Falls back to [pixelWidth] (no downscale) if any step fails.
-Future<int> _iosLogicalWidth(int pixelWidth) async {
+Future<int> _iosLogicalWidth(int pixelWidth, String? deviceUdid) async {
   try {
     final devicesResult = await Process.run(
       'xcrun',
@@ -553,8 +561,10 @@ Future<int> _iosLogicalWidth(int pixelWidth) async {
     );
     if (devicesResult.exitCode != 0) return pixelWidth;
 
-    final deviceTypeId =
-        _parseBootedDeviceTypeId(devicesResult.stdout as String);
+    final deviceTypeId = _parseBootedDeviceTypeId(
+      devicesResult.stdout as String,
+      deviceUdid,
+    );
     if (deviceTypeId == null) return pixelWidth;
 
     final typesResult = await Process.run(
@@ -620,9 +630,43 @@ int? _parsePixelWidth(String sipsOutput) {
   return int.tryParse(match.group(1)!);
 }
 
-/// Parses the `deviceTypeIdentifier` for the first booted simulator from
-/// `xcrun simctl list devices booted --json` output.
-String? _parseBootedDeviceTypeId(String json) {
+/// Parses the `deviceTypeIdentifier` for the booted simulator matching
+/// [deviceUdid] from `xcrun simctl list devices booted --json` output.
+///
+/// When [deviceUdid] is provided, finds the object whose `udid` field matches
+/// and returns its `deviceTypeIdentifier`. Falls back to the first booted
+/// device if no match is found or [deviceUdid] is null.
+String? _parseBootedDeviceTypeId(String json, String? deviceUdid) {
+  if (deviceUdid != null) {
+    // Find the JSON object for this specific UDID and extract its
+    // deviceTypeIdentifier from the same object.
+    final escapedUdid = RegExp.escape(deviceUdid);
+    final udidMatch =
+        RegExp('"udid"\\s*:\\s*"$escapedUdid"').firstMatch(json);
+    if (udidMatch != null) {
+      final objectStart = json.lastIndexOf('{', udidMatch.start);
+      if (objectStart != -1) {
+        var depth = 0;
+        var objectEnd = objectStart;
+        for (var i = objectStart; i < json.length; i++) {
+          if (json[i] == '{') depth++;
+          if (json[i] == '}') {
+            depth--;
+            if (depth == 0) {
+              objectEnd = i;
+              break;
+            }
+          }
+        }
+        final objectJson = json.substring(objectStart, objectEnd + 1);
+        final typeMatch =
+            RegExp(r'"deviceTypeIdentifier"\s*:\s*"([^"]+)"')
+                .firstMatch(objectJson);
+        if (typeMatch != null) return typeMatch.group(1);
+      }
+    }
+  }
+  // Fallback: first booted device
   final match =
       RegExp(r'"deviceTypeIdentifier"\s*:\s*"([^"]+)"').firstMatch(json);
   return match?.group(1);

--- a/lib/commands/screenshot.dart
+++ b/lib/commands/screenshot.dart
@@ -2,11 +2,10 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:image/image.dart' as img;
-
 import 'package:fdb/constants.dart';
 import 'package:fdb/process_utils.dart';
 import 'package:fdb/vm_service.dart';
+import 'package:image/image.dart' as img;
 
 Future<int> runScreenshot(List<String> args) async {
   var output = defaultScreenshotPath;
@@ -177,8 +176,7 @@ Future<int> _captureIosSimulator(String? deviceId, String output) async {
       output,
     ]);
     if (result.exitCode != 0) {
-      stderr.writeln(
-          'ERROR: xcrun simctl screenshot failed: ${result.stderr}');
+      stderr.writeln('ERROR: xcrun simctl screenshot failed: ${result.stderr}');
       return 1;
     }
     return 0;
@@ -258,17 +256,16 @@ Future<int?> _macWindowId(int pid) async {
   final pidsArg = pids.join(',');
   final result = await Process.run('swift', [
     '-e',
-    r'''
+    '''
 import Cocoa
-let pidStrs = CommandLine.arguments[1].split(separator: ",")
-let pids = pidStrs.compactMap { Int32($0) }
+let pidStrs = "$pidsArg".split(separator: ",")
+let pids = pidStrs.compactMap { Int32(\$0) }
 guard let list = CGWindowListCopyWindowInfo(.optionOnScreenOnly, kCGNullWindowID) as? [NSDictionary] else { exit(0) }
 for w in list {
   guard let ownerPid = w[kCGWindowOwnerPID] as? Int32, pids.contains(ownerPid) else { continue }
   if let num = w[kCGWindowNumber] as? Int { print(num); break }
 }
 ''',
-    pidsArg,
   ]);
   if (result.exitCode != 0) return null;
   return int.tryParse((result.stdout as String).trim());
@@ -345,10 +342,12 @@ Future<int> _captureWeb(String output) async {
   try {
     final client = HttpClient()..connectionTimeout = const Duration(seconds: 5);
     try {
-      final req =
-          await client.getUrl(Uri.parse('http://localhost:$port/json'));
-      final resp = await req.close();
-      final body = await resp.transform(utf8.decoder).join();
+      final req = await client.getUrl(Uri.parse('http://localhost:$port/json'));
+      final resp = await req.close().timeout(const Duration(seconds: 5));
+      final body = await resp
+          .transform(utf8.decoder)
+          .join()
+          .timeout(const Duration(seconds: 5));
       final pages = jsonDecode(body) as List<dynamic>;
       if (pages.isEmpty) {
         stderr.writeln('ERROR: No Chrome pages found on CDP port $port.\n'
@@ -375,11 +374,12 @@ Future<int> _captureWeb(String output) async {
 
   // Capture via CDP Page.captureScreenshot.
   WebSocket? ws;
+  StreamSubscription<dynamic>? subscription;
   try {
     ws = await WebSocket.connect(wsUrl);
     final completer = Completer<Map<String, dynamic>>();
 
-    ws.listen(
+    subscription = ws.listen(
       (data) {
         final msg = jsonDecode(data as String) as Map<String, dynamic>;
         if (msg['id'] == 1 && !completer.isCompleted) completer.complete(msg);
@@ -390,18 +390,20 @@ Future<int> _captureWeb(String output) async {
       onDone: () {
         if (!completer.isCompleted) {
           completer.completeError(
-              StateError('WebSocket closed before CDP response'));
+            StateError('WebSocket closed before CDP response'),
+          );
         }
       },
     );
 
     ws.add(jsonEncode(
-        {'id': 1, 'method': 'Page.captureScreenshot', 'params': {}}));
+      {'id': 1, 'method': 'Page.captureScreenshot', 'params': {}},
+    ));
 
     final response =
         await completer.future.timeout(const Duration(seconds: 10));
-    final data = (response['result'] as Map<String, dynamic>?)?['data']
-        as String?;
+    final data =
+        (response['result'] as Map<String, dynamic>?)?['data'] as String?;
     if (data == null) {
       stderr.writeln('ERROR: CDP screenshot returned no image data.');
       return 1;
@@ -415,6 +417,7 @@ Future<int> _captureWeb(String output) async {
     stderr.writeln('ERROR: CDP screenshot failed: $e');
     return 1;
   } finally {
+    await subscription?.cancel();
     await ws?.close();
   }
 }

--- a/lib/commands/screenshot.dart
+++ b/lib/commands/screenshot.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:image/image.dart' as img;
+
 import 'package:fdb/constants.dart';
 import 'package:fdb/process_utils.dart';
 import 'package:fdb/vm_service.dart';
@@ -482,51 +484,45 @@ Future<int> _captureViaFdbHelper(String output) async {
 const _maxScreenshotDimension = 1200;
 
 /// Downscales [path] in-place so its longest side does not exceed
-/// [_maxScreenshotDimension] pixels, preserving aspect ratio.
+/// [_maxScreenshotDimension] pixels, preserving aspect ratio, then
+/// re-encodes the PNG with level-6 compression.
 ///
-/// Uses `sips` (macOS built-in) for both measurement and resampling.
-/// No-ops if the image already fits within the limit.
+/// Uses the pure-Dart `image` package — no external tools, cross-platform.
+/// No-ops if the image already fits within the limit (still re-encodes for
+/// better compression than the raw capture output).
 /// Returns 0 on success, 1 on failure.
 Future<int> _resizeToMaxDimension(String path) async {
-  final queryResult =
-      await Process.run('sips', ['-g', 'pixelWidth', '-g', 'pixelHeight', path]);
-  if (queryResult.exitCode != 0) {
-    stderr.writeln(
-        'ERROR: Could not read image dimensions: ${queryResult.stderr}');
+  try {
+    final file = File(path);
+    final bytes = await file.readAsBytes();
+
+    final src = img.decodePng(bytes);
+    if (src == null) {
+      stderr.writeln('ERROR: Could not decode PNG for resizing');
+      return 1;
+    }
+
+    final img.Image resized;
+    final longest = src.width > src.height ? src.width : src.height;
+    if (longest > _maxScreenshotDimension) {
+      final scale = _maxScreenshotDimension / longest;
+      resized = img.copyResize(
+        src,
+        width: (src.width * scale).round(),
+        height: (src.height * scale).round(),
+        interpolation: img.Interpolation.linear,
+      );
+    } else {
+      resized = src;
+    }
+
+    final encoded = img.encodePng(resized, level: 6);
+    await file.writeAsBytes(encoded);
+    return 0;
+  } catch (e) {
+    stderr.writeln('ERROR: Could not resize image: $e');
     return 1;
   }
-
-  final width = _parseSipsDimension(queryResult.stdout as String, 'pixelWidth');
-  final height =
-      _parseSipsDimension(queryResult.stdout as String, 'pixelHeight');
-  if (width == null || height == null) {
-    stderr.writeln('ERROR: Could not parse image dimensions from sips output');
-    return 1;
-  }
-
-  final maxSide = width > height ? width : height;
-  if (maxSide <= _maxScreenshotDimension) return 0; // already small enough
-
-  // sips --resampleHeightWidthMax scales the longest side to the given value.
-  final resizeResult = await Process.run('sips', [
-    '--resampleHeightWidthMax',
-    '$_maxScreenshotDimension',
-    path,
-    '--out',
-    path,
-  ]);
-  if (resizeResult.exitCode != 0) {
-    stderr.writeln('ERROR: Could not resize image: ${resizeResult.stderr}');
-    return 1;
-  }
-
-  return 0;
-}
-
-int? _parseSipsDimension(String sipsOutput, String key) {
-  final match = RegExp('$key:\\s*(\\d+)').firstMatch(sipsOutput);
-  if (match == null) return null;
-  return int.tryParse(match.group(1)!);
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -33,6 +33,7 @@ String get logCollectorScript => '$_sessionDir/log_collector.dart';
 String get vmUriFile => '$_sessionDir/vm_uri.txt';
 String get launcherScript => '$_sessionDir/launcher.sh';
 String get deviceFile => '$_sessionDir/device.txt';
+String get platformFile => '$_sessionDir/platform.txt';
 String get defaultScreenshotPath => '$_sessionDir/screenshot.png';
 
 const launchTimeoutSeconds = 300; // 5 minutes

--- a/lib/process_utils.dart
+++ b/lib/process_utils.dart
@@ -47,6 +47,18 @@ int? readLogCollectorPid() {
   return int.tryParse(content);
 }
 
+/// Extracts the JSON array from `flutter devices --machine` output.
+///
+/// Flutter may prepend non-JSON text (download progress, upgrade banners)
+/// before the actual JSON array. Scans for the first `[` to find the start.
+String? extractDevicesJson(String output) {
+  final start = output.indexOf('[');
+  if (start == -1) return null;
+  final end = output.lastIndexOf(']');
+  if (end == -1 || end < start) return null;
+  return output.substring(start, end + 1);
+}
+
 bool isProcessAlive(int pid) {
   try {
     final result = Process.runSync('kill', ['-0', pid.toString()]);

--- a/lib/process_utils.dart
+++ b/lib/process_utils.dart
@@ -22,6 +22,23 @@ String? readDevice() {
   return content.isEmpty ? null : content;
 }
 
+/// Stores the Flutter target platform string and emulator flag for the active
+/// session. Written by `fdb launch`, read by `fdb screenshot`.
+///
+/// Format: `<targetPlatform> <emulator>` e.g. `ios true` or `android-arm64 false`.
+void writePlatformInfo(String targetPlatform, bool emulator) {
+  File(platformFile).writeAsStringSync('$targetPlatform $emulator');
+}
+
+/// Returns `(platform, emulator)` from the platform file, or null if absent.
+({String platform, bool emulator})? readPlatformInfo() {
+  final file = File(platformFile);
+  if (!file.existsSync()) return null;
+  final parts = file.readAsStringSync().trim().split(' ');
+  if (parts.length < 2) return null;
+  return (platform: parts[0], emulator: parts[1] == 'true');
+}
+
 /// Read the log collector PID from its PID file.
 int? readLogCollectorPid() {
   final file = File(logCollectorPidFile);
@@ -48,6 +65,7 @@ void cleanupTempFiles() {
     vmUriFile,
     launcherScript,
     deviceFile,
+    platformFile,
   ]) {
     final file = File(path);
     if (file.existsSync()) {

--- a/packages/fdb_helper/lib/src/fdb_binding.dart
+++ b/packages/fdb_helper/lib/src/fdb_binding.dart
@@ -1104,6 +1104,10 @@ class FdbBinding extends WidgetsFlutterBinding {
         return _errorResponse('Invalid view size: ${width}x$height');
       }
 
+      if (!layer.attached) {
+        return _errorResponse('Render view layer is detached');
+      }
+
       final builder = ui.SceneBuilder();
       layer.addToScene(builder);
       scene = builder.build();

--- a/packages/fdb_helper/lib/src/fdb_binding.dart
+++ b/packages/fdb_helper/lib/src/fdb_binding.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:developer' as developer;
 import 'dart:io';
+import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
@@ -23,13 +24,14 @@ import 'widget_matcher.dart';
 /// }
 /// ```
 ///
-/// This registers five VM service extensions (in debug and profile mode only):
+/// This registers the following VM service extensions (in debug and profile mode only):
 /// - `ext.fdb.elements` — list all interactive elements with bounds
 /// - `ext.fdb.tap` — tap a widget by key, text, type, or coordinates
 /// - `ext.fdb.longPress` — long-press a widget (same as tap with duration=500ms)
 /// - `ext.fdb.enterText` — enter text into a text field
 /// - `ext.fdb.scroll` — perform a swipe/scroll gesture
 /// - `ext.fdb.back` — trigger Navigator.maybePop()
+/// - `ext.fdb.screenshot` — capture the Flutter rendering surface as base64 PNG
 class FdbBinding extends WidgetsFlutterBinding {
   FdbBinding._();
 
@@ -72,6 +74,7 @@ class FdbBinding extends WidgetsFlutterBinding {
     _registerExtension('ext.fdb.back', _handleBack);
     _registerExtension('ext.fdb.clean', _handleClean);
     _registerExtension('ext.fdb.sharedPrefs', _handleSharedPrefs);
+    _registerExtension('ext.fdb.screenshot', _handleScreenshot);
   }
 
   /// Registers a VM service extension, silently ignoring double-registration
@@ -1054,6 +1057,72 @@ class FdbBinding extends WidgetsFlutterBinding {
       );
     } catch (e) {
       return _errorResponse('clean failed: $e');
+    }
+  }
+
+  /// Handles `ext.fdb.screenshot`.
+  ///
+  /// Renders the current Flutter surface to a PNG and returns it as a
+  /// base64-encoded string under the `screenshot` key.
+  ///
+  /// Used as a fallback capture backend on platforms that have no native
+  /// screenshot CLI (physical iOS, Windows, Linux Wayland).
+  Future<developer.ServiceExtensionResponse> _handleScreenshot(
+    String method,
+    Map<String, String> params,
+  ) async {
+    ui.Scene? scene;
+    ui.Image? image;
+    try {
+      final renderViews = WidgetsBinding.instance.renderViews;
+      if (renderViews.isEmpty) {
+        return _errorResponse('No render views available');
+      }
+
+      final view = renderViews.first;
+      final flutterView = view.flutterView;
+
+      // Ensure the frame is painted before capturing.
+      // ignore: invalid_use_of_protected_member
+      if (view.debugNeedsPaint || view.layer == null) {
+        WidgetsBinding.instance.scheduleFrame();
+        await WidgetsBinding.instance.endOfFrame;
+      }
+
+      // ignore: invalid_use_of_protected_member
+      final layer = view.layer;
+      if (layer == null) {
+        return _errorResponse('Render view layer is null');
+      }
+
+      // Capture at physical pixel resolution.
+      final size = flutterView.physicalSize;
+      final width = size.width.ceil();
+      final height = size.height.ceil();
+
+      if (width <= 0 || height <= 0) {
+        return _errorResponse('Invalid view size: ${width}x$height');
+      }
+
+      final builder = ui.SceneBuilder();
+      layer.addToScene(builder);
+      scene = builder.build();
+      image = await scene.toImage(width, height);
+
+      final byteData = await image.toByteData(format: ui.ImageByteFormat.png);
+      if (byteData == null) {
+        return _errorResponse('Failed to encode image as PNG');
+      }
+
+      final base64Data = base64Encode(byteData.buffer.asUint8List());
+      return developer.ServiceExtensionResponse.result(
+        jsonEncode({'screenshot': base64Data}),
+      );
+    } catch (e) {
+      return _errorResponse('Screenshot failed: $e');
+    } finally {
+      scene?.dispose();
+      image?.dispose();
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,3 +8,5 @@ executables:
   fdb: fdb
 dev_dependencies:
   test: ^1.31.0
+dependencies:
+  image: ^4.8.0

--- a/skills/using-fdb/SKILL.md
+++ b/skills/using-fdb/SKILL.md
@@ -79,10 +79,10 @@ fdb restart   # SIGUSR2 - resets state
 ### Screenshot
 
 ```bash
-fdb screenshot [--output <path>]
+fdb screenshot [--output <path>] [--full]
 ```
 
-Auto-detects Android (`adb screencap`) vs iOS simulator (`xcrun simctl io screenshot`). Default output: `<project>/.fdb/screenshot.png`. Read the file with the Read tool to view it.
+Dispatches to the right capture tool per platform: `adb` (Android), `xcrun simctl` (iOS simulator), `screencapture` (macOS), `xdotool`+`import` (Linux X11), Chrome DevTools Protocol (web), or `fdb_helper` VM extension (physical iOS, Windows, Wayland). Default output: `<project>/.fdb/screenshot.png`. Output is downscaled so the longest side fits within 1200px — pass `--full` to skip. Read the file with the Read tool to view it.
 
 ### Logs
 
@@ -368,4 +368,6 @@ All state lives in `<project>/.fdb/`:
 - `<project>/.fdb/fdb.pid` - flutter run process ID
 - `<project>/.fdb/logs.txt` - full app output
 - `<project>/.fdb/vm_uri.txt` - VM service websocket URI
+- `<project>/.fdb/device.txt` - device ID used at launch
+- `<project>/.fdb/platform.txt` - target platform + emulator flag (written at launch, read by screenshot)
 - `<project>/.fdb/screenshot.png` - last screenshot


### PR DESCRIPTION
## What this does

Screenshot only worked on Android and iOS simulator. This adds macOS, Linux, physical iOS, Windows, and web support, and fixes downscaling so the output is actually useful to an AI agent.

## Changes

### Platform detection

`fdb launch` now calls `flutter devices --machine` to record the target platform and emulator flag in `.fdb/platform.txt`. Screenshot reads that to pick the right backend. Old sessions without the file fall back to the original adb/xcrun heuristic.

### Screenshot backends

| Platform | Tool |
|---|---|
| Android | `adb exec-out screencap -p` |
| iOS simulator | `xcrun simctl io <udid> screenshot` |
| iOS physical | `fdb_helper` VM extension (Flutter surface only) |
| macOS | `screencapture -l <windowId>` via Swift + CGWindowListCopyWindowInfo; falls back to `fdb_helper` if Screen Recording permission is missing |
| Linux X11 | `xdotool` + ImageMagick `import` |
| Linux Wayland / Windows | `fdb_helper` VM extension |
| Web | Chrome DevTools Protocol `Page.captureScreenshot` (port from `CHROME_CDP_PORT` env or 9222) |

### Downscaling

The old heuristic (`> 1000px → ÷3, > 500px → ÷2`) was wrong for landscape screenshots, macOS windows, and unusual resolutions.

New: scale so the longest side fits within 1200px, preserving aspect ratio. Uses the `image` Dart package instead of the macOS-only `sips` tool — works on all platforms.

Before/after on real devices:
- iOS 1206×2622, 215KB → 552×1200, 62KB
- Android 1440×3200, 181KB → 540×1200, 55KB

### `fdb_helper` — `ext.fdb.screenshot`

New VM extension that renders the Flutter surface to PNG and returns base64. Fallback for platforms with no native capture CLI.

### Other fixes

- `extractDevicesJson` deduplicated into `process_utils.dart` (was copied in both `launch.dart` and `devices.dart`)
- All non-nullable JSON casts in `devices.dart` made null-safe
- Web platform match broadened to `startsWith('web')` to cover `web-unknown` and future variants
- CDP HTTP client: 5s connection timeout + response read timeout
- CDP WebSocket subscription cancelled in `finally`
- xdotool window selection: `.first` (main window) instead of `.last`
- `layer.attached` checked before `addToScene` in fdb_helper

## Testing

Tested on iPhone 17 Pro simulator (3x, iOS) and a physical Android device (1440×3200). Screenshots read back as images — all content visible and legible.

- `dart analyze`: clean on both `fdb` and `fdb_helper`
- `dart test`: all 6 pass
- `task test:screenshot`: passes