### PR TITLE
fix: keep live logs readable after app crashes

### DIFF
--- a/bin/log_collector.dart
+++ b/bin/log_collector.dart
@@ -1,4 +1,3 @@
-const logCollectorSource = r'''
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
@@ -12,11 +11,13 @@ Future<void> main(List<String> args) async {
 
   File(pidPath).writeAsStringSync('$pid');
 
-  // Clean up PID file on SIGTERM (from fdb kill) or SIGINT (Ctrl+C).
   void cleanup() {
-    try { File(pidPath).deleteSync(); } catch (_) {}
+    try {
+      File(pidPath).deleteSync();
+    } catch (_) {}
     exit(0);
   }
+
   ProcessSignal.sigterm.watch().listen((_) => cleanup());
   ProcessSignal.sigint.watch().listen((_) => cleanup());
 
@@ -24,7 +25,9 @@ Future<void> main(List<String> args) async {
     await _collect(wsUri, logPath);
   } catch (_) {
   } finally {
-    try { File(pidPath).deleteSync(); } catch (_) {}
+    try {
+      File(pidPath).deleteSync();
+    } catch (_) {}
   }
 }
 
@@ -40,7 +43,10 @@ Future<void> _collect(String wsUri, String logPath) async {
   Future<void> pendingWrite = Future.value();
 
   void enqueueLine(String line) {
-    pendingWrite = pendingWrite.then<void>((_) => appendLine(line), onError: (_) => appendLine(line));
+    pendingWrite = pendingWrite.then<void>(
+      (_) => appendLine(line),
+      onError: (_) => appendLine(line),
+    );
   }
 
   for (final stream in ['Logging', 'Stdout', 'Stderr']) {
@@ -89,8 +95,12 @@ Future<void> _collect(String wsUri, String logPath) async {
         }
       } catch (_) {}
     },
-    onDone: () { if (!completer.isCompleted) completer.complete(); },
-    onError: (_) { if (!completer.isCompleted) completer.complete(); },
+    onDone: () {
+      if (!completer.isCompleted) completer.complete();
+    },
+    onError: (_) {
+      if (!completer.isCompleted) completer.complete();
+    },
   );
 
   try {
@@ -102,4 +112,3 @@ Future<void> _collect(String wsUri, String logPath) async {
     await ws.close();
   }
 }
-''';

--- a/lib/commands/launch.dart
+++ b/lib/commands/launch.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:isolate';
 
 import 'package:fdb/constants.dart';
-import 'package:fdb/log_collector_source.dart';
 import 'package:fdb/process_utils.dart';
 
 Future<int> runLaunch(List<String> args) async {
@@ -190,21 +190,44 @@ exec $flutterCmd > $logFile 2>&1
 }
 
 Future<void> _startLogCollector(String vmUri) async {
-  // Write a self-contained Dart script that subscribes to the VM service
-  // Logging/Stdout/Stderr streams and appends events to the log file.
-  // This runs as a detached process so it outlives the fdb launch command.
-  File(logCollectorScript).writeAsStringSync(logCollectorSource);
+  final collectorEntrypoint = await _resolveLogCollectorEntrypoint();
+  if (collectorEntrypoint == null) {
+    stderr.writeln('WARNING: Log collector entrypoint not found; developer.log() events may be missing');
+    return;
+  }
 
   // Launch via nohup so the collector survives after fdb exits.
   // Same pattern used for the flutter run launcher script.
   await Process.run('bash', [
     '-c',
-    'nohup dart run ${_shellEscape(logCollectorScript)}'
+    'nohup dart ${_shellEscape(collectorEntrypoint)}'
         ' ${_shellEscape(vmUri)}'
         ' ${_shellEscape(logFile)}'
         ' ${_shellEscape(logCollectorPidFile)}'
         ' > /dev/null 2>&1 &',
   ]);
+}
+
+Future<String?> _resolveLogCollectorEntrypoint() async {
+  const relativePath = 'bin/log_collector.dart';
+  final packageUri = Uri.parse('package:fdb/commands/launch.dart');
+  final resolved = await Isolate.resolvePackageUri(packageUri);
+  if (resolved != null) {
+    final packageRoot = File.fromUri(resolved).parent.parent.parent;
+    final candidate = File('${packageRoot.path}/$relativePath');
+    if (candidate.existsSync()) {
+      return candidate.path;
+    }
+  }
+
+  final scriptDir = Directory.fromUri(Platform.script).parent;
+  final packageRoot = scriptDir.parent;
+  final fallback = File('${packageRoot.path}/$relativePath');
+  if (fallback.existsSync()) {
+    return fallback.path;
+  }
+
+  return null;
 }
 
 /// Extract VM service websocket URI from flutter run log output.

--- a/lib/commands/launch.dart
+++ b/lib/commands/launch.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:fdb/constants.dart';
+import 'package:fdb/log_collector_source.dart';
 import 'package:fdb/process_utils.dart';
 
 Future<int> runLaunch(List<String> args) async {
@@ -192,7 +193,7 @@ Future<void> _startLogCollector(String vmUri) async {
   // Write a self-contained Dart script that subscribes to the VM service
   // Logging/Stdout/Stderr streams and appends events to the log file.
   // This runs as a detached process so it outlives the fdb launch command.
-  File(logCollectorScript).writeAsStringSync(_logCollectorSource);
+  File(logCollectorScript).writeAsStringSync(logCollectorSource);
 
   // Launch via nohup so the collector survives after fdb exits.
   // Same pattern used for the flutter run launcher script.
@@ -205,99 +206,6 @@ Future<void> _startLogCollector(String vmUri) async {
         ' > /dev/null 2>&1 &',
   ]);
 }
-
-const _logCollectorSource = r'''
-import 'dart:async';
-import 'dart:convert';
-import 'dart:io';
-
-Future<void> main(List<String> args) async {
-  if (args.length < 3) exit(1);
-
-  final wsUri = args[0];
-  final logPath = args[1];
-  final pidPath = args[2];
-
-  File(pidPath).writeAsStringSync('$pid');
-
-  // Clean up PID file on SIGTERM (from fdb kill) or SIGINT (Ctrl+C).
-  void cleanup() {
-    try { File(pidPath).deleteSync(); } catch (_) {}
-    exit(0);
-  }
-  ProcessSignal.sigterm.watch().listen((_) => cleanup());
-  ProcessSignal.sigint.watch().listen((_) => cleanup());
-
-  try {
-    await _collect(wsUri, logPath);
-  } catch (_) {
-  } finally {
-    try { File(pidPath).deleteSync(); } catch (_) {}
-  }
-}
-
-Future<void> _collect(String wsUri, String logPath) async {
-  final ws = await WebSocket.connect(wsUri);
-  final logSink = File(logPath).openWrite(mode: FileMode.append);
-
-  void appendLine(String line) {
-    logSink.writeln(line);
-  }
-
-  for (final stream in ['Logging', 'Stdout', 'Stderr']) {
-    ws.add(jsonEncode({
-      'jsonrpc': '2.0',
-      'id': 'listen_$stream',
-      'method': 'streamListen',
-      'params': {'streamId': stream},
-    }));
-  }
-
-  final completer = Completer<void>();
-
-  ws.listen(
-    (data) {
-      try {
-        final msg = jsonDecode(data as String) as Map<String, dynamic>;
-        if (msg['method'] != 'streamNotify') return;
-
-        final params = msg['params'] as Map<String, dynamic>;
-        final event = params['event'] as Map<String, dynamic>;
-        final kind = event['kind'] as String?;
-
-        if (kind == 'Logging') {
-          final logRecord = event['logRecord'] as Map<String, dynamic>?;
-          if (logRecord == null) return;
-          final message = logRecord['message'] as Map<String, dynamic>?;
-          final loggerName = logRecord['loggerName'] as Map<String, dynamic>?;
-          final text = message?['valueAsString'] as String?;
-          if (text == null || text.isEmpty) return;
-          final name = loggerName?['valueAsString'] as String?;
-          if (name != null && name.isNotEmpty) {
-            appendLine('[$name] $text');
-          } else {
-            appendLine(text);
-          }
-        } else if (kind == 'WriteEvent') {
-          final bytes = event['bytes'] as String?;
-          if (bytes == null) return;
-          try {
-            final decoded = utf8.decode(base64Decode(bytes)).trimRight();
-            if (decoded.isNotEmpty) appendLine(decoded);
-          } catch (_) {}
-        }
-      } catch (_) {}
-    },
-    onDone: () { if (!completer.isCompleted) completer.complete(); },
-    onError: (_) { if (!completer.isCompleted) completer.complete(); },
-  );
-
-  await completer.future;
-  await logSink.flush();
-  await logSink.close();
-  await ws.close();
-}
-''';
 
 /// Extract VM service websocket URI from flutter run log output.
 String? _extractVmUri(String logContent) {

--- a/lib/log_collector_source.dart
+++ b/lib/log_collector_source.dart
@@ -1,0 +1,105 @@
+const logCollectorSource = r'''
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+Future<void> main(List<String> args) async {
+  if (args.length < 3) exit(1);
+
+  final wsUri = args[0];
+  final logPath = args[1];
+  final pidPath = args[2];
+
+  File(pidPath).writeAsStringSync('$pid');
+
+  // Clean up PID file on SIGTERM (from fdb kill) or SIGINT (Ctrl+C).
+  void cleanup() {
+    try { File(pidPath).deleteSync(); } catch (_) {}
+    exit(0);
+  }
+  ProcessSignal.sigterm.watch().listen((_) => cleanup());
+  ProcessSignal.sigint.watch().listen((_) => cleanup());
+
+  try {
+    await _collect(wsUri, logPath);
+  } catch (_) {
+  } finally {
+    try { File(pidPath).deleteSync(); } catch (_) {}
+  }
+}
+
+Future<void> _collect(String wsUri, String logPath) async {
+  final ws = await WebSocket.connect(wsUri);
+  final logSink = File(logPath).openWrite(mode: FileMode.append);
+
+  Future<void> appendLine(String line) async {
+    logSink.writeln(line);
+    await logSink.flush();
+  }
+
+  Future<void> pendingWrite = Future.value();
+
+  void enqueueLine(String line) {
+    pendingWrite = pendingWrite.then<void>((_) => appendLine(line), onError: (_) => appendLine(line));
+  }
+
+  for (final stream in ['Logging', 'Stdout', 'Stderr']) {
+    ws.add(jsonEncode({
+      'jsonrpc': '2.0',
+      'id': 'listen_$stream',
+      'method': 'streamListen',
+      'params': {'streamId': stream},
+    }));
+  }
+
+  final completer = Completer<void>();
+
+  ws.listen(
+    (data) {
+      try {
+        final msg = jsonDecode(data as String) as Map<String, dynamic>;
+        if (msg['method'] != 'streamNotify') return;
+
+        final params = msg['params'] as Map<String, dynamic>;
+        final event = params['event'] as Map<String, dynamic>;
+        final kind = event['kind'] as String?;
+
+        if (kind == 'Logging') {
+          final logRecord = event['logRecord'] as Map<String, dynamic>?;
+          if (logRecord == null) return;
+          final message = logRecord['message'] as Map<String, dynamic>?;
+          final loggerName = logRecord['loggerName'] as Map<String, dynamic>?;
+          final text = message?['valueAsString'] as String?;
+          if (text == null || text.isEmpty) return;
+          final name = loggerName?['valueAsString'] as String?;
+          if (name != null && name.isNotEmpty) {
+            enqueueLine('[$name] $text');
+          } else {
+            enqueueLine(text);
+          }
+        } else if (kind == 'WriteEvent') {
+          final bytes = event['bytes'] as String?;
+          if (bytes == null) return;
+          try {
+            final decoded = utf8.decode(base64Decode(bytes)).trimRight();
+            if (decoded.isNotEmpty) {
+              enqueueLine(decoded);
+            }
+          } catch (_) {}
+        }
+      } catch (_) {}
+    },
+    onDone: () { if (!completer.isCompleted) completer.complete(); },
+    onError: (_) { if (!completer.isCompleted) completer.complete(); },
+  );
+
+  try {
+    await completer.future;
+    await pendingWrite;
+  } finally {
+    await logSink.flush();
+    await logSink.close();
+    await ws.close();
+  }
+}
+''';

--- a/test/log_collector_source_test.dart
+++ b/test/log_collector_source_test.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:fdb/log_collector_source.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -18,9 +17,7 @@ void main() {
       final sessionDir = Directory('${tempDir.path}/.fdb')..createSync(recursive: true);
       final logPath = '${sessionDir.path}/logs.txt';
       final pidPath = '${sessionDir.path}/collector.pid';
-      final sourcePath = '${tempDir.path}/collector.dart';
       final followScriptPath = '${tempDir.path}/follow_logs.dart';
-      await File(sourcePath).writeAsString(logCollectorSource);
       await File(followScriptPath).writeAsString(_followLogsScript);
 
       final allowClose = Completer<void>();
@@ -48,7 +45,7 @@ void main() {
       addTearDown(() async => server.close(force: true));
 
       final process = await Process.start('dart', [
-        sourcePath,
+        _collectorEntrypointPath(),
         _wsUri(server),
         logPath,
         pidPath,
@@ -89,8 +86,6 @@ void main() {
       final sessionDir = Directory('${tempDir.path}/.fdb')..createSync(recursive: true);
       final logPath = '${sessionDir.path}/logs.txt';
       final pidPath = '${sessionDir.path}/collector.pid';
-      final sourcePath = '${tempDir.path}/collector.dart';
-      await File(sourcePath).writeAsString(logCollectorSource);
 
       final crashComplete = Completer<void>();
       late HttpServer server;
@@ -120,7 +115,7 @@ void main() {
       addTearDown(() async => server.close(force: true));
 
       final collectorProcess = await Process.start('dart', [
-        sourcePath,
+        _collectorEntrypointPath(),
         _wsUri(server),
         logPath,
         pidPath,
@@ -149,10 +144,10 @@ void main() {
       final logPath = '${sessionDir.path}/logs.txt';
       final pidPath = '${sessionDir.path}/collector.pid';
       final sourcePath = '${tempDir.path}/collector.dart';
-      final delayedFlushSource = logCollectorSource.replaceFirst(
-        'await logSink.flush();',
-        'await Future<void>.delayed(const Duration(milliseconds: 50));\n    await logSink.flush();',
-      );
+      final delayedFlushSource = File(_collectorEntrypointPath()).readAsStringSync().replaceFirst(
+            'await logSink.flush();',
+            'await Future<void>.delayed(const Duration(milliseconds: 50));\n    await logSink.flush();',
+          );
       await File(sourcePath).writeAsString(delayedFlushSource);
 
       final allowClose = Completer<void>();
@@ -246,6 +241,8 @@ Map<String, dynamic> _writeEvent(String text) {
 String _wsUri(HttpServer server) => 'ws://${server.address.host}:${server.port}';
 
 String _packageConfigPath() => '${Directory.current.path}/.dart_tool/package_config.json';
+
+String _collectorEntrypointPath() => '${Directory.current.path}/bin/log_collector.dart';
 
 Future<void> _waitForFile(String path) async {
   final deadline = DateTime.now().add(const Duration(seconds: 5));

--- a/test/log_collector_source_test.dart
+++ b/test/log_collector_source_test.dart
@@ -1,0 +1,300 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:fdb/log_collector_source.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('generated log collector', () {
+    test('fdb logs --follow streams Logging and WriteEvent lines while running', () async {
+      final tempDir = await Directory.systemTemp.createTemp('fdb_log_collector_test');
+      addTearDown(() async {
+        if (tempDir.existsSync()) {
+          await tempDir.delete(recursive: true);
+        }
+      });
+
+      final sessionDir = Directory('${tempDir.path}/.fdb')..createSync(recursive: true);
+      final logPath = '${sessionDir.path}/logs.txt';
+      final pidPath = '${sessionDir.path}/collector.pid';
+      final sourcePath = '${tempDir.path}/collector.dart';
+      final followScriptPath = '${tempDir.path}/follow_logs.dart';
+      await File(sourcePath).writeAsString(logCollectorSource);
+      await File(followScriptPath).writeAsString(_followLogsScript);
+
+      final allowClose = Completer<void>();
+
+      final server = await _startServer((socket) async {
+        var listenRequests = 0;
+
+        await for (final data in socket) {
+          final request = jsonDecode(data as String) as Map<String, dynamic>;
+          if (request['method'] != 'streamListen') {
+            continue;
+          }
+
+          listenRequests++;
+          if (listenRequests != 3) {
+            continue;
+          }
+
+          socket.add(jsonEncode(_loggingEvent('ui', 'logging line')));
+          socket.add(jsonEncode(_writeEvent('stdout line\n')));
+          await allowClose.future;
+          await socket.close();
+        }
+      });
+      addTearDown(() async => server.close(force: true));
+
+      final process = await Process.start('dart', [
+        sourcePath,
+        _wsUri(server),
+        logPath,
+        pidPath,
+      ]);
+      addTearDown(() async {
+        process.kill();
+        await process.exitCode;
+      });
+
+      await _waitForFile(logPath);
+
+      final followProcess = await Process.start('dart', [
+        '--packages=${_packageConfigPath()}',
+        followScriptPath,
+        tempDir.path,
+      ]);
+      addTearDown(() async {
+        followProcess.kill();
+        await followProcess.exitCode;
+      });
+
+      final lines = await _waitForProcessLines(
+        followProcess.stdout,
+        2,
+      );
+      expect(lines, ['[ui] logging line', 'stdout line']);
+      allowClose.complete();
+    });
+
+    test('keeps latest lines readable after an unexpected VM stream crash', () async {
+      final tempDir = await Directory.systemTemp.createTemp('fdb_log_collector_test');
+      addTearDown(() async {
+        if (tempDir.existsSync()) {
+          await tempDir.delete(recursive: true);
+        }
+      });
+
+      final sessionDir = Directory('${tempDir.path}/.fdb')..createSync(recursive: true);
+      final logPath = '${sessionDir.path}/logs.txt';
+      final pidPath = '${sessionDir.path}/collector.pid';
+      final sourcePath = '${tempDir.path}/collector.dart';
+      await File(sourcePath).writeAsString(logCollectorSource);
+
+      final crashComplete = Completer<void>();
+      late HttpServer server;
+      server = await _startServer((socket) async {
+        var listenRequests = 0;
+
+        await for (final data in socket) {
+          final request = jsonDecode(data as String) as Map<String, dynamic>;
+          if (request['method'] != 'streamListen') {
+            continue;
+          }
+
+          listenRequests++;
+          if (listenRequests != 3) {
+            continue;
+          }
+
+          socket.add(jsonEncode(_loggingEvent('crash', 'logging line')));
+          socket.add(jsonEncode(_writeEvent('stdout before crash\n')));
+          await Future<void>.delayed(const Duration(milliseconds: 20));
+          await server.close(force: true);
+          if (!crashComplete.isCompleted) {
+            crashComplete.complete();
+          }
+        }
+      });
+      addTearDown(() async => server.close(force: true));
+
+      final collectorProcess = await Process.start('dart', [
+        sourcePath,
+        _wsUri(server),
+        logPath,
+        pidPath,
+      ]);
+      addTearDown(() async {
+        collectorProcess.kill();
+        await collectorProcess.exitCode;
+      });
+
+      await crashComplete.future.timeout(const Duration(seconds: 5));
+      expect(
+        await _waitForLogLines(logPath, 2),
+        ['[crash] logging line', 'stdout before crash'],
+      );
+    });
+
+    test('awaits queued flushes before closing the sink', () async {
+      final tempDir = await Directory.systemTemp.createTemp('fdb_log_collector_test');
+      addTearDown(() async {
+        if (tempDir.existsSync()) {
+          await tempDir.delete(recursive: true);
+        }
+      });
+
+      final sessionDir = Directory('${tempDir.path}/.fdb')..createSync(recursive: true);
+      final logPath = '${sessionDir.path}/logs.txt';
+      final pidPath = '${sessionDir.path}/collector.pid';
+      final sourcePath = '${tempDir.path}/collector.dart';
+      final delayedFlushSource = logCollectorSource.replaceFirst(
+        'await logSink.flush();',
+        'await Future<void>.delayed(const Duration(milliseconds: 50));\n    await logSink.flush();',
+      );
+      await File(sourcePath).writeAsString(delayedFlushSource);
+
+      final allowClose = Completer<void>();
+
+      final server = await _startServer((socket) async {
+        var listenRequests = 0;
+
+        await for (final data in socket) {
+          final request = jsonDecode(data as String) as Map<String, dynamic>;
+          if (request['method'] != 'streamListen') {
+            continue;
+          }
+
+          listenRequests++;
+          if (listenRequests != 3) {
+            continue;
+          }
+
+          socket.add(jsonEncode(_writeEvent('last line\n')));
+          await allowClose.future;
+          await socket.close();
+        }
+      });
+      addTearDown(() async => server.close(force: true));
+
+      final process = await Process.start('dart', [
+        sourcePath,
+        _wsUri(server),
+        logPath,
+        pidPath,
+      ]);
+      addTearDown(() async {
+        process.kill();
+        await process.exitCode;
+      });
+
+      expect(await _waitForLogLines(logPath, 1), ['last line']);
+      allowClose.complete();
+    });
+  });
+}
+
+const _followLogsScript = '''
+import 'dart:io';
+
+import 'package:fdb/commands/logs.dart';
+import 'package:fdb/constants.dart';
+
+Future<void> main(List<String> args) async {
+  initSessionDir(args[0]);
+  exit(await runLogs(['--follow']));
+}
+''';
+
+Future<HttpServer> _startServer(Future<void> Function(WebSocket socket) onSocket) {
+  return HttpServer.bind(InternetAddress.loopbackIPv4, 0).then((server) {
+    server.transform(WebSocketTransformer()).listen((socket) {
+      unawaited(onSocket(socket));
+    });
+    return server;
+  });
+}
+
+Map<String, dynamic> _loggingEvent(String loggerName, String message) {
+  return {
+    'method': 'streamNotify',
+    'params': {
+      'event': {
+        'kind': 'Logging',
+        'logRecord': {
+          'message': {'valueAsString': message},
+          'loggerName': {'valueAsString': loggerName},
+        },
+      },
+    },
+  };
+}
+
+Map<String, dynamic> _writeEvent(String text) {
+  return {
+    'method': 'streamNotify',
+    'params': {
+      'event': {
+        'kind': 'WriteEvent',
+        'bytes': base64Encode(utf8.encode(text)),
+      },
+    },
+  };
+}
+
+String _wsUri(HttpServer server) => 'ws://${server.address.host}:${server.port}';
+
+String _packageConfigPath() => '${Directory.current.path}/.dart_tool/package_config.json';
+
+Future<void> _waitForFile(String path) async {
+  final deadline = DateTime.now().add(const Duration(seconds: 5));
+
+  while (DateTime.now().isBefore(deadline)) {
+    if (File(path).existsSync()) {
+      return;
+    }
+
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+  }
+
+  fail('Timed out waiting for file $path');
+}
+
+Future<List<String>> _waitForProcessLines(Stream<List<int>> stream, int expectedCount) async {
+  final lines = <String>[];
+  final completer = Completer<void>();
+  late final StreamSubscription<String> subscription;
+
+  subscription = stream.transform(utf8.decoder).transform(const LineSplitter()).listen((line) {
+    lines.add(line);
+    if (lines.length >= expectedCount && !completer.isCompleted) {
+      completer.complete();
+    }
+  });
+
+  try {
+    await completer.future.timeout(const Duration(seconds: 5));
+    return lines.take(expectedCount).toList();
+  } finally {
+    await subscription.cancel();
+  }
+}
+
+Future<List<String>> _waitForLogLines(String logPath, int expectedCount) async {
+  final deadline = DateTime.now().add(const Duration(seconds: 5));
+
+  while (DateTime.now().isBefore(deadline)) {
+    final logFile = File(logPath);
+    if (logFile.existsSync()) {
+      final lines = await logFile.readAsLines();
+      if (lines.length >= expectedCount) {
+        return lines;
+      }
+    }
+
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+  }
+
+  fail('Timed out waiting for $expectedCount log lines in $logPath');
+}


### PR DESCRIPTION
Memory-leak and crash investigations need `.fdb/logs.txt` to keep the latest VM-service output even when the app dies unexpectedly. This makes collector writes deterministic so `fdb logs --follow` and post-crash reads stay reliable, and manual verification passed on macOS, Android physical, and the iOS simulator.

Closes #43