### PR TITLE
chore: install and configure Beads (bd) issue tracker

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -1,0 +1,73 @@
+# Dolt database (managed by Dolt, not git)
+dolt/
+embeddeddolt/
+
+# Runtime files
+bd.sock
+bd.sock.startlock
+sync-state.json
+last-touched
+.exclusive-lock
+
+# Daemon runtime (lock, log, pid)
+daemon.*
+
+# Interactions log (runtime, not versioned)
+interactions.jsonl
+
+# Push state (runtime, per-machine)
+push-state.json
+
+# Lock files (various runtime locks)
+*.lock
+
+# Credential key (encryption key for federation peer auth — never commit)
+.beads-credential-key
+
+# Local version tracking (prevents upgrade notification spam after git ops)
+.local_version
+
+# Worktree redirect file (contains relative path to main repo's .beads/)
+# Must not be committed as paths would be wrong in other clones
+redirect
+
+# Sync state (local-only, per-machine)
+# These files are machine-specific and should not be shared across clones
+.sync.lock
+export-state/
+export-state.json
+
+# Ephemeral store (SQLite - wisps/molecules, intentionally not versioned)
+ephemeral.sqlite3
+ephemeral.sqlite3-journal
+ephemeral.sqlite3-wal
+ephemeral.sqlite3-shm
+
+# Dolt server management (auto-started by bd)
+dolt-server.pid
+dolt-server.log
+dolt-server.lock
+dolt-server.port
+dolt-server.activity
+
+# Corrupt backup directories (created by bd doctor --fix recovery)
+*.corrupt.backup/
+
+# Backup data (auto-exported JSONL, local-only)
+backup/
+
+# Per-project environment file (Dolt connection config, GH#2520)
+.env
+
+# Legacy files (from pre-Dolt versions)
+*.db
+*.db?*
+*.db-journal
+*.db-wal
+*.db-shm
+db.sqlite
+bd.db
+# NOTE: Do NOT add negation patterns here.
+# They would override fork protection in .git/info/exclude.
+# Config files (metadata.json, config.yaml) are tracked by git by default
+# since no pattern above ignores them.

--- a/.beads/README.md
+++ b/.beads/README.md
@@ -1,0 +1,81 @@
+# Beads - AI-Native Issue Tracking
+
+Welcome to Beads! This repository uses **Beads** for issue tracking - a modern, AI-native tool designed to live directly in your codebase alongside your code.
+
+## What is Beads?
+
+Beads is issue tracking that lives in your repo, making it perfect for AI coding agents and developers who want their issues close to their code. No web UI required - everything works through the CLI and integrates seamlessly with git.
+
+**Learn more:** [github.com/steveyegge/beads](https://github.com/steveyegge/beads)
+
+## Quick Start
+
+### Essential Commands
+
+```bash
+# Create new issues
+bd create "Add user authentication"
+
+# View all issues
+bd list
+
+# View issue details
+bd show <issue-id>
+
+# Update issue status
+bd update <issue-id> --claim
+bd update <issue-id> --status done
+
+# Sync with Dolt remote
+bd dolt push
+```
+
+### Working with Issues
+
+Issues in Beads are:
+- **Git-native**: Stored in Dolt database with version control and branching
+- **AI-friendly**: CLI-first design works perfectly with AI coding agents
+- **Branch-aware**: Issues can follow your branch workflow
+- **Always in sync**: Auto-syncs with your commits
+
+## Why Beads?
+
+✨ **AI-Native Design**
+- Built specifically for AI-assisted development workflows
+- CLI-first interface works seamlessly with AI coding agents
+- No context switching to web UIs
+
+🚀 **Developer Focused**
+- Issues live in your repo, right next to your code
+- Works offline, syncs when you push
+- Fast, lightweight, and stays out of your way
+
+🔧 **Git Integration**
+- Automatic sync with git commits
+- Branch-aware issue tracking
+- Dolt-native three-way merge resolution
+
+## Get Started with Beads
+
+Try Beads in your own projects:
+
+```bash
+# Install Beads
+curl -sSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+
+# Initialize in your repo
+bd init
+
+# Create your first issue
+bd create "Try out Beads"
+```
+
+## Learn More
+
+- **Documentation**: [github.com/steveyegge/beads/docs](https://github.com/steveyegge/beads/tree/main/docs)
+- **Quick Start Guide**: Run `bd quickstart`
+- **Examples**: [github.com/steveyegge/beads/examples](https://github.com/steveyegge/beads/tree/main/examples)
+
+---
+
+*Beads: Issue tracking that moves at the speed of thought* ⚡

--- a/.beads/README.md
+++ b/.beads/README.md
@@ -1,81 +1,26 @@
-# Beads - AI-Native Issue Tracking
+# Beads Issue Tracker
 
-Welcome to Beads! This repository uses **Beads** for issue tracking - a modern, AI-native tool designed to live directly in your codebase alongside your code.
+This repo uses `bd` (Beads) for issue tracking.
 
-## What is Beads?
+Issues live in `.beads/embeddeddolt/` (gitignored, local Dolt DB) and are auto-exported to `.beads/issues.jsonl` (git-tracked) after every write.
 
-Beads is issue tracking that lives in your repo, making it perfect for AI coding agents and developers who want their issues close to their code. No web UI required - everything works through the CLI and integrates seamlessly with git.
-
-**Learn more:** [github.com/steveyegge/beads](https://github.com/steveyegge/beads)
-
-## Quick Start
-
-### Essential Commands
+## Quick start
 
 ```bash
-# Create new issues
-bd create "Add user authentication"
-
-# View all issues
-bd list
-
-# View issue details
-bd show <issue-id>
-
-# Update issue status
-bd update <issue-id> --claim
-bd update <issue-id> --status done
-
-# Sync with Dolt remote
-bd dolt push
+bd prime                                                          # Load session context
+bd ready                                                          # List available issues
+bd show <id>                                                      # View issue details
+bd update <id> --claim                                            # Claim an issue
+bd create --title="..." --description="..." --type=task --priority=2  # Create an issue
+bd close <id>                                                     # Close an issue
+bd github sync                                                    # Bidirectional sync with GitHub Issues
+bd bootstrap                                                      # Rebuild local DB after git pull
 ```
 
-### Working with Issues
+## Collaboration flow
 
-Issues in Beads are:
-- **Git-native**: Stored in Dolt database with version control and branching
-- **AI-friendly**: CLI-first design works perfectly with AI coding agents
-- **Branch-aware**: Issues can follow your branch workflow
-- **Always in sync**: Auto-syncs with your commits
+1. Write/update issues with `bd`
+2. Commit `issues.jsonl` alongside code changes
+3. Teammates run `git pull` + `bd bootstrap`
 
-## Why Beads?
-
-✨ **AI-Native Design**
-- Built specifically for AI-assisted development workflows
-- CLI-first interface works seamlessly with AI coding agents
-- No context switching to web UIs
-
-🚀 **Developer Focused**
-- Issues live in your repo, right next to your code
-- Works offline, syncs when you push
-- Fast, lightweight, and stays out of your way
-
-🔧 **Git Integration**
-- Automatic sync with git commits
-- Branch-aware issue tracking
-- Dolt-native three-way merge resolution
-
-## Get Started with Beads
-
-Try Beads in your own projects:
-
-```bash
-# Install Beads
-curl -sSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
-
-# Initialize in your repo
-bd init
-
-# Create your first issue
-bd create "Try out Beads"
-```
-
-## Learn More
-
-- **Documentation**: [github.com/steveyegge/beads/docs](https://github.com/steveyegge/beads/tree/main/docs)
-- **Quick Start Guide**: Run `bd quickstart`
-- **Examples**: [github.com/steveyegge/beads/examples](https://github.com/steveyegge/beads/tree/main/examples)
-
----
-
-*Beads: Issue tracking that moves at the speed of thought* ⚡
+See `AGENTS.md` for full agent instructions.

--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -1,0 +1,54 @@
+# Beads Configuration File
+# This file configures default behavior for all bd commands in this repository
+# All settings can also be set via environment variables (BD_* prefix)
+# or overridden with command-line flags
+
+# Issue prefix for this repository (used by bd init)
+# If not set, bd init will auto-detect from directory name
+# Example: issue-prefix: "myproject" creates issues like "myproject-1", "myproject-2", etc.
+# issue-prefix: ""
+
+# Use no-db mode: JSONL-only, no Dolt database
+# When true, bd will use .beads/issues.jsonl as the source of truth
+# no-db: false
+
+# Enable JSON output by default
+# json: false
+
+# Feedback title formatting for mutating commands (create/update/close/dep/edit)
+# 0 = hide titles, N > 0 = truncate to N characters
+# output:
+#   title-length: 255
+
+# Default actor for audit trails (overridden by BEADS_ACTOR or --actor)
+# actor: ""
+
+# Export events (audit trail) to .beads/events.jsonl on each flush/sync
+# When enabled, new events are appended incrementally using a high-water mark.
+# Use 'bd export --events' to trigger manually regardless of this setting.
+# events-export: false
+
+# Multi-repo configuration (experimental - bd-307)
+# Allows hydrating from multiple repositories and routing writes to the correct database
+# repos:
+#   primary: "."  # Primary repo (where this database lives)
+#   additional:   # Additional repos to hydrate from (read-only)
+#     - ~/beads-planning  # Personal planning repo
+#     - ~/work-planning   # Work planning repo
+
+# JSONL backup (periodic export for off-machine recovery)
+# Auto-enabled when a git remote exists. Override explicitly:
+# backup:
+#   enabled: false     # Disable auto-backup entirely
+#   interval: 15m      # Minimum time between auto-exports
+#   git-push: false    # Disable git push (export locally only)
+#   git-repo: ""       # Separate git repo for backups (default: project repo)
+
+# Integration settings (access with 'bd config get/set')
+# These are stored in the database, not in this file:
+# - jira.url
+# - jira.project
+# - linear.url
+# - linear.api-key
+# - github.org
+# - github.repo

--- a/.beads/hooks/post-checkout
+++ b/.beads/hooks/post-checkout
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v1.0.3 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run post-checkout "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'post-checkout' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run post-checkout "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'post-checkout'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v1.0.3 ---

--- a/.beads/hooks/post-merge
+++ b/.beads/hooks/post-merge
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v1.0.3 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run post-merge "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'post-merge' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run post-merge "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'post-merge'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v1.0.3 ---

--- a/.beads/hooks/pre-commit
+++ b/.beads/hooks/pre-commit
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v1.0.3 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run pre-commit "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'pre-commit' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run pre-commit "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'pre-commit'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v1.0.3 ---

--- a/.beads/hooks/pre-push
+++ b/.beads/hooks/pre-push
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v1.0.3 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run pre-push "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'pre-push' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run pre-push "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'pre-push'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v1.0.3 ---

--- a/.beads/hooks/prepare-commit-msg
+++ b/.beads/hooks/prepare-commit-msg
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v1.0.3 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run prepare-commit-msg "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'prepare-commit-msg' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run prepare-commit-msg "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'prepare-commit-msg'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v1.0.3 ---

--- a/.beads/metadata.json
+++ b/.beads/metadata.json
@@ -2,6 +2,6 @@
   "database": "dolt",
   "backend": "dolt",
   "dolt_mode": "embedded",
-  "dolt_database": "feature_beads",
+  "dolt_database": "fdb",
   "project_id": "38c5f299-3861-471c-a310-8f8b9a291d9f"
 }

--- a/.beads/metadata.json
+++ b/.beads/metadata.json
@@ -1,0 +1,7 @@
+{
+  "database": "dolt",
+  "backend": "dolt",
+  "dolt_mode": "embedded",
+  "dolt_database": "feature_beads",
+  "project_id": "38c5f299-3861-471c-a310-8f8b9a291d9f"
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "command": "bd sync",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "bd prime",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ example/test_app/.metadata
 
 # Task log output
 .task/
+
+# Beads issue tracker (runtime DB and credential key)
+.dolt/
+.beads-credential-key

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,5 @@ example/test_app/.metadata
 # Task log output
 .task/
 
-# Beads issue tracker (runtime DB and credential key)
+# Beads issue tracker
 .dolt/
-.beads-credential-key

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ example/test_app/.metadata
 
 # Beads issue tracker
 .dolt/
+.beads-credential-key

--- a/.opencode/skills/managing-beads/SKILL.md
+++ b/.opencode/skills/managing-beads/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: managing-beads
+description: >
+  Project issue tracker using bd (Beads). Issues travel via git through
+  .beads/issues.jsonl. Use when asked to work on, pick, or fix an issue;
+  when capturing discovered work; or when checking what to do next.
+---
+
+# Managing Beads Issues
+
+## Session workflow
+
+1. Run `bd prime` — loads context and shows open/claimed issues.
+2. Pick work with `bd ready`, claim with `bd update <id> --claim`.
+3. Work on code. Create follow-up issues as you discover them.
+4. Before committing: run `bd sync` to flush any pending writes.
+5. Commit `issues.jsonl` together with the code it tracks.
+6. Close finished issues with `bd close <id>`.
+
+## Core commands
+
+```bash
+bd prime                                                          # Session start: load context
+bd ready                                                          # List unclaimed available issues
+bd show <id>                                                      # View issue details
+bd update <id> --claim                                            # Claim an issue
+bd update <id> --status=in-progress                               # Update status
+bd create --title="..." --description="..." --type=task --priority=2  # Create an issue
+bd close <id>                                                     # Mark issue done
+bd sync                                                           # Flush pending writes (before compaction)
+bd bootstrap                                                      # Rebuild local DB after git pull
+```
+
+## Creating issues
+
+```bash
+bd create \
+  --title="Add scroll support for web" \
+  --description="CDP-based scroll not yet implemented; fdb scroll fails on web targets." \
+  --type=task \
+  --priority=2
+```
+
+Types: `task`, `bug`, `feature`, `chore`  
+Priorities: `1` (critical) → `4` (low)
+
+## Rules
+
+- Always commit `issues.jsonl` together with the code changes it tracks — never in isolation.
+- Run `bd bootstrap` after `git pull` on any machine that already has a local DB.
+- Run `bd prime` at session start only — not during compaction (`bd sync` handles compaction).
+- Never run `bd doctor --fix` — it can corrupt the local DB.
+- Issues are the source of truth for planned and in-progress work; capture anything discovered.

--- a/.opencode/skills/managing-beads/SKILL.md
+++ b/.opencode/skills/managing-beads/SKILL.md
@@ -13,8 +13,8 @@ description: >
 1. Run `bd prime` — loads context and shows open/claimed issues.
 2. Pick work with `bd ready`, claim with `bd update <id> --claim`.
 3. Work on code. Create follow-up issues as you discover them.
-4. Before committing: run `bd sync` to flush any pending writes.
-5. Commit `issues.jsonl` together with the code it tracks.
+4. Commit `issues.jsonl` together with the code it tracks (the pre-commit hook exports it automatically).
+5. Before context compaction: run `bd sync` to flush any pending writes.
 6. Close finished issues with `bd close <id>`.
 
 ## Core commands
@@ -53,5 +53,5 @@ Priorities: `1` (critical) → `4` (low)
 - Run `bd bootstrap` after `git pull` on any machine that already has a local DB.
 - Run `bd prime` at session start only — not during compaction (`bd sync` handles compaction).
 - Never run `bd doctor --fix` — it can corrupt the local DB.
-- Issues are the source of truth for planned and in-progress work; capture anything discovered.
 - `bd` is the source of truth; GitHub Issues are a mirror — sync with `bd github sync`.
+- Capture any work discovered during implementation as new issues immediately.

--- a/.opencode/skills/managing-beads/SKILL.md
+++ b/.opencode/skills/managing-beads/SKILL.md
@@ -29,6 +29,9 @@ bd create --title="..." --description="..." --type=task --priority=2  # Create a
 bd close <id>                                                     # Mark issue done
 bd sync                                                           # Flush pending writes (before compaction)
 bd bootstrap                                                      # Rebuild local DB after git pull
+bd github sync                                                    # Bidirectional sync with GitHub Issues
+bd github sync --pull-only                                        # Pull from GitHub only
+bd github sync --push-only                                        # Push to GitHub only
 ```
 
 ## Creating issues
@@ -51,3 +54,4 @@ Priorities: `1` (critical) → `4` (low)
 - Run `bd prime` at session start only — not during compaction (`bd sync` handles compaction).
 - Never run `bd doctor --fix` — it can corrupt the local DB.
 - Issues are the source of truth for planned and in-progress work; capture anything discovered.
+- `bd` is the source of truth; GitHub Issues are a mirror — sync with `bd github sync`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,9 @@ bd update <id> --claim                                            # Claim an iss
 bd create --title="..." --description="..." --type=task --priority=2  # Create an issue
 bd close <id>                                                     # Close an issue
 bd bootstrap                                                      # Rebuild local DB after git pull
+bd github sync                                                    # Bidirectional sync with GitHub Issues
+bd github sync --pull-only                                        # Pull from GitHub only
+bd github sync --push-only                                        # Push to GitHub only
 ```
 
 ### Rules
@@ -102,4 +105,5 @@ bd bootstrap                                                      # Rebuild loca
 - Commit `issues.jsonl` together with the code changes it tracks.
 - Run `bd bootstrap` after `git pull` on a machine that already has a local DB.
 - Run `bd prime` at the start of every session — not at compaction.
+- `bd` is the source of truth; GitHub Issues are a mirror via `bd github sync`.
 <!-- END BEADS INTEGRATION -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,6 @@ bd github sync --push-only                                        # Push to GitH
 
 - Commit `issues.jsonl` together with the code changes it tracks.
 - Run `bd bootstrap` after `git pull` on a machine that already has a local DB.
-- Run `bd prime` at the start of every session — not at compaction.
+- Run `bd prime` at session start and `bd sync` before compaction — not the other way around.
 - `bd` is the source of truth; GitHub Issues are a mirror via `bd github sync`.
 <!-- END BEADS INTEGRATION -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,3 +77,29 @@ dart format .                         # Format
 - Manual arg parsing with `for` loop + `switch`.
 
 **Full details**: [CODE-STYLE.md](CODE-STYLE.md)
+
+<!-- BEGIN BEADS INTEGRATION -->
+## Issue Tracker (`bd`)
+
+This repo uses `bd` (Beads) as its issue tracker. Issues live in `.beads/embeddeddolt/` (gitignored) and are auto-exported to `.beads/issues.jsonl` (git-tracked) after every write.
+
+**Collaboration flow:** write issues → commit `issues.jsonl` alongside code → teammates `git pull` + `bd bootstrap`.
+
+### Quick reference
+
+```bash
+bd prime                                                          # Load session context (run at session start)
+bd ready                                                          # List available issues
+bd show <id>                                                      # View issue details
+bd update <id> --claim                                            # Claim an issue
+bd create --title="..." --description="..." --type=task --priority=2  # Create an issue
+bd close <id>                                                     # Close an issue
+bd bootstrap                                                      # Rebuild local DB after git pull
+```
+
+### Rules
+
+- Commit `issues.jsonl` together with the code changes it tracks.
+- Run `bd bootstrap` after `git pull` on a machine that already has a local DB.
+- Run `bd prime` at the start of every session — not at compaction.
+<!-- END BEADS INTEGRATION -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,11 +89,12 @@ This repo uses `bd` (Beads) as its issue tracker. Issues live in `.beads/embedde
 
 ```bash
 bd prime                                                          # Load session context (run at session start)
-bd ready                                                          # List available issues
+bd ready                                                          # List unclaimed available issues
 bd show <id>                                                      # View issue details
 bd update <id> --claim                                            # Claim an issue
 bd create --title="..." --description="..." --type=task --priority=2  # Create an issue
 bd close <id>                                                     # Close an issue
+bd sync                                                           # Flush pending writes (before compaction)
 bd bootstrap                                                      # Rebuild local DB after git pull
 bd github sync                                                    # Bidirectional sync with GitHub Issues
 bd github sync --pull-only                                        # Pull from GitHub only

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,9 +104,10 @@ bd github sync --push-only                                        # Push to GitH
 
 ### Rules
 
-- Commit `issues.jsonl` together with the code changes it tracks.
+- Commit `issues.jsonl` together with the code changes it tracks — never in isolation.
 - Run `bd bootstrap` after `git pull` on a machine that already has a local DB.
 - Run `bd prime` at session start only — not during compaction (`bd sync` handles compaction).
 - `bd` is the source of truth; GitHub Issues are a mirror via `bd github sync`.
 - Never run `bd doctor --fix` — it can corrupt the local DB.
+- Capture any work discovered during implementation as new issues immediately.
 <!-- END BEADS INTEGRATION -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,4 +107,5 @@ bd github sync --push-only                                        # Push to GitH
 - Run `bd bootstrap` after `git pull` on a machine that already has a local DB.
 - Run `bd prime` at session start and `bd sync` before compaction — not the other way around.
 - `bd` is the source of truth; GitHub Issues are a mirror via `bd github sync`.
+- Never run `bd doctor --fix` — it can corrupt the local DB.
 <!-- END BEADS INTEGRATION -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,7 @@ bd prime                                                          # Load session
 bd ready                                                          # List unclaimed available issues
 bd show <id>                                                      # View issue details
 bd update <id> --claim                                            # Claim an issue
+bd update <id> --status=in-progress                               # Mark issue as in progress
 bd create --title="..." --description="..." --type=task --priority=2  # Create an issue
 bd close <id>                                                     # Close an issue
 bd sync                                                           # Flush pending writes (before compaction)
@@ -105,7 +106,7 @@ bd github sync --push-only                                        # Push to GitH
 
 - Commit `issues.jsonl` together with the code changes it tracks.
 - Run `bd bootstrap` after `git pull` on a machine that already has a local DB.
-- Run `bd prime` at session start and `bd sync` before compaction — not the other way around.
+- Run `bd prime` at session start only — not during compaction (`bd sync` handles compaction).
 - `bd` is the source of truth; GitHub Issues are a mirror via `bd github sync`.
 - Never run `bd doctor --fix` — it can corrupt the local DB.
 <!-- END BEADS INTEGRATION -->


### PR DESCRIPTION
## Summary

- Runs `bd init` and commits all `.beads/` config files (`.gitignore`, `config.yaml`, `metadata.json`, hooks)
- Replaces the generic `bd init` boilerplate in `AGENTS.md` with a tight, project-specific Beads section covering storage layout, collaboration flow, and a quick-reference command table
- Deletes `CLAUDE.md` — the project already has a comprehensive `AGENTS.md`; a separate Claude Code file would just duplicate noise
- Fixes `.claude/settings.json`: `PreCompact` hook runs `bd sync` (saves state before compaction), `SessionStart` keeps `bd prime` (loads context at start)
- Adds `.opencode/skills/managing-beads/SKILL.md`: project-local skill for picking up, creating, and tracking issues via `bd`
- Updates `.gitignore` with `.dolt/` and `.beads-credential-key` entries

## Verification checklist

- [x] `bd version` works (v1.0.3)
- [x] `bd init` completed without errors
- [x] `.beads/.gitignore` committed (controls what stays local)
- [x] `.gitignore` has `.dolt/` and `.beads-credential-key`
- [x] `PreCompact` hook runs `bd sync`, not `bd prime`
- [x] No placeholder sections in `AGENTS.md`
- [x] `CLAUDE.md` deleted (superseded by `AGENTS.md`)