### PR TITLE
feat: add fdb wait and fix macOS reload detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ fdb kill
 | `fdb scroll <direction> [--at x,y] [--distance px]` | Scroll in a direction |
 | `fdb scroll --from x,y --to x,y` | Drag gesture between two points |
 | `fdb scroll-to --text/--key/--type <selector> [--index N]` | Scroll until widget is visible |
+| `fdb wait --key/--text/--type/--route <selector> --present\|--absent [--timeout <ms>]` | Wait for a widget or route condition without shell polling |
 | `fdb swipe <direction> [--key/--text/--type <selector>]` | Swipe widget (PageView, Dismissible) |
 | `fdb back` | Navigate back (Navigator.maybePop) |
 | `fdb deeplink <url>` | Open a deep link |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1019,6 +1019,91 @@ tasks:
         {{.FDB}} back >/dev/null 2>&1
         sleep 1
 
+  test:wait:
+    desc: Wait until widgets and routes change state
+    dir: '{{.TEST_APP}}'
+    cmds:
+      - |
+        echo "==> [wait] Waiting for home route to be present"
+        OUTPUT=$({{.FDB}} wait --route "/" --present --timeout 3000 2>&1)
+        EXIT_CODE=$?
+        echo "$OUTPUT"
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "FAIL: fdb wait --route / --present exited with code $EXIT_CODE" >&2
+          exit 1
+        fi
+        if echo "$OUTPUT" | grep -q "CONDITION_MET=present ROUTE=/"; then
+          echo "PASS: fdb wait --route / --present"
+        else
+          echo "FAIL: fdb wait --route / --present - CONDITION_MET=present ROUTE=/ not found in output" >&2
+          exit 1
+        fi
+
+        echo "==> [wait] Tapping 'show_delayed' to trigger delayed widget"
+        {{.FDB}} tap --key "show_delayed" >/dev/null 2>&1
+
+        echo "==> [wait] Waiting for delayed_button to appear"
+        OUTPUT=$({{.FDB}} wait --key "delayed_button" --present --timeout 10000 2>&1)
+        EXIT_CODE=$?
+        echo "$OUTPUT"
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "FAIL: fdb wait --key delayed_button --present exited with code $EXIT_CODE" >&2
+          exit 1
+        fi
+        if echo "$OUTPUT" | grep -q "CONDITION_MET=present KEY=delayed_button"; then
+          echo "PASS: fdb wait --key delayed_button --present"
+        else
+          echo "FAIL: fdb wait --key delayed_button --present - CONDITION_MET=present KEY=delayed_button not found in output" >&2
+          exit 1
+        fi
+
+        echo "==> [wait] Waiting for delayed button text to be present"
+        OUTPUT=$({{.FDB}} wait --text "I was delayed" --present --timeout 3000 2>&1)
+        EXIT_CODE=$?
+        echo "$OUTPUT"
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "FAIL: fdb wait --text 'I was delayed' --present exited with code $EXIT_CODE" >&2
+          exit 1
+        fi
+        if echo "$OUTPUT" | grep -q "CONDITION_MET=present TEXT=I was delayed"; then
+          echo "PASS: fdb wait --text 'I was delayed' --present"
+        else
+          echo "FAIL: fdb wait --text 'I was delayed' --present - CONDITION_MET=present TEXT=I was delayed not found in output" >&2
+          exit 1
+        fi
+
+        echo "==> [wait] Waiting for CircularProgressIndicator to stay absent"
+        OUTPUT=$({{.FDB}} wait --type "CircularProgressIndicator" --absent --timeout 1000 2>&1)
+        EXIT_CODE=$?
+        echo "$OUTPUT"
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "FAIL: fdb wait --type CircularProgressIndicator --absent exited with code $EXIT_CODE" >&2
+          exit 1
+        fi
+        if echo "$OUTPUT" | grep -q "CONDITION_MET=absent TYPE=CircularProgressIndicator"; then
+          echo "PASS: fdb wait --type CircularProgressIndicator --absent"
+        else
+          echo "FAIL: fdb wait --type CircularProgressIndicator --absent - CONDITION_MET=absent TYPE=CircularProgressIndicator not found in output" >&2
+          exit 1
+        fi
+
+        echo "==> [wait] Waiting for a widget that never appears to time out"
+        set +e
+        OUTPUT=$({{.FDB}} wait --key "nonexistent_widget_xyz" --present --timeout 1000 2>&1)
+        EXIT_CODE=$?
+        set -e
+        echo "$OUTPUT"
+        if [ $EXIT_CODE -ne 1 ]; then
+          echo "FAIL: fdb wait timeout should exit 1, got $EXIT_CODE" >&2
+          exit 1
+        fi
+        if echo "$OUTPUT" | grep -q "ERROR: Timeout after 1000ms waiting for present KEY=nonexistent_widget_xyz"; then
+          echo "PASS: fdb wait timeout"
+        else
+          echo "FAIL: fdb wait timeout - expected timeout error output" >&2
+          exit 1
+        fi
+
   test:swipe:
     desc: Swipe the screen
     dir: '{{.TEST_APP}}'
@@ -1271,6 +1356,7 @@ tasks:
       - task: test:input
       - task: test:scroll
       - task: test:scroll-to
+      - task: test:wait
       - task: test:swipe
       - task: test:back
       - task: test:clean

--- a/bin/fdb.dart
+++ b/bin/fdb.dart
@@ -25,6 +25,7 @@ import 'package:fdb/commands/status.dart';
 import 'package:fdb/commands/swipe.dart';
 import 'package:fdb/commands/tap.dart';
 import 'package:fdb/commands/tree.dart';
+import 'package:fdb/commands/wait.dart';
 import 'package:fdb/constants.dart';
 
 const usage = '''
@@ -47,6 +48,7 @@ Commands:
   input       Enter text into a field
   scroll      Scroll in a direction
   scroll-to   Scroll until a widget is visible
+  wait        Wait until a widget or route changes state
   swipe       Swipe a widget or screen (PageView, Dismissible)
   back        Navigate back (Navigator.maybePop)
   clean       Clear app cache and data directories (requires fdb_helper)
@@ -124,6 +126,8 @@ Future<int> _runCommand(String command, List<String> args) {
       return runScroll(args);
     case 'scroll-to':
       return runScrollTo(args);
+    case 'wait':
+      return runWait(args);
     case 'swipe':
       return runSwipe(args);
     case 'back':

--- a/doc/README.agents.md
+++ b/doc/README.agents.md
@@ -90,6 +90,7 @@ curl -fsSL https://raw.githubusercontent.com/andrzejchm/fdb/main/skills/using-fd
 | `fdb input [--text/--key/--type <selector>] <text>` | Enter text into field |
 | `fdb scroll <direction> [--at x,y]` | Scroll screen |
 | `fdb scroll-to --text/--key/--type <selector> [--index N]` | Scroll until widget is visible |
+| `fdb wait --key/--text/--type/--route <selector> --present\|--absent [--timeout <ms>]` | Wait for UI state changes without manual polling loops |
 | `fdb swipe <direction> [--key/--text/--type <selector>]` | Swipe widget (PageView, Dismissible) |
 | `fdb back` | Navigate back (Navigator.maybePop) |
 | `fdb status` | Check if app is running |

--- a/example/test_app/lib/main.dart
+++ b/example/test_app/lib/main.dart
@@ -57,6 +57,7 @@ class _FdbTestHomePageState extends State<FdbTestHomePage> {
   int _secondaryDoubleTapCount = 0;
   int _indexedDoubleTapPrimaryCount = 0;
   int _indexedDoubleTapSecondaryCount = 0;
+  bool _showDelayed = false;
   final _textController = TextEditingController();
   late final Timer _heartbeat;
 
@@ -186,6 +187,25 @@ class _FdbTestHomePageState extends State<FdbTestHomePage> {
                     Navigator.pushNamed(context, scrollToTestRoute),
                 child: const Text('Scroll-To Tests'),
               ),
+              const SizedBox(height: 8),
+              ElevatedButton(
+                key: const Key('show_delayed'),
+                onPressed: () async {
+                  await Future<void>.delayed(const Duration(seconds: 2));
+                  if (mounted) {
+                    setState(() {
+                      _showDelayed = true;
+                    });
+                  }
+                },
+                child: const Text('Show Delayed'),
+              ),
+              if (_showDelayed)
+                ElevatedButton(
+                  key: const Key('delayed_button'),
+                  onPressed: () {},
+                  child: const Text('I was delayed'),
+                ),
               const SizedBox(height: 16),
               GestureDetector(
                 key: const Key('double_tap_target'),

--- a/lib/commands/reload.dart
+++ b/lib/commands/reload.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:fdb/constants.dart';
+import 'package:fdb/log_marker_detector.dart';
 import 'package:fdb/process_utils.dart';
 
 Future<int> runReload(List<String> args) async {
@@ -26,8 +27,11 @@ Future<int> runReload(List<String> args) async {
   while (stopwatch.elapsed.inSeconds < reloadTimeoutSeconds) {
     await Future<void>.delayed(const Duration(milliseconds: 500));
     final logContent = File(logFile).readAsStringSync();
-    final newContent = logContent.substring(logBefore.length);
-    if (newContent.contains('Reloaded')) {
+    if (didLogGainMarker(
+      before: logBefore,
+      after: logContent,
+      marker: 'Reloaded',
+    )) {
       stdout.writeln('RELOADED in ${stopwatch.elapsedMilliseconds}ms');
       return 0;
     }

--- a/lib/commands/restart.dart
+++ b/lib/commands/restart.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:fdb/constants.dart';
+import 'package:fdb/log_marker_detector.dart';
 import 'package:fdb/process_utils.dart';
 
 Future<int> runRestart(List<String> args) async {
@@ -26,8 +27,11 @@ Future<int> runRestart(List<String> args) async {
   while (stopwatch.elapsed.inSeconds < restartTimeoutSeconds) {
     await Future<void>.delayed(const Duration(milliseconds: 500));
     final logContent = File(logFile).readAsStringSync();
-    final newContent = logContent.substring(logBefore.length);
-    if (newContent.contains('Restarted')) {
+    if (didLogGainMarker(
+      before: logBefore,
+      after: logContent,
+      marker: 'Restarted',
+    )) {
       stdout.writeln('RESTARTED in ${stopwatch.elapsedMilliseconds}ms');
       return 0;
     }

--- a/lib/commands/wait.dart
+++ b/lib/commands/wait.dart
@@ -1,0 +1,128 @@
+import 'dart:io';
+
+import 'package:fdb/vm_service.dart';
+
+Future<int> runWait(List<String> args) async {
+  String? text;
+  String? key;
+  String? type;
+  String? route;
+  String? condition;
+  var timeoutMs = 10000;
+
+  for (var i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--text':
+        if (i + 1 >= args.length) {
+          stderr.writeln('ERROR: Missing value for --text');
+          return 1;
+        }
+        text = args[++i];
+      case '--key':
+        if (i + 1 >= args.length) {
+          stderr.writeln('ERROR: Missing value for --key');
+          return 1;
+        }
+        key = args[++i];
+      case '--type':
+        if (i + 1 >= args.length) {
+          stderr.writeln('ERROR: Missing value for --type');
+          return 1;
+        }
+        type = args[++i];
+      case '--route':
+        if (i + 1 >= args.length) {
+          stderr.writeln('ERROR: Missing value for --route');
+          return 1;
+        }
+        route = args[++i];
+      case '--present':
+        condition = condition == null ? 'present' : 'invalid';
+      case '--absent':
+        condition = condition == null ? 'absent' : 'invalid';
+      case '--timeout':
+        if (i + 1 >= args.length) {
+          stderr.writeln('ERROR: Missing value for --timeout');
+          return 1;
+        }
+        final rawTimeout = args[++i];
+        final parsed = int.tryParse(rawTimeout);
+        if (parsed == null) {
+          stderr.writeln('ERROR: Invalid value for --timeout: $rawTimeout');
+          return 1;
+        }
+        timeoutMs = parsed;
+      default:
+        stderr.writeln('ERROR: Unknown flag: ${args[i]}');
+        return 1;
+    }
+  }
+
+  if (condition == null || condition == 'invalid') {
+    stderr.writeln('ERROR: Missing required flag: --present or --absent');
+    return 1;
+  }
+
+  final selectorCount = [key, text, type, route].where((value) => value != null).length;
+  if (selectorCount != 1) {
+    stderr.writeln('ERROR: Missing selector: use --key, --text, --type, or --route');
+    return 1;
+  }
+
+  try {
+    final isolateId = await checkFdbHelper();
+    if (isolateId == null) {
+      stderr.writeln(
+        'ERROR: fdb_helper not detected in running app. '
+        'Add fdb_helper package to your Flutter app and call '
+        'FdbBinding.ensureInitialized() in main()',
+      );
+      return 1;
+    }
+
+    final params = <String, String>{
+      'isolateId': isolateId,
+      'condition': condition,
+      'timeout': timeoutMs.toString(),
+    };
+    if (text != null) params['text'] = text;
+    if (key != null) params['key'] = key;
+    if (type != null) params['type'] = type;
+    if (route != null) params['route'] = route;
+
+    final response = await vmServiceCall(
+      'ext.fdb.waitFor',
+      params: params,
+      timeout: Duration(milliseconds: timeoutMs + 5000),
+    );
+    final result = unwrapRawExtensionResult(response);
+
+    if (result is Map<String, dynamic>) {
+      final status = result['status'] as String?;
+      final error = result['error'] as String?;
+
+      if (status == 'Success') {
+        stdout.writeln('CONDITION_MET=$condition ${_selectorToken(key, text, type, route)}');
+        return 0;
+      }
+
+      if (error != null) {
+        stderr.writeln('ERROR: $error');
+        return 1;
+      }
+    }
+
+    stderr.writeln('ERROR: Unexpected response from ext.fdb.waitFor: $result');
+    return 1;
+  } catch (e) {
+    stderr.writeln('ERROR: $e');
+    return 1;
+  }
+}
+
+String _selectorToken(String? key, String? text, String? type, String? route) {
+  if (key != null) return 'KEY=$key';
+  if (text != null) return 'TEXT=$text';
+  if (type != null) return 'TYPE=$type';
+  return 'ROUTE=$route';
+}

--- a/lib/log_marker_detector.dart
+++ b/lib/log_marker_detector.dart
@@ -1,0 +1,18 @@
+bool didLogGainMarker({
+  required String before,
+  required String after,
+  required String marker,
+}) {
+  if (before == after) {
+    return false;
+  }
+
+  final sharedLength = before.length < after.length ? before.length : after.length;
+  var firstDiff = 0;
+  while (firstDiff < sharedLength && before.codeUnitAt(firstDiff) == after.codeUnitAt(firstDiff)) {
+    firstDiff++;
+  }
+
+  final searchStart = firstDiff >= marker.length ? firstDiff - marker.length + 1 : 0;
+  return after.substring(searchStart).contains(marker);
+}

--- a/packages/fdb_helper/lib/src/fdb_binding.dart
+++ b/packages/fdb_helper/lib/src/fdb_binding.dart
@@ -15,6 +15,7 @@ import 'handlers/scroll_to_handler.dart';
 import 'handlers/shared_prefs_handler.dart';
 import 'handlers/swipe_handler.dart';
 import 'handlers/tap_handler.dart';
+import 'handlers/wait_handler.dart';
 
 /// A custom binding that registers VM service extensions for widget interaction.
 ///
@@ -35,6 +36,7 @@ import 'handlers/tap_handler.dart';
 /// - `ext.fdb.enterText` — enter text into a text field
 /// - `ext.fdb.scroll` — perform a swipe/scroll gesture
 /// - `ext.fdb.scrollTo` — scroll until a target widget becomes visible
+/// - `ext.fdb.waitFor` — wait until a widget or route is present or absent
 /// - `ext.fdb.swipe` — swipe in a direction
 /// - `ext.fdb.back` — trigger Navigator.maybePop()
 /// - `ext.fdb.clean` — delete app storage directories
@@ -76,6 +78,7 @@ class FdbBinding extends WidgetsFlutterBinding {
     _registerExtension('ext.fdb.enterText', handleEnterText);
     _registerExtension('ext.fdb.scroll', handleScroll);
     _registerExtension('ext.fdb.scrollTo', handleScrollTo);
+    _registerExtension('ext.fdb.waitFor', handleWaitFor);
     _registerExtension('ext.fdb.swipe', handleSwipe);
     _registerExtension('ext.fdb.back', handleBack);
     _registerExtension('ext.fdb.clean', handleClean);

--- a/packages/fdb_helper/lib/src/handlers/wait_handler.dart
+++ b/packages/fdb_helper/lib/src/handlers/wait_handler.dart
@@ -1,0 +1,126 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:developer' as developer;
+
+import 'package:flutter/widgets.dart';
+
+import '../element_tree_finder.dart';
+import '../widget_matcher.dart';
+import 'handler_utils.dart';
+
+const _pollInterval = Duration(milliseconds: 200);
+
+Future<developer.ServiceExtensionResponse> handleWaitFor(
+  String method,
+  Map<String, String> params,
+) async {
+  try {
+    final condition = params['condition'];
+    if (condition != 'present' && condition != 'absent') {
+      return errorResponse('condition must be present or absent');
+    }
+    final resolvedCondition = condition as String;
+
+    final timeout = int.tryParse(params['timeout'] ?? '10000');
+    if (timeout == null) {
+      return errorResponse('timeout must be a valid integer');
+    }
+
+    final route = params['route'];
+    WidgetMatcher? matcher;
+    if (route == null) {
+      matcher = WidgetMatcher.fromParams(params);
+      if (matcher is FocusedMatcher || matcher is CoordinatesMatcher) {
+        return errorResponse('wait supports only --key, --text, --type, or --route');
+      }
+    }
+
+    final selectorDescription = _selectorDescription(
+      key: params['key'],
+      text: params['text'],
+      type: params['type'],
+      route: route,
+    );
+    if (selectorDescription == null) {
+      return errorResponse('Missing selector: use --key, --text, --type, or --route');
+    }
+
+    final deadline = DateTime.now().add(Duration(milliseconds: timeout));
+
+    while (true) {
+      if (_conditionMet(
+        condition: resolvedCondition,
+        matcher: matcher,
+        route: route,
+      )) {
+        return developer.ServiceExtensionResponse.result(
+          jsonEncode({
+            'status': 'Success',
+            'condition': resolvedCondition,
+            'selector': selectorDescription,
+          }),
+        );
+      }
+
+      if (DateTime.now().isAfter(deadline) || DateTime.now().isAtSameMomentAs(deadline)) {
+        return errorResponse(
+          'Timeout after ${timeout}ms waiting for $resolvedCondition $selectorDescription',
+        );
+      }
+
+      await Future<void>.delayed(_pollInterval);
+    }
+  } on ArgumentError catch (e) {
+    return errorResponse(e.message.toString());
+  } catch (e) {
+    return errorResponse('waitFor failed: $e');
+  }
+}
+
+bool _conditionMet({
+  required String condition,
+  required WidgetMatcher? matcher,
+  required String? route,
+}) {
+  if (route != null) {
+    final currentRouteName = _currentRouteName();
+    return condition == 'present' ? currentRouteName == route : currentRouteName != route;
+  }
+
+  final result = findHittableElement(matcher!);
+  if (condition == 'present') {
+    return result.element != null;
+  }
+  return result.element == null && result.matchCount == 0;
+}
+
+String? _currentRouteName() {
+  final root = WidgetsBinding.instance.rootElement;
+  if (root == null) return null;
+
+  String? routeName;
+
+  void visit(Element element) {
+    final route = ModalRoute.of(element);
+    if (route != null && route.isCurrent && route.settings.name != null) {
+      routeName = route.settings.name;
+    }
+    element.visitChildren(visit);
+  }
+
+  visit(root);
+  return routeName;
+}
+
+String? _selectorDescription({
+  required String? key,
+  required String? text,
+  required String? type,
+  required String? route,
+}) {
+  if (key != null) return 'KEY=$key';
+  if (text != null) return 'TEXT=$text';
+  if (type != null) return 'TYPE=$type';
+  if (route != null) return 'ROUTE=$route';
+  return null;
+}

--- a/skills/using-fdb/SKILL.md
+++ b/skills/using-fdb/SKILL.md
@@ -401,6 +401,7 @@ fdb longpress --key "photo_card"           # long-press to open context menu
 fdb screenshot                             # verify result visually
 fdb input --key "search_field" "flutter"   # type into a text field
 fdb tap --text "Search"                    # tap the search button
+fdb wait --key "loading_spinner" --absent  # wait in-app instead of shell sleep loops
 fdb scroll down                            # scroll to reveal more content
 fdb scroll-to --key "list_item_42"         # scroll until a specific item is visible
 fdb swipe left --key "photo_card"          # swipe a PageView card left

--- a/test/log_marker_detector_test.dart
+++ b/test/log_marker_detector_test.dart
@@ -1,0 +1,42 @@
+import 'package:fdb/log_marker_detector.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('didLogGainMarker', () {
+    test('detects marker in appended content', () {
+      const before = 'line 1\nline 2\n';
+      const after = 'line 1\nline 2\nReloaded 0 libraries in 44ms.\n';
+
+      final result = didLogGainMarker(
+        before: before,
+        after: after,
+        marker: 'Reloaded',
+      );
+
+      expect(result, isTrue);
+    });
+
+    test('detects marker when the log tail is rewritten before prior eof', () {
+      const before =
+          'header\n'
+          'older log line\n'
+          'tail AAAAA heartbeat counter=0\n'
+          'tail BBBBB heartbeat counter=0\n';
+      const after =
+          'header\n'
+          'older log line\n'
+          'Performing hot reload...       \n'
+          'Reloaded 0 libraries in 45ms.\n';
+
+      expect(after.length, equals(before.length));
+
+      final result = didLogGainMarker(
+        before: before,
+        after: after,
+        marker: 'Reloaded',
+      );
+
+      expect(result, isTrue);
+    });
+  });
+}

--- a/test/log_marker_detector_test.dart
+++ b/test/log_marker_detector_test.dart
@@ -17,13 +17,11 @@ void main() {
     });
 
     test('detects marker when the log tail is rewritten before prior eof', () {
-      const before =
-          'header\n'
+      const before = 'header\n'
           'older log line\n'
           'tail AAAAA heartbeat counter=0\n'
           'tail BBBBB heartbeat counter=0\n';
-      const after =
-          'header\n'
+      const after = 'header\n'
           'older log line\n'
           'Performing hot reload...       \n'
           'Reloaded 0 libraries in 45ms.\n';


### PR DESCRIPTION
Agents currently have to poll with repeated describe calls and sleep delays when waiting for UI state changes. This adds an in-app wait command and also fixes macOS reload/restart completion detection so the agent workflow stays reliable after code changes.

Closes #31