### PR TITLE
feat: fdb doctor — pre-flight health check for agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ fdb kill
 | `fdb launch --device <id> --project <path>` | Launch app, wait for start |
 | `fdb reload` | Hot reload |
 | `fdb restart` | Hot restart |
+| `fdb doctor` | Pre-flight check for app, VM service, fdb_helper, platform tools, and device state |
 | `fdb status` | Check if app is running |
 | `fdb kill` | Stop app, clean up |
 
@@ -184,6 +185,8 @@ void main() {
 **`RUNNING=false` right after launch** - The process crashed. Check `fdb logs --last 50`.
 
 **Widget interaction fails** - `fdb_helper` missing from `pubspec.yaml`, or `FdbBinding.ensureInitialized()` not called.
+
+**Agent setup fails mid-flow** - Run `fdb doctor` to check app process, VM service reachability, `fdb_helper`, platform tools, and stored device state before continuing.
 
 ## Contributing
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -96,6 +96,130 @@ tasks:
           exit 1
         fi
 
+  test:doctor:
+    desc: Run pre-flight environment checks (expects a running app with fdb_helper)
+    dir: '{{.TEST_APP}}'
+    cmds:
+      - |
+        # Normalise raw output: the dart run build-hook preamble has no trailing
+        # newline so it can run onto the first DOCTOR_ token on the same physical
+        # line.  Split every DOCTOR_ prefix onto its own line so all ^-anchored
+        # greps work correctly regardless of the runner environment.
+        normalize() { sed "s/DOCTOR_/"$'\\\nDOCTOR_'"/g"; }
+
+        echo "==> Running doctor checks"
+        RAW=$({{.FDB}} doctor 2>&1)
+        EXIT_CODE=$?
+        OUTPUT=$(echo "$RAW" | normalize)
+        echo "$OUTPUT"
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "FAIL: fdb doctor exited with code $EXIT_CODE" >&2
+          exit 1
+        fi
+        CHECK_COUNT=$(echo "$OUTPUT" | grep -c '^DOCTOR_CHECK=')
+        if [ "$CHECK_COUNT" -ne 5 ]; then
+          echo "FAIL: fdb doctor - expected 5 DOCTOR_CHECK lines, got $CHECK_COUNT" >&2
+          exit 1
+        fi
+        ACTUAL_ORDER=$(echo "$OUTPUT" | grep '^DOCTOR_CHECK=' | sed 's/^DOCTOR_CHECK=\([^ ]*\).*/\1/' | tr '\n' ' ' | sed 's/ $//')
+        EXPECTED_ORDER="app_running vm_service fdb_helper platform_tools device"
+        if [ "$ACTUAL_ORDER" != "$EXPECTED_ORDER" ]; then
+          echo "FAIL: fdb doctor - expected check order '$EXPECTED_ORDER', got '$ACTUAL_ORDER'" >&2
+          exit 1
+        fi
+        if ! echo "$OUTPUT" | grep -q '^DOCTOR_CHECK=app_running STATUS=pass$'; then
+          echo "FAIL: fdb doctor - app_running pass line missing or malformed" >&2
+          exit 1
+        fi
+        if ! echo "$OUTPUT" | grep -q '^DOCTOR_CHECK=vm_service STATUS=pass VM_SERVICE_URI='; then
+          echo "FAIL: fdb doctor - vm_service pass line missing VM_SERVICE_URI" >&2
+          exit 1
+        fi
+        if ! echo "$OUTPUT" | grep -q '^DOCTOR_CHECK=fdb_helper STATUS=pass$'; then
+          echo "FAIL: fdb doctor - fdb_helper pass line missing or malformed" >&2
+          exit 1
+        fi
+        if ! echo "$OUTPUT" | grep -Eq '^DOCTOR_CHECK=platform_tools STATUS=(pass|warn) TOOLS='; then
+          echo "FAIL: fdb doctor - platform_tools line missing status or TOOLS" >&2
+          exit 1
+        fi
+        if echo "$OUTPUT" | grep -q '^DOCTOR_CHECK=platform_tools STATUS=warn'; then
+          if ! echo "$OUTPUT" | grep -q '^DOCTOR_CHECK=platform_tools STATUS=warn .*MISSING=.*HINT=.*missing'; then
+            echo "FAIL: fdb doctor - platform_tools warning missing MISSING or HINT" >&2
+            exit 1
+          fi
+        fi
+        if ! echo "$OUTPUT" | grep -q '^DOCTOR_CHECK=device STATUS=pass DEVICE_ID=.* PLATFORM='; then
+          echo "FAIL: fdb doctor - device pass line missing DEVICE_ID or PLATFORM" >&2
+          exit 1
+        fi
+        if ! echo "$OUTPUT" | grep -q '^DOCTOR_SUMMARY=pass CHECKS=5 FAILED=0$'; then
+          echo "FAIL: fdb doctor - passing summary missing or malformed" >&2
+          exit 1
+        fi
+
+        echo "==> Scenario: dead PID (app_running=fail)"
+        ORIGINAL_PID=$(cat .fdb/fdb.pid)
+        restore_pid() { printf '%s' "$ORIGINAL_PID" > .fdb/fdb.pid; }
+        trap restore_pid EXIT
+        printf '999999' > .fdb/fdb.pid
+        FAILURE_RAW=$({{.FDB}} doctor 2>&1)
+        FAILURE_EXIT_CODE=$?
+        restore_pid
+        trap - EXIT
+        FAILURE_OUTPUT=$(echo "$FAILURE_RAW" | normalize)
+        echo "$FAILURE_OUTPUT"
+        if [ $FAILURE_EXIT_CODE -ne 0 ]; then
+          echo "FAIL: fdb doctor returned non-zero for failed checks: $FAILURE_EXIT_CODE" >&2
+          exit 1
+        fi
+        if ! echo "$FAILURE_OUTPUT" | grep -q '^DOCTOR_CHECK=app_running STATUS=fail HINT='; then
+          echo "FAIL: fdb doctor - app_running failure line missing HINT" >&2
+          exit 1
+        fi
+        if ! echo "$FAILURE_OUTPUT" | grep -q '^DOCTOR_CHECK=vm_service STATUS=fail HINT='; then
+          echo "FAIL: fdb doctor - vm_service failure line missing HINT" >&2
+          exit 1
+        fi
+        if ! echo "$FAILURE_OUTPUT" | grep -q '^DOCTOR_CHECK=fdb_helper STATUS=fail HINT='; then
+          echo "FAIL: fdb doctor - fdb_helper failure line missing HINT" >&2
+          exit 1
+        fi
+        if ! echo "$FAILURE_OUTPUT" | grep -q '^DOCTOR_SUMMARY=fail CHECKS=5 FAILED=3$'; then
+          echo "FAIL: fdb doctor - failed summary missing or warnings counted as failures" >&2
+          exit 1
+        fi
+
+        echo "==> Scenario: stale VM URI while PID is alive (vm_service=fail)"
+        ORIGINAL_URI=$(cat .fdb/vm_uri.txt)
+        restore_uri() { printf '%s' "$ORIGINAL_URI" > .fdb/vm_uri.txt; }
+        trap restore_uri EXIT
+        printf 'ws://127.0.0.1:1/stale=/ws' > .fdb/vm_uri.txt
+        STALE_RAW=$({{.FDB}} doctor 2>&1)
+        STALE_EXIT_CODE=$?
+        restore_uri
+        trap - EXIT
+        STALE_OUTPUT=$(echo "$STALE_RAW" | normalize)
+        echo "$STALE_OUTPUT"
+        if [ $STALE_EXIT_CODE -ne 0 ]; then
+          echo "FAIL: fdb doctor returned non-zero for stale URI scenario: $STALE_EXIT_CODE" >&2
+          exit 1
+        fi
+        if ! echo "$STALE_OUTPUT" | grep -q '^DOCTOR_CHECK=app_running STATUS=pass$'; then
+          echo "FAIL: fdb doctor stale-URI - app_running should still pass" >&2
+          exit 1
+        fi
+        if ! echo "$STALE_OUTPUT" | grep -q '^DOCTOR_CHECK=vm_service STATUS=fail HINT=App is running'; then
+          echo "FAIL: fdb doctor stale-URI - vm_service should fail with app-is-running hint" >&2
+          exit 1
+        fi
+        if ! echo "$STALE_OUTPUT" | grep -q '^DOCTOR_SUMMARY=fail'; then
+          echo "FAIL: fdb doctor stale-URI - summary should be fail" >&2
+          exit 1
+        fi
+
+        echo "PASS: fdb doctor"
+
   test:reload:
     desc: Hot reload the running app
     dir: '{{.TEST_APP}}'

--- a/bin/fdb.dart
+++ b/bin/fdb.dart
@@ -6,6 +6,7 @@ import 'package:fdb/commands/shared_prefs.dart';
 import 'package:fdb/commands/deeplink.dart';
 import 'package:fdb/commands/describe.dart';
 import 'package:fdb/commands/devices.dart';
+import 'package:fdb/commands/doctor.dart';
 import 'package:fdb/commands/input.dart';
 import 'package:fdb/commands/kill.dart';
 import 'package:fdb/commands/launch.dart';
@@ -38,6 +39,7 @@ Commands:
   logs        Get filtered app logs
   tree        Get the widget tree
   describe    Describe the current screen (interactive elements + text)
+  doctor      Check app, VM service, fdb_helper, platform tools, and device state
   tap         Tap a widget by selector or @N ref from describe
   longpress   Long-press a widget by selector
   input       Enter text into a field
@@ -106,6 +108,8 @@ Future<int> _runCommand(String command, List<String> args) {
       return runTree(args);
     case 'describe':
       return runDescribe(args);
+    case 'doctor':
+      return runDoctor(args);
     case 'tap':
       return runTap(args);
     case 'longpress':

--- a/doc/README.agents.md
+++ b/doc/README.agents.md
@@ -75,6 +75,7 @@ curl -fsSL https://raw.githubusercontent.com/andrzejchm/fdb/main/skills/using-fd
 | `fdb devices` | List connected devices |
 | `fdb deeplink <url>` | Open deep link on device |
 | `fdb launch --device <id> --project <path>` | Launch app, wait for start |
+| `fdb doctor` | Pre-flight check for app, VM service, fdb_helper, platform tools, and device state |
 | `fdb reload` | Hot reload (SIGUSR1) |
 | `fdb restart` | Hot restart (SIGUSR2) |
 | `fdb screenshot [--output <path>] [--full]` | Screenshot (all platforms; `--full` skips downscaling) |
@@ -104,6 +105,14 @@ fdb launch --device <device_id> --project <path> [--flavor <flavor>] [--target <
 Output: `APP_STARTED`, `VM_SERVICE_URI=...`, `PID=...`, `LOG_FILE=...`
 
 Find device IDs: `fdb devices`
+
+### Doctor
+
+```bash
+fdb doctor
+```
+
+Runs pre-flight checks for the app process, VM service, `fdb_helper`, platform tools, and stored device state. Always exits `0`; inspect `DOCTOR_SUMMARY=pass|fail CHECKS=<n> FAILED=<n>` and per-check `DOCTOR_CHECK=<name> STATUS=pass|fail|warn` lines.
 
 ### Hot reload / restart
 

--- a/lib/commands/doctor.dart
+++ b/lib/commands/doctor.dart
@@ -1,0 +1,159 @@
+import 'dart:io';
+
+import 'package:fdb/process_utils.dart';
+import 'package:fdb/vm_service.dart';
+
+Future<int> runDoctor(List<String> args) async {
+  var failed = 0;
+  final appRunning = _checkAppRunning();
+
+  if (appRunning) {
+    _printCheck('app_running', 'pass');
+  } else {
+    failed++;
+    _printCheck(
+      'app_running',
+      'fail',
+      hint: "Run 'fdb launch --device <id> --project <path>' to start the app",
+    );
+  }
+
+  final vmServiceUri = appRunning ? await _checkVmService() : null;
+  if (vmServiceUri != null) {
+    _printCheck('vm_service', 'pass', values: {'VM_SERVICE_URI': vmServiceUri});
+  } else {
+    failed++;
+    _printCheck(
+      'vm_service',
+      'fail',
+      hint: appRunning
+          ? 'App is running but VM service is unreachable. Check if the app crashed.'
+          : "Run 'fdb launch --device <id> --project <path>' to start the app",
+    );
+  }
+
+  if (vmServiceUri != null && await _checkFdbHelper()) {
+    _printCheck('fdb_helper', 'pass');
+  } else {
+    failed++;
+    _printCheck(
+      'fdb_helper',
+      'fail',
+      hint: 'Add fdb_helper to pubspec.yaml dev_dependencies and call FdbBinding.ensureInitialized() in main()',
+    );
+  }
+
+  final tools = await _checkPlatformTools();
+  if (tools.missing.isEmpty) {
+    _printCheck('platform_tools', 'pass', values: {'TOOLS': tools.present.join(',')});
+  } else {
+    _printCheck(
+      'platform_tools',
+      'warn',
+      values: {
+        'TOOLS': tools.present.join(','),
+        'MISSING': tools.missing.join(','),
+      },
+      hint: _platformToolsHint(tools.missing),
+    );
+  }
+
+  if (_checkDevice()) {
+    final device = readDevice();
+    final platformInfo = readPlatformInfo();
+    _printCheck(
+      'device',
+      'pass',
+      values: {
+        'DEVICE_ID': device!,
+        'PLATFORM': platformInfo!.platform,
+      },
+    );
+  } else {
+    failed++;
+    _printCheck(
+      'device',
+      'fail',
+      hint: "Run 'fdb launch --device <id> --project <path>' to store the active device.",
+    );
+  }
+
+  final summary = failed == 0 ? 'pass' : 'fail';
+  stdout.writeln('DOCTOR_SUMMARY=$summary CHECKS=5 FAILED=$failed');
+  return 0;
+}
+
+bool _checkAppRunning() {
+  final pid = readPid();
+  return pid != null && isProcessAlive(pid);
+}
+
+Future<String?> _checkVmService() async {
+  try {
+    final response = await vmServiceCall('getVM', timeout: const Duration(seconds: 3));
+    final result = response['result'] as Map<String, dynamic>?;
+    if (response['error'] != null || result == null) return null;
+    final uri = readVmUri();
+    if (uri == null || uri.isEmpty) return null;
+    return uri.replaceFirst('http://', 'ws://').replaceFirst('https://', 'wss://');
+  } catch (_) {
+    return null;
+  }
+}
+
+Future<bool> _checkFdbHelper() async {
+  final isolateId = await checkFdbHelper();
+  return isolateId != null;
+}
+
+Future<({List<String> present, List<String> missing})> _checkPlatformTools() async {
+  final present = <String>[];
+  final missing = <String>[];
+
+  for (final tool in ['adb', 'xcrun', 'screencapture']) {
+    final result = await Process.run('which', [tool]);
+    if (result.exitCode == 0) {
+      present.add(tool);
+    } else {
+      missing.add(tool);
+    }
+  }
+
+  return (present: present, missing: missing);
+}
+
+String _platformToolsHint(List<String> missing) {
+  final hints = <String>[];
+  if (missing.contains('adb')) {
+    hints.add('adb missing — Android screenshots and interactions will fail. Install Android platform-tools.');
+  }
+  if (missing.contains('xcrun')) {
+    hints.add('xcrun missing — iOS simulator screenshots will fail. Install Xcode.');
+  }
+  if (missing.contains('screencapture')) {
+    hints.add('screencapture missing — macOS screenshots will fail. Use a macOS host with screencapture available.');
+  }
+  return hints.join(' ');
+}
+
+bool _checkDevice() {
+  final device = readDevice();
+  final platformInfo = readPlatformInfo();
+  return device != null && platformInfo != null;
+}
+
+void _printCheck(
+  String name,
+  String status, {
+  Map<String, String> values = const {},
+  String? hint,
+}) {
+  final parts = [
+    'DOCTOR_CHECK=$name',
+    'STATUS=$status',
+    for (final entry in values.entries)
+      if (entry.value.isNotEmpty) '${entry.key}=${entry.value}',
+    if (hint != null) 'HINT=$hint',
+  ];
+  stdout.writeln(parts.join(' '));
+}

--- a/skills/using-fdb/SKILL.md
+++ b/skills/using-fdb/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-fdb
-description: Uses fdb (Flutter Debug Bridge) CLI to interact with running Flutter apps on physical devices and simulators. Launches apps, hot reloads/restarts, takes screenshots, reads logs, inspects widget trees, taps/long-presses widgets, enters text, scrolls, and navigates back. Use when launching a Flutter app on device, hot reloading after code changes, taking device screenshots, reading app logs, inspecting the widget hierarchy, debugging UI on device, or interacting with widgets via fdb.
+description: Uses fdb (Flutter Debug Bridge) CLI to interact with running Flutter apps on physical devices and simulators. Launches apps, runs pre-flight health checks, hot reloads/restarts, takes screenshots, reads logs, inspects widget trees, taps/long-presses widgets, enters text, scrolls, and navigates back. Use when launching a Flutter app on device, checking fdb environment health, hot reloading after code changes, taking device screenshots, reading app logs, inspecting the widget hierarchy, debugging UI on device, or interacting with widgets via fdb.
 license: MIT
 compatibility: opencode
 ---
@@ -68,6 +68,26 @@ fdb launch --device <device_id> --project <path> [--flavor <flavor>] [--target <
 Output: `APP_STARTED`, `VM_SERVICE_URI=...`, `PID=...`, `LOG_FILE=...`
 
 Find device IDs: `fdb devices`
+
+### Doctor pre-flight check
+
+```bash
+fdb doctor
+```
+
+Run this before an interaction session when you need to validate that the app is running and the environment is usable. It checks the app process, VM service, `fdb_helper`, platform tools, and stored device state, then prints `DOCTOR_SUMMARY=pass|fail CHECKS=<n> FAILED=<n>`.
+
+Example output:
+```
+DOCTOR_CHECK=app_running STATUS=pass
+DOCTOR_CHECK=vm_service STATUS=pass VM_SERVICE_URI=ws://127.0.0.1:56789/ws
+DOCTOR_CHECK=fdb_helper STATUS=pass
+DOCTOR_CHECK=platform_tools STATUS=warn TOOLS=xcrun,screencapture MISSING=adb HINT=adb missing — Android screenshots and interactions will fail. Install Android platform-tools.
+DOCTOR_CHECK=device STATUS=pass DEVICE_ID=macos PLATFORM=darwin-x64
+DOCTOR_SUMMARY=pass CHECKS=5 FAILED=0
+```
+
+Warnings do not make the summary fail. Failed checks include `HINT=...` remediation text. The command always exits `0`, so parse the summary instead of relying on the process exit code.
 
 ### Hot reload / restart
 


### PR DESCRIPTION
Agents often waste several round-trips diagnosing environmental failures mid-flow — the app isn't running, the VM service is unreachable, or fdb_helper was never initialised. This adds `fdb doctor`, a single command that validates all preconditions upfront and reports each as a structured `DOCTOR_CHECK=<name> STATUS=pass|fail|warn` line, so an agent can detect and fix environment issues before starting a session.

Closes #35