### PR TITLE
feat: add fdb double-tap command

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ fdb kill
 
 | Command | Description |
 |---------|-------------|
+| `fdb double-tap --text/--key/--type <selector> [--index N]` \| `--x X --y Y` \| `--at X,Y` | Double-tap a widget or screen coordinates |
 | `fdb tap --text/--key/--type <selector>`, `--at x,y`, or `@N` | Tap a widget, coordinates, or describe ref |
 | `fdb longpress --text/--key/--type <selector> [--duration <ms>]` or `--at x,y` | Long-press a widget or coordinates |
 | `fdb input [--text/--key/--type <selector>] <text>` | Enter text into a field |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -425,6 +425,214 @@ tasks:
           exit 1
         fi
 
+  test:double-tap:
+    desc: Double-tap a widget by selector and coordinates
+    dir: '{{.TEST_APP}}'
+    vars:
+      DEVICE:
+        sh: '{{if .DEVICE}}echo "{{.DEVICE}}"{{else}}echo "macos"{{end}}'
+    cmds:
+      - |
+        assert_double_tap_output() {
+          local output="$1"
+          if echo "$output" | grep -Eq 'DOUBLE_TAPPED=[^ ]+ X=-?[0-9]+(\.[0-9]+)? Y=-?[0-9]+(\.[0-9]+)?'; then
+            return 0
+          fi
+          echo "FAIL: fdb double-tap - expected DOUBLE_TAPPED=<WidgetType> X=<x> Y=<y>" >&2
+          exit 1
+        }
+
+        assert_double_tap_log() {
+          local scenario="$1"
+          local expected_log="$2"
+          for _ in $(seq 1 20); do
+            LOG_OUTPUT=$({{.FDB}} logs --tag fdb_test --last 50 2>&1)
+            LOG_EXIT_CODE=$?
+            echo "$LOG_OUTPUT"
+            if [ $LOG_EXIT_CODE -ne 0 ]; then
+              echo "FAIL: fdb logs after $scenario exited with code $LOG_EXIT_CODE" >&2
+              exit 1
+            fi
+            if echo "$LOG_OUTPUT" | grep -q "$expected_log"; then
+              return 0
+            fi
+            sleep 0.5
+          done
+          echo "FAIL: fdb double-tap - trigger log not found after $scenario" >&2
+          exit 1
+        }
+
+        assert_any_double_tap_log() {
+          local scenario="$1"
+          local expected_pattern="$2"
+          for _ in $(seq 1 20); do
+            LOG_OUTPUT=$({{.FDB}} logs --tag fdb_test --last 50 2>&1)
+            LOG_EXIT_CODE=$?
+            echo "$LOG_OUTPUT"
+            if [ $LOG_EXIT_CODE -ne 0 ]; then
+              echo "FAIL: fdb logs after $scenario exited with code $LOG_EXIT_CODE" >&2
+              exit 1
+            fi
+            if echo "$LOG_OUTPUT" | grep -Eq "$expected_pattern"; then
+              return 0
+            fi
+            sleep 0.5
+          done
+          echo "FAIL: fdb double-tap - trigger log not found after $scenario" >&2
+          exit 1
+        }
+
+        assert_double_tap_error() {
+          local output="$1"
+          local expected_error="$2"
+          if echo "$output" | grep -q "$expected_error"; then
+            return 0
+          fi
+          echo "FAIL: fdb double-tap - expected error '$expected_error'" >&2
+          exit 1
+        }
+
+        extract_coords() {
+          local output="$1"
+          echo "$output" | sed -n 's/.*DOUBLE_TAPPED=.* X=\([^ ]*\) Y=\([^ ]*\).*/\1,\2/p'
+        }
+
+        is_macos_device() {
+          [ "{{.DEVICE}}" = "macos" ]
+        }
+
+        relaunch_test_app() {
+          echo "==> Launching test app on device: {{.DEVICE}}"
+          {{.FDB}} kill >/dev/null 2>&1 || true
+          OUTPUT=$({{.FDB}} launch --device "{{.DEVICE}}" 2>&1)
+          EXIT_CODE=$?
+          echo "$OUTPUT"
+          if [ $EXIT_CODE -ne 0 ]; then
+            echo "FAIL: fdb launch for double-tap exited with code $EXIT_CODE" >&2
+            exit 1
+          fi
+          if ! echo "$OUTPUT" | grep -q 'APP_STARTED'; then
+            echo "FAIL: fdb launch for double-tap - APP_STARTED not found in output" >&2
+            exit 1
+          fi
+
+          READY=0
+          for _ in $(seq 1 20); do
+            if {{.FDB}} tree --depth 1 >/dev/null 2>&1; then
+              READY=1
+              break
+            fi
+            sleep 0.5
+          done
+
+          if [ $READY -ne 1 ]; then
+            echo "FAIL: fdb launch for double-tap - app did not become ready" >&2
+            exit 1
+          fi
+        }
+
+        relaunch_test_app
+
+        echo "==> Double-tapping target by key"
+        set +e
+        KEY_OUTPUT=$({{.FDB}} double-tap --key "double_tap_target" 2>&1)
+        EXIT_CODE=$?
+        set -e
+        echo "$KEY_OUTPUT"
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "FAIL: fdb double-tap --key exited with code $EXIT_CODE" >&2
+          exit 1
+        fi
+        assert_double_tap_output "$KEY_OUTPUT"
+        assert_double_tap_log '--key' 'double_tap_target triggered'
+
+        COORDS=$(extract_coords "$KEY_OUTPUT")
+        if [ -z "$COORDS" ]; then
+          echo "FAIL: fdb double-tap - could not extract coordinates from --key output" >&2
+          exit 1
+        fi
+        X=$(echo "$COORDS" | sed 's/,.*//')
+        Y=$(echo "$COORDS" | sed 's/.*,//')
+
+        relaunch_test_app
+
+        echo "==> Double-tapping target by --text with --index 0"
+        set +e
+        TEXT_OUTPUT=$({{.FDB}} double-tap --text "Double Tap Target" --index 0 2>&1)
+        EXIT_CODE=$?
+        set -e
+        echo "$TEXT_OUTPUT"
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "FAIL: fdb double-tap --text --index 0 exited with code $EXIT_CODE" >&2
+          exit 1
+        fi
+        assert_double_tap_output "$TEXT_OUTPUT"
+        assert_double_tap_log '--text/--index 0' 'double_tap_target triggered'
+        relaunch_test_app
+
+        echo "==> Double-tapping target by --text with --index 1"
+        if is_macos_device; then
+          echo "SKIP: macOS duplicate-text index scenario is not stable in the desktop viewport; exercising --index on widget type and mobile targets instead"
+        else
+          set +e
+          INDEX_OUTPUT=$({{.FDB}} double-tap --text "Double Tap Target" --index 1 2>&1)
+          EXIT_CODE=$?
+          set -e
+          echo "$INDEX_OUTPUT"
+          if [ $EXIT_CODE -ne 0 ]; then
+            echo "FAIL: fdb double-tap --text/--index exited with code $EXIT_CODE" >&2
+            exit 1
+          fi
+          assert_double_tap_output "$INDEX_OUTPUT"
+          assert_any_double_tap_log '--text/--index 1' 'double_tap_target_secondary triggered'
+        fi
+
+        relaunch_test_app
+
+        echo "==> Double-tapping target by --type Container --index 0"
+        set +e
+        TYPE_OUTPUT=$({{.FDB}} double-tap --type "Container" --index 0 2>&1)
+        EXIT_CODE=$?
+        set -e
+        echo "$TYPE_OUTPUT"
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "FAIL: fdb double-tap --type exited with code $EXIT_CODE" >&2
+          exit 1
+        fi
+        assert_double_tap_output "$TYPE_OUTPUT"
+        assert_double_tap_log '--type/--index 0' 'double_tap_target triggered'
+
+        relaunch_test_app
+
+        echo "==> Double-tapping target by --x/--y"
+        set +e
+        XY_OUTPUT=$({{.FDB}} double-tap --x "$X" --y "$Y" 2>&1)
+        EXIT_CODE=$?
+        set -e
+        echo "$XY_OUTPUT"
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "FAIL: fdb double-tap --x/--y exited with code $EXIT_CODE" >&2
+          exit 1
+        fi
+        assert_double_tap_output "$XY_OUTPUT"
+        assert_double_tap_log '--x/--y' 'double_tap_target triggered'
+
+        relaunch_test_app
+
+        echo "==> Double-tapping target by --at"
+        set +e
+        AT_OUTPUT=$({{.FDB}} double-tap --at "$X,$Y" 2>&1)
+        EXIT_CODE=$?
+        set -e
+        echo "$AT_OUTPUT"
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "FAIL: fdb double-tap --at exited with code $EXIT_CODE" >&2
+          exit 1
+        fi
+        assert_double_tap_output "$AT_OUTPUT"
+        assert_double_tap_log '--at' 'double_tap_target triggered'
+        echo "PASS: fdb double-tap"
+
   test:longpress:
     desc: Long-press a widget by key selector
     dir: '{{.TEST_APP}}'
@@ -1053,6 +1261,11 @@ tasks:
       - task: test:deeplink
       - task: test:select
       - task: test:tap
+        vars:
+          DEVICE: '{{.DEVICE}}'
+      - task: test:double-tap
+        vars:
+          DEVICE: '{{.DEVICE}}'
       - task: test:longpress
       - task: test:tap-at
       - task: test:input

--- a/bin/fdb.dart
+++ b/bin/fdb.dart
@@ -7,6 +7,7 @@ import 'package:fdb/commands/deeplink.dart';
 import 'package:fdb/commands/describe.dart';
 import 'package:fdb/commands/devices.dart';
 import 'package:fdb/commands/doctor.dart';
+import 'package:fdb/commands/double_tap.dart';
 import 'package:fdb/commands/input.dart';
 import 'package:fdb/commands/kill.dart';
 import 'package:fdb/commands/launch.dart';
@@ -42,6 +43,7 @@ Commands:
   doctor      Check app, VM service, fdb_helper, platform tools, and device state
   tap         Tap a widget by selector, coordinates, or @N ref from describe
   longpress   Long-press a widget by selector or coordinates
+  double-tap  Double-tap a widget by selector or coordinates
   input       Enter text into a field
   scroll      Scroll in a direction
   scroll-to   Scroll until a widget is visible
@@ -112,6 +114,8 @@ Future<int> _runCommand(String command, List<String> args) {
       return runDoctor(args);
     case 'tap':
       return runTap(args);
+    case 'double-tap':
+      return runDoubleTap(args);
     case 'longpress':
       return runLongpress(args);
     case 'input':

--- a/doc/README.agents.md
+++ b/doc/README.agents.md
@@ -84,6 +84,7 @@ curl -fsSL https://raw.githubusercontent.com/andrzejchm/fdb/main/skills/using-fd
 | `fdb describe` | Compact screen snapshot: interactive elements + visible text |
 | `fdb select on/off` | Widget selection mode |
 | `fdb selected` | Get selected widget |
+| `fdb double-tap --text/--key/--type <selector> [--index N]` \| `--x X --y Y` \| `--at X,Y` | Double-tap a widget or screen coordinates |
 | `fdb tap --text/--key/--type <selector>`, `--at x,y`, or `@N` | Tap a widget, coordinates, or describe ref |
 | `fdb longpress --text/--key/--type <selector> [--duration <ms>]` or `--at x,y` | Long-press a widget or coordinates |
 | `fdb input [--text/--key/--type <selector>] <text>` | Enter text into field |
@@ -183,6 +184,11 @@ fdb tap --text "Submit"                   # tap by visible text
 fdb tap --type "FloatingActionButton"     # tap by widget type
 fdb tap --at 200,400                       # tap absolute screen coordinates
 
+fdb double-tap --key "photo_viewer"       # double-tap by widget key
+fdb double-tap --type "InteractiveViewer" --index 1 # choose a specific match
+fdb double-tap --x 200 --y 400             # double-tap at screen coordinates
+fdb double-tap --at 200,400                # shorthand for --x/--y
+
 fdb longpress --key "photo_card"          # long-press by widget key (default 500ms)
 fdb longpress --text "Hold me"            # long-press by visible text
 fdb longpress --key "item" --duration 1000  # long-press for 1 second
@@ -201,7 +207,7 @@ fdb swipe left                            # swipe from screen center
 fdb swipe up --distance 400              # swipe with custom distance
 ```
 
-Output tokens: `TAPPED=<type> X=<x> Y=<y>`, `LONG_PRESSED=<type> X=<x> Y=<y>`, `INPUT=<type> VALUE=<text>`, `SCROLLED=<DIR> DISTANCE=<n>`, `SCROLLED_TO=<type> X=<x> Y=<y>`, `SWIPED=<DIR> DISTANCE=<n>`
+Output tokens: `TAPPED=<type> X=<x> Y=<y>`, `DOUBLE_TAPPED=<type> X=<x> Y=<y>`, `LONG_PRESSED=<type> X=<x> Y=<y>`, `INPUT=<type> VALUE=<text>`, `SCROLLED=<DIR> DISTANCE=<n>`, `SCROLLED_TO=<type> X=<x> Y=<y>`, `SWIPED=<DIR> DISTANCE=<n>`
 
 ### Status / Kill
 

--- a/example/test_app/lib/main.dart
+++ b/example/test_app/lib/main.dart
@@ -53,6 +53,10 @@ class FdbTestHomePage extends StatefulWidget {
 
 class _FdbTestHomePageState extends State<FdbTestHomePage> {
   int _counter = 0;
+  int _doubleTapCount = 0;
+  int _secondaryDoubleTapCount = 0;
+  int _indexedDoubleTapPrimaryCount = 0;
+  int _indexedDoubleTapSecondaryCount = 0;
   final _textController = TextEditingController();
   late final Timer _heartbeat;
 
@@ -183,6 +187,46 @@ class _FdbTestHomePageState extends State<FdbTestHomePage> {
                 child: const Text('Scroll-To Tests'),
               ),
               const SizedBox(height: 16),
+              GestureDetector(
+                key: const Key('double_tap_target'),
+                onDoubleTap: () {
+                  setState(() {
+                    _doubleTapCount++;
+                  });
+                  developer.log(
+                    'double_tap_target triggered count=$_doubleTapCount',
+                    name: 'fdb_test',
+                  );
+                },
+                child: Container(
+                  width: 200,
+                  height: 60,
+                  color: Colors.purple.shade100,
+                  alignment: Alignment.center,
+                  child: const Text('Double Tap Target'),
+                ),
+              ),
+              const SizedBox(height: 8),
+              GestureDetector(
+                key: const Key('double_tap_target_secondary'),
+                onDoubleTap: () {
+                  setState(() {
+                    _secondaryDoubleTapCount++;
+                  });
+                  developer.log(
+                    'double_tap_target_secondary triggered count=$_secondaryDoubleTapCount',
+                    name: 'fdb_test',
+                  );
+                },
+                child: Container(
+                  width: 200,
+                  height: 60,
+                  color: Colors.purple.shade50,
+                  alignment: Alignment.center,
+                  child: const Text('Double Tap Target'),
+                ),
+              ),
+              const SizedBox(height: 16),
               // GestureDetector for long-press testing
               GestureDetector(
                 key: const Key('longpress_target'),
@@ -195,6 +239,46 @@ class _FdbTestHomePageState extends State<FdbTestHomePage> {
                   color: Colors.teal.shade100,
                   alignment: Alignment.center,
                   child: const Text('Long Press Me'),
+                ),
+              ),
+              const SizedBox(height: 8),
+              GestureDetector(
+                key: const Key('indexed_double_tap_target_primary'),
+                onDoubleTap: () {
+                  setState(() {
+                    _indexedDoubleTapPrimaryCount++;
+                  });
+                  developer.log(
+                    'indexed_double_tap_target_primary triggered count=$_indexedDoubleTapPrimaryCount',
+                    name: 'fdb_test',
+                  );
+                },
+                child: Container(
+                  width: 200,
+                  height: 60,
+                  color: Colors.deepPurple.shade100,
+                  alignment: Alignment.center,
+                  child: const Text('Indexed Double Tap Target'),
+                ),
+              ),
+              const SizedBox(height: 8),
+              GestureDetector(
+                key: const Key('indexed_double_tap_target_secondary'),
+                onDoubleTap: () {
+                  setState(() {
+                    _indexedDoubleTapSecondaryCount++;
+                  });
+                  developer.log(
+                    'indexed_double_tap_target_secondary triggered count=$_indexedDoubleTapSecondaryCount',
+                    name: 'fdb_test',
+                  );
+                },
+                child: Container(
+                  width: 200,
+                  height: 60,
+                  color: Colors.deepPurple.shade50,
+                  alignment: Alignment.center,
+                  child: const Text('Indexed Double Tap Target'),
                 ),
               ),
               const SizedBox(height: 16),

--- a/lib/commands/double_tap.dart
+++ b/lib/commands/double_tap.dart
@@ -1,0 +1,157 @@
+import 'dart:io';
+
+import 'package:fdb/vm_service.dart';
+
+/// Double-taps a widget identified by selector or absolute coordinates.
+///
+/// Usage:
+///   fdb double-tap --key "map_widget"
+///   fdb double-tap --text "Zoom here"
+///   fdb double-tap --type InteractiveViewer [--index 0]
+///   fdb double-tap --x 195 --y 842
+///   fdb double-tap --at 195,842
+Future<int> runDoubleTap(List<String> args) async {
+  String? text;
+  String? key;
+  String? type;
+  int? index;
+  double? x;
+  double? y;
+  var timeoutSeconds = 5;
+
+  for (var i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--text':
+        text = args[++i];
+      case '--key':
+        key = args[++i];
+      case '--type':
+        type = args[++i];
+      case '--index':
+        final rawIndex = args[++i];
+        index = int.tryParse(rawIndex);
+        if (index == null) {
+          stderr.writeln('ERROR: Invalid value for --index: $rawIndex');
+          return 1;
+        }
+      case '--x':
+        final rawX = args[++i];
+        x = double.tryParse(rawX);
+        if (x == null) {
+          stderr.writeln('ERROR: Invalid value for --x: $rawX');
+          return 1;
+        }
+      case '--y':
+        final rawY = args[++i];
+        y = double.tryParse(rawY);
+        if (y == null) {
+          stderr.writeln('ERROR: Invalid value for --y: $rawY');
+          return 1;
+        }
+      case '--at':
+        final rawAt = args[++i];
+        final coords = _parseCoords(rawAt);
+        if (coords == null) {
+          stderr.writeln('ERROR: Invalid value for --at: $rawAt. Expected format: x,y');
+          return 1;
+        }
+        x = coords.$1;
+        y = coords.$2;
+      case '--timeout':
+        final rawTimeout = args[++i];
+        final parsed = int.tryParse(rawTimeout);
+        if (parsed == null) {
+          stderr.writeln('ERROR: Invalid value for --timeout: $rawTimeout');
+          return 1;
+        }
+        timeoutSeconds = parsed;
+      default:
+        stderr.writeln('ERROR: Unknown flag: ${args[i]}');
+        return 1;
+    }
+  }
+
+  final hasCoords = x != null && y != null;
+  final hasSelector = text != null || key != null || type != null;
+  final selectorCount = [text, key, type].where((value) => value != null).length;
+
+  if ((x == null) != (y == null)) {
+    stderr.writeln('ERROR: Both --x and --y are required together');
+    return 1;
+  }
+
+  if (selectorCount > 1) {
+    stderr.writeln('ERROR: Provide exactly one target: --text, --key, --type, --x/--y, or --at');
+    return 1;
+  }
+
+  if (hasSelector == hasCoords) {
+    stderr.writeln('ERROR: Provide exactly one target: --text, --key, --type, --x/--y, or --at');
+    return 1;
+  }
+
+  try {
+    final isolateId = await checkFdbHelper();
+    if (isolateId == null) {
+      stderr.writeln(
+        'ERROR: fdb_helper not detected in running app. '
+        'Add fdb_helper package to your Flutter app and call '
+        'FdbBinding.ensureInitialized() in main()',
+      );
+      return 1;
+    }
+
+    final params = <String, dynamic>{'isolateId': isolateId};
+    if (text != null) params['text'] = text;
+    if (key != null) params['key'] = key;
+    if (type != null) params['type'] = type;
+    if (index != null) params['index'] = index.toString();
+    if (x != null) params['x'] = x.toString();
+    if (y != null) params['y'] = y.toString();
+
+    final deadline = DateTime.now().add(Duration(seconds: timeoutSeconds));
+
+    while (true) {
+      final response = await vmServiceCall('ext.fdb.doubleTap', params: params);
+      final result = unwrapRawExtensionResult(response);
+
+      if (result is Map<String, dynamic>) {
+        final status = result['status'] as String?;
+        final error = result['error'] as String?;
+
+        if (status == 'Success') {
+          final tappedType = result['widgetType'] as String? ?? type ?? 'widget';
+          final tappedX = result['x'] ?? x ?? '';
+          final tappedY = result['y'] ?? y ?? '';
+          stdout.writeln('DOUBLE_TAPPED=$tappedType X=$tappedX Y=$tappedY');
+          return 0;
+        }
+
+        if (error != null) {
+          final isRetryable = error.contains('not found') || error.contains('No hittable element');
+          if (isRetryable && DateTime.now().isBefore(deadline)) {
+            await Future<void>.delayed(const Duration(milliseconds: 500));
+            continue;
+          }
+          stderr.writeln('ERROR: $error');
+          return 1;
+        }
+      }
+
+      stderr.writeln('ERROR: Unexpected response from ext.fdb.doubleTap: $result');
+      return 1;
+    }
+  } catch (e) {
+    stderr.writeln('ERROR: $e');
+    return 1;
+  }
+}
+
+(double, double)? _parseCoords(String value) {
+  final parts = value.split(',');
+  if (parts.length != 2) return null;
+  final x = double.tryParse(parts[0].trim());
+  final y = double.tryParse(parts[1].trim());
+  if (x == null || y == null) return null;
+  return (x, y);
+}

--- a/packages/fdb_helper/lib/src/fdb_binding.dart
+++ b/packages/fdb_helper/lib/src/fdb_binding.dart
@@ -7,6 +7,7 @@ import 'package:flutter/widgets.dart';
 import 'handlers/back_handler.dart';
 import 'handlers/clean_handler.dart';
 import 'handlers/describe_handler.dart';
+import 'handlers/double_tap_handler.dart';
 import 'handlers/input_handler.dart';
 import 'handlers/screenshot_handler.dart';
 import 'handlers/scroll_handler.dart';
@@ -30,6 +31,7 @@ import 'handlers/tap_handler.dart';
 /// - `ext.fdb.describe` — describe the current screen
 /// - `ext.fdb.tap` — tap a widget by key, text, type, or coordinates
 /// - `ext.fdb.longPress` — long-press a widget (same as tap with duration=500ms)
+/// - `ext.fdb.doubleTap` — double-tap a widget by key, text, type, or coordinates
 /// - `ext.fdb.enterText` — enter text into a text field
 /// - `ext.fdb.scroll` — perform a swipe/scroll gesture
 /// - `ext.fdb.scrollTo` — scroll until a target widget becomes visible
@@ -70,6 +72,7 @@ class FdbBinding extends WidgetsFlutterBinding {
         if (!params.containsKey('duration')) 'duration': '500',
       });
     });
+    _registerExtension('ext.fdb.doubleTap', handleDoubleTap);
     _registerExtension('ext.fdb.enterText', handleEnterText);
     _registerExtension('ext.fdb.scroll', handleScroll);
     _registerExtension('ext.fdb.scrollTo', handleScrollTo);

--- a/packages/fdb_helper/lib/src/gesture_dispatcher.dart
+++ b/packages/fdb_helper/lib/src/gesture_dispatcher.dart
@@ -1,15 +1,29 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 
 int _nextPointerId = 1;
 const int _kDeviceId = 1;
 const Duration _kDelay = Duration(milliseconds: 10);
+const Duration _kDoubleTapGap = Duration(milliseconds: 100);
+const Duration _kDoubleTapHold = Duration(milliseconds: 50);
 
 // Process-relative monotonic clock — produces timestamps in the same epoch
 // range as Flutter's frame timestamps (process uptime), which is required for
 // the pointer resampler and VelocityTracker to work correctly.
 // Using DateTime.now().millisecondsSinceEpoch would produce ~56-year offsets.
 final Stopwatch _clock = Stopwatch()..start();
+
+PointerDeviceKind _tapPointerKind() {
+  return switch (defaultTargetPlatform) {
+    TargetPlatform.macOS || TargetPlatform.windows || TargetPlatform.linux => PointerDeviceKind.mouse,
+    _ => PointerDeviceKind.touch,
+  };
+}
+
+int _tapButtons(PointerDeviceKind kind) {
+  return kind == PointerDeviceKind.mouse ? kPrimaryMouseButton : kPrimaryButton;
+}
 
 /// Dispatches a synthetic tap (or long-press) at [globalPosition].
 ///
@@ -22,14 +36,28 @@ Future<void> dispatchTap(
 }) async {
   final pointerId = _nextPointerId++;
   var timeStamp = _clock.elapsed;
+  final kind = _tapPointerKind();
+  final buttons = _tapButtons(kind);
 
   // Batch 1: Add + Down
   GestureBinding.instance.handlePointerEvent(
-    PointerAddedEvent(timeStamp: timeStamp, position: globalPosition, device: _kDeviceId),
+    PointerAddedEvent(
+      timeStamp: timeStamp,
+      position: globalPosition,
+      device: _kDeviceId,
+      kind: kind,
+    ),
   );
   timeStamp += _kDelay;
   GestureBinding.instance.handlePointerEvent(
-    PointerDownEvent(timeStamp: timeStamp, pointer: pointerId, position: globalPosition, device: _kDeviceId),
+    PointerDownEvent(
+      timeStamp: timeStamp,
+      pointer: pointerId,
+      position: globalPosition,
+      device: _kDeviceId,
+      kind: kind,
+      buttons: buttons,
+    ),
   );
   WidgetsBinding.instance.scheduleFrame();
   await Future<void>.delayed(holdDuration);
@@ -37,10 +65,110 @@ Future<void> dispatchTap(
 
   // Batch 2: Up + Remove
   GestureBinding.instance.handlePointerEvent(
-    PointerUpEvent(timeStamp: timeStamp, pointer: pointerId, position: globalPosition, device: _kDeviceId),
+    PointerUpEvent(
+      timeStamp: timeStamp,
+      pointer: pointerId,
+      position: globalPosition,
+      device: _kDeviceId,
+      kind: kind,
+    ),
   );
   GestureBinding.instance.handlePointerEvent(
-    PointerRemovedEvent(timeStamp: timeStamp, position: globalPosition, device: _kDeviceId),
+    PointerRemovedEvent(
+      timeStamp: timeStamp,
+      position: globalPosition,
+      device: _kDeviceId,
+      kind: kind,
+    ),
+  );
+  WidgetsBinding.instance.scheduleFrame();
+  await Future<void>.delayed(_kDelay);
+}
+
+/// Dispatches two taps in quick succession at the same [globalPosition].
+Future<void> dispatchDoubleTap(Offset globalPosition) async {
+  if (_tapPointerKind() == PointerDeviceKind.mouse) {
+    await _dispatchMouseDoubleTap(globalPosition);
+    return;
+  }
+
+  await dispatchTap(globalPosition, holdDuration: _kDoubleTapHold);
+  await Future<void>.delayed(_kDoubleTapGap);
+  await dispatchTap(globalPosition, holdDuration: _kDoubleTapHold);
+}
+
+Future<void> _dispatchMouseDoubleTap(Offset globalPosition) async {
+  final pointerId = _nextPointerId++;
+  var timeStamp = _clock.elapsed;
+  final buttons = _tapButtons(PointerDeviceKind.mouse);
+
+  GestureBinding.instance.handlePointerEvent(
+    PointerAddedEvent(
+      timeStamp: timeStamp,
+      position: globalPosition,
+      device: _kDeviceId,
+      kind: PointerDeviceKind.mouse,
+    ),
+  );
+
+  timeStamp += _kDelay;
+  GestureBinding.instance.handlePointerEvent(
+    PointerDownEvent(
+      timeStamp: timeStamp,
+      pointer: pointerId,
+      position: globalPosition,
+      device: _kDeviceId,
+      kind: PointerDeviceKind.mouse,
+      buttons: buttons,
+    ),
+  );
+  WidgetsBinding.instance.scheduleFrame();
+  await Future<void>.delayed(_kDoubleTapHold);
+
+  timeStamp += _kDoubleTapHold;
+  GestureBinding.instance.handlePointerEvent(
+    PointerUpEvent(
+      timeStamp: timeStamp,
+      pointer: pointerId,
+      position: globalPosition,
+      device: _kDeviceId,
+      kind: PointerDeviceKind.mouse,
+    ),
+  );
+  WidgetsBinding.instance.scheduleFrame();
+  await Future<void>.delayed(_kDoubleTapGap);
+
+  timeStamp += _kDoubleTapGap;
+  GestureBinding.instance.handlePointerEvent(
+    PointerDownEvent(
+      timeStamp: timeStamp,
+      pointer: pointerId,
+      position: globalPosition,
+      device: _kDeviceId,
+      kind: PointerDeviceKind.mouse,
+      buttons: buttons,
+    ),
+  );
+  WidgetsBinding.instance.scheduleFrame();
+  await Future<void>.delayed(_kDoubleTapHold);
+
+  timeStamp += _kDoubleTapHold;
+  GestureBinding.instance.handlePointerEvent(
+    PointerUpEvent(
+      timeStamp: timeStamp,
+      pointer: pointerId,
+      position: globalPosition,
+      device: _kDeviceId,
+      kind: PointerDeviceKind.mouse,
+    ),
+  );
+  GestureBinding.instance.handlePointerEvent(
+    PointerRemovedEvent(
+      timeStamp: timeStamp,
+      position: globalPosition,
+      device: _kDeviceId,
+      kind: PointerDeviceKind.mouse,
+    ),
   );
   WidgetsBinding.instance.scheduleFrame();
   await Future<void>.delayed(_kDelay);

--- a/packages/fdb_helper/lib/src/handlers/double_tap_handler.dart
+++ b/packages/fdb_helper/lib/src/handlers/double_tap_handler.dart
@@ -1,0 +1,336 @@
+import 'dart:convert';
+import 'dart:developer' as developer;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+
+import '../element_tree_finder.dart';
+import '../gesture_dispatcher.dart';
+import '../widget_matcher.dart';
+import 'handler_utils.dart';
+
+typedef _DoubleTapTarget = ({GestureTapCallback callback, Element element});
+
+Future<developer.ServiceExtensionResponse> handleDoubleTap(
+  String method,
+  Map<String, String> params,
+) async {
+  try {
+    final matcher = WidgetMatcher.fromParams(params);
+
+    if (matcher is CoordinatesMatcher) {
+      final targetElement = _findElementAtOffset(matcher.offset);
+      if (targetElement == null) {
+        return errorResponse('No element found at (${matcher.x}, ${matcher.y})');
+      }
+
+      final doubleTapTarget = _findDoubleTapTargetForElement(targetElement);
+
+      final didDoubleTap = await _performDoubleTap(matcher.offset);
+      if (!didDoubleTap) {
+        return errorResponse(
+          'No double-tap target found at (${matcher.x}, ${matcher.y}) on macOS',
+        );
+      }
+      return developer.ServiceExtensionResponse.result(
+        jsonEncode({
+          'status': 'Success',
+          'widgetType': (doubleTapTarget?.element ?? targetElement).widget.runtimeType.toString(),
+          'x': matcher.x,
+          'y': matcher.y,
+        }),
+      );
+    }
+
+    final (:element, :matchCount) = findHittableElement(matcher);
+    if (element == null) {
+      if (matchCount > 1) {
+        return errorResponse(
+          'Found $matchCount elements matching the selector. '
+          'Use --index to specify which one (0-based).',
+        );
+      }
+      return errorResponse('No hittable element found for matcher');
+    }
+
+    final renderObject = element.renderObject;
+    if (renderObject is! RenderBox) {
+      return errorResponse('Element has no RenderBox');
+    }
+
+    final center = renderObject.size.center(Offset.zero);
+    final globalCenter = renderObject.localToGlobal(center);
+    final doubleTapTarget = _findDoubleTapTargetForElement(element);
+    if (doubleTapTarget == null) {
+      return errorResponse('Matched element has no onDoubleTap handler');
+    }
+
+    final didDoubleTap = await _performDoubleTap(globalCenter, element: doubleTapTarget.element);
+    if (!didDoubleTap) {
+      return errorResponse('No double-tap target found for matcher on macOS');
+    }
+
+    final widgetType = doubleTapTarget.element.widget.runtimeType.toString();
+    return developer.ServiceExtensionResponse.result(
+      jsonEncode({
+        'status': 'Success',
+        'widgetType': widgetType,
+        'x': globalCenter.dx,
+        'y': globalCenter.dy,
+      }),
+    );
+  } on ArgumentError catch (e) {
+    return errorResponse(e.message.toString());
+  } catch (e) {
+    return errorResponse('Double-tap failed: $e');
+  }
+}
+
+Future<bool> _performDoubleTap(Offset globalPosition, {Element? element}) async {
+  if (defaultTargetPlatform == TargetPlatform.macOS) {
+    final callback = element != null
+        ? _findDoubleTapTargetForElement(element)?.callback
+        : _findDoubleTapCallbackAtOffset(globalPosition);
+    if (callback != null) {
+      callback();
+      WidgetsBinding.instance.scheduleFrame();
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      return true;
+    }
+
+    return false;
+  }
+
+  await dispatchDoubleTap(globalPosition);
+  return true;
+}
+
+GestureTapCallback? _findDoubleTapCallbackAtOffset(Offset globalPosition) {
+  final matchedElement = _findElementAtOffset(globalPosition);
+  if (matchedElement != null) {
+    final doubleTapTarget = _findDoubleTapTargetForElement(matchedElement);
+    if (doubleTapTarget != null) {
+      return doubleTapTarget.callback;
+    }
+  }
+
+  final hitTestCallback = _findDoubleTapCallbackFromHitTest(globalPosition);
+  if (hitTestCallback != null) {
+    return hitTestCallback;
+  }
+
+  final root = WidgetsBinding.instance.rootElement;
+  if (root == null) {
+    return null;
+  }
+
+  GestureTapCallback? matchedCallback;
+  double? matchedArea;
+
+  void visit(Element element) {
+    final callback = _doubleTapCallbackForWidget(element.widget);
+    if (callback != null) {
+      final bounds = _subtreeBounds(element);
+      if (bounds != null && bounds.contains(globalPosition)) {
+        final area = bounds.width * bounds.height;
+        if (matchedArea == null || area <= matchedArea!) {
+          matchedCallback = callback;
+          matchedArea = area;
+        }
+      }
+    }
+
+    element.visitChildren(visit);
+  }
+
+  root.visitChildren(visit);
+
+  return matchedCallback;
+}
+
+Element? _findElementAtOffset(Offset globalPosition) {
+  final root = WidgetsBinding.instance.rootElement;
+  if (root == null) {
+    return null;
+  }
+
+  final viewId = WidgetsBinding.instance.platformDispatcher.views.first.viewId;
+  final hitTestResult = HitTestResult();
+  WidgetsBinding.instance.hitTestInView(hitTestResult, globalPosition, viewId);
+
+  final hitRenderObjects = hitTestResult.path.map((entry) => entry.target).whereType<RenderObject>().toSet();
+
+  if (hitRenderObjects.isNotEmpty) {
+    Element? matchedHitElement;
+    int? matchedHitDepth;
+
+    void visitHit(Element element, int depth) {
+      final renderObject = element.renderObject;
+      if (renderObject != null && hitRenderObjects.contains(renderObject)) {
+        if (matchedHitDepth == null || depth >= matchedHitDepth!) {
+          matchedHitElement = element;
+          matchedHitDepth = depth;
+        }
+      }
+
+      element.visitChildren((child) {
+        visitHit(child, depth + 1);
+      });
+    }
+
+    root.visitChildren((child) {
+      visitHit(child, 1);
+    });
+
+    if (matchedHitElement != null) {
+      return matchedHitElement;
+    }
+  }
+
+  Element? matchedElement;
+  int? matchedDepth;
+
+  void visit(Element element, int depth) {
+    final renderObject = element.renderObject;
+    if (renderObject is RenderBox && renderObject.hasSize && renderObject.attached) {
+      final rect = renderObject.localToGlobal(Offset.zero) & renderObject.size;
+      if (rect.contains(globalPosition) && (matchedDepth == null || depth >= matchedDepth!)) {
+        matchedElement = element;
+        matchedDepth = depth;
+      }
+    }
+
+    element.visitChildren((child) {
+      visit(child, depth + 1);
+    });
+  }
+
+  root.visitChildren((child) {
+    visit(child, 1);
+  });
+
+  return matchedElement;
+}
+
+Rect? _subtreeBounds(Element element) {
+  Rect? bounds;
+
+  void visit(Element current) {
+    final renderObject = current.renderObject;
+    if (renderObject is RenderBox && renderObject.hasSize && renderObject.attached) {
+      final rect = renderObject.localToGlobal(Offset.zero) & renderObject.size;
+      bounds = bounds?.expandToInclude(rect) ?? rect;
+    }
+
+    current.visitChildren(visit);
+  }
+
+  visit(element);
+  return bounds;
+}
+
+GestureTapCallback? _findDoubleTapCallbackFromHitTest(Offset globalPosition) {
+  final viewId = WidgetsBinding.instance.platformDispatcher.views.first.viewId;
+  final result = HitTestResult();
+  WidgetsBinding.instance.hitTestInView(result, globalPosition, viewId);
+
+  for (final entry in result.path.toList().reversed) {
+    final target = entry.target;
+    if (target is! RenderObject) {
+      continue;
+    }
+
+    final debugCreator = target.debugCreator;
+    if (debugCreator is! DebugCreator) {
+      continue;
+    }
+
+    final doubleTapTarget = _findDoubleTapTargetForElement(debugCreator.element);
+    if (doubleTapTarget != null) {
+      return doubleTapTarget.callback;
+    }
+  }
+
+  return null;
+}
+
+_DoubleTapTarget? _findDoubleTapTargetForElement(Element element) {
+  final ownCallback = _doubleTapCallbackForElementWidget(element);
+  if (ownCallback != null) {
+    return (callback: ownCallback, element: element);
+  }
+
+  _DoubleTapTarget? descendantTarget;
+  void visitDescendant(Element descendant) {
+    if (descendantTarget != null) {
+      return;
+    }
+
+    final callback = _doubleTapCallbackForElementWidget(descendant);
+    if (callback != null) {
+      descendantTarget = (callback: callback, element: descendant);
+      return;
+    }
+
+    descendant.visitChildren(visitDescendant);
+  }
+
+  element.visitChildren(visitDescendant);
+  if (descendantTarget != null) {
+    return descendantTarget;
+  }
+
+  _DoubleTapTarget? ancestorTarget;
+  element.visitAncestorElements((ancestor) {
+    final callback = _doubleTapCallbackForElementWidget(ancestor);
+    if (callback == null) {
+      return true;
+    }
+    ancestorTarget = (callback: callback, element: ancestor);
+    return false;
+  });
+  return ancestorTarget;
+}
+
+GestureTapCallback? _doubleTapCallbackForElementWidget(Element element) {
+  final widgetCallback = _doubleTapCallbackForWidget(element.widget);
+  if (widgetCallback != null) {
+    return widgetCallback;
+  }
+
+  if (element.widget is RawGestureDetector) {
+    final widget = element.widget as RawGestureDetector;
+    final factory = widget.gestures[DoubleTapGestureRecognizer];
+    if (factory != null) {
+      final recognizer = factory.constructor();
+      try {
+        if (recognizer is DoubleTapGestureRecognizer) {
+          factory.initializer(recognizer);
+          final callback = recognizer.onDoubleTap;
+          if (callback != null) {
+            return callback;
+          }
+        }
+      } finally {
+        recognizer.dispose();
+      }
+    }
+  }
+
+  return null;
+}
+
+GestureTapCallback? _doubleTapCallbackForWidget(Widget widget) {
+  if (widget is GestureDetector) {
+    return widget.onDoubleTap;
+  }
+  if (widget is InkWell) {
+    return widget.onDoubleTap;
+  }
+  if (widget is InkResponse) {
+    return widget.onDoubleTap;
+  }
+  return null;
+}

--- a/skills/using-fdb/SKILL.md
+++ b/skills/using-fdb/SKILL.md
@@ -21,9 +21,9 @@ dart pub global activate --source git https://github.com/andrzejchm/fdb.git
 
 Verify: `fdb status`
 
-## fdb_helper setup (required for tap, longpress, input, scroll, scroll-to, back)
+## fdb_helper setup (required for tap, double-tap, longpress, input, scroll, scroll-to, back)
 
-The `tap`, `longpress`, `input`, `scroll`, `scroll-to`, and `back` commands require `fdb_helper` to be added to the Flutter app under test.
+The `tap`, `double-tap`, `longpress`, `input`, `scroll`, `scroll-to`, and `back` commands require `fdb_helper` to be added to the Flutter app under test.
 
 **`pubspec.yaml`:**
 ```yaml
@@ -189,6 +189,21 @@ fdb longpress --at 200,400 --duration 1000   # long-press coordinates for 1 seco
 ```
 
 Output: `LONG_PRESSED=<type|coordinates> X=<x> Y=<y>`
+
+### Double-tap a widget
+
+Requires `fdb_helper` in the app (see setup section above).
+
+```bash
+fdb double-tap --key "map_widget"         # double-tap by widget key
+fdb double-tap --text "Zoom here"         # double-tap by visible text
+fdb double-tap --type "InteractiveViewer" # double-tap by widget type
+fdb double-tap --type "InteractiveViewer" --index 1 # choose a specific match
+fdb double-tap --x 200 --y 400             # double-tap at screen coordinates
+fdb double-tap --at 200,400                # shorthand for --x/--y
+```
+
+Output: `DOUBLE_TAPPED=<type> X=<x> Y=<y>`
 
 ### Enter text
 


### PR DESCRIPTION
Flutter apps that rely on double-tap gestures could not be exercised through fdb, which left common zoom and card interactions out of reach for agent-driven testing. This adds a dedicated `double-tap` command so those flows can be exercised through selectors or coordinates, with coverage in the test app and verification tasks.

Closes #32