### PR TITLE
fix: fdb status returns RUNNING=true when launch was interrupted but app is alive

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1628,6 +1628,47 @@ tasks:
           exit 1
         fi
 
+        echo "==> Scenario: VM URI present but service unreachable → RUNNING=false"
+        ORIGINAL_PID3=$(cat .fdb/fdb.pid 2>/dev/null || echo "")
+        ORIGINAL_URI3=$(cat .fdb/vm_uri.txt 2>/dev/null || echo "")
+        if [ -z "$ORIGINAL_URI3" ]; then
+          echo "FAIL: .fdb/vm_uri.txt not found — run test:launch first" >&2
+          exit 1
+        fi
+
+        restore_scenario3() {
+          if [ -n "$ORIGINAL_PID3" ]; then
+            printf '%s' "$ORIGINAL_PID3" > .fdb/fdb.pid
+          else
+            rm -f .fdb/fdb.pid
+          fi
+          printf '%s' "$ORIGINAL_URI3" > .fdb/vm_uri.txt
+        }
+        trap restore_scenario3 EXIT
+
+        # Remove PID file so only the VM URI path is exercised.
+        rm -f .fdb/fdb.pid
+        # Replace VM URI with a URI that refuses connections immediately.
+        printf 'ws://127.0.0.1:1/' > .fdb/vm_uri.txt
+
+        OUTPUT3=$({{.FDB}} status 2>&1)
+        EXIT_CODE3=$?
+        echo "$OUTPUT3"
+
+        restore_scenario3
+        trap - EXIT
+
+        if [ $EXIT_CODE3 -ne 0 ]; then
+          echo "FAIL: fdb status exited with code $EXIT_CODE3" >&2
+          exit 1
+        fi
+        if echo "$OUTPUT3" | grep -q "RUNNING=false"; then
+          echo "PASS: fdb status correctly reports RUNNING=false when VM URI present but unreachable"
+        else
+          echo "FAIL: fdb status - expected RUNNING=false when VM URI present but service unreachable" >&2
+          exit 1
+        fi
+
   # ---------------------------------------------------------------------------
   # Cleanup
   # ---------------------------------------------------------------------------

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1553,6 +1553,81 @@ tasks:
           exit 1
         fi
 
+  test:status-after-interrupted-launch:
+    desc: Verify status reports RUNNING=true when app is alive but PID file is missing (interrupted launch scenario)
+    dir: '{{.TEST_APP}}'
+    cmds:
+      - |
+        echo "==> Scenario: PID file missing but VM URI reachable (interrupted launch)"
+        if [ ! -f .fdb/vm_uri.txt ]; then
+          echo "FAIL: .fdb/vm_uri.txt not found — run test:launch first" >&2
+          exit 1
+        fi
+
+        # Remove the PID file to simulate an interrupted fdb launch where
+        # flutter run's --pid-file was not written before fdb was killed.
+        ORIGINAL_PID=""
+        if [ -f .fdb/fdb.pid ]; then
+          ORIGINAL_PID=$(cat .fdb/fdb.pid)
+          rm .fdb/fdb.pid
+        fi
+
+        restore_pid() {
+          if [ -n "$ORIGINAL_PID" ]; then
+            printf '%s' "$ORIGINAL_PID" > .fdb/fdb.pid
+          fi
+        }
+        trap restore_pid EXIT
+
+        OUTPUT=$({{.FDB}} status 2>&1)
+        EXIT_CODE=$?
+        echo "$OUTPUT"
+
+        restore_pid
+        trap - EXIT
+
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "FAIL: fdb status exited with code $EXIT_CODE" >&2
+          exit 1
+        fi
+        if echo "$OUTPUT" | grep -q "RUNNING=true"; then
+          echo "PASS: fdb status correctly reports RUNNING=true via VM URI fallback"
+        else
+          echo "FAIL: fdb status - expected RUNNING=true when app is alive but PID file missing" >&2
+          exit 1
+        fi
+
+        echo "==> Scenario: PID file points to dead process but VM URI reachable"
+        ORIGINAL_PID=$(cat .fdb/fdb.pid 2>/dev/null || echo "")
+        printf '999999' > .fdb/fdb.pid
+
+        restore_stale_pid() {
+          if [ -n "$ORIGINAL_PID" ]; then
+            printf '%s' "$ORIGINAL_PID" > .fdb/fdb.pid
+          else
+            rm -f .fdb/fdb.pid
+          fi
+        }
+        trap restore_stale_pid EXIT
+
+        OUTPUT2=$({{.FDB}} status 2>&1)
+        EXIT_CODE2=$?
+        echo "$OUTPUT2"
+
+        restore_stale_pid
+        trap - EXIT
+
+        if [ $EXIT_CODE2 -ne 0 ]; then
+          echo "FAIL: fdb status exited with code $EXIT_CODE2" >&2
+          exit 1
+        fi
+        if echo "$OUTPUT2" | grep -q "RUNNING=true"; then
+          echo "PASS: fdb status correctly reports RUNNING=true via VM URI fallback (stale PID)"
+        else
+          echo "FAIL: fdb status - expected RUNNING=true when VM URI reachable but PID is stale" >&2
+          exit 1
+        fi
+
   # ---------------------------------------------------------------------------
   # Cleanup
   # ---------------------------------------------------------------------------
@@ -1583,6 +1658,7 @@ tasks:
         vars:
           DEVICE: '{{.DEVICE}}'
       - task: test:status
+      - task: test:status-after-interrupted-launch
       - task: test:reload
       - task: test:restart
       - task: test:logs

--- a/example/test_app/lib/main.dart
+++ b/example/test_app/lib/main.dart
@@ -196,7 +196,8 @@ class _FdbTestHomePageState extends State<FdbTestHomePage> {
               const SizedBox(height: 8),
               ElevatedButton(
                 key: const Key('go_to_native_view_test'),
-                onPressed: () => Navigator.pushNamed(context, '/native-view-test'),
+                onPressed: () =>
+                    Navigator.pushNamed(context, '/native-view-test'),
                 child: const Text('Native View Test'),
               ),
               const SizedBox(height: 8),
@@ -206,10 +207,13 @@ class _FdbTestHomePageState extends State<FdbTestHomePage> {
                   try {
                     final result = await _nativeDialogChannel
                         .invokeMethod<String>('showNativeAlert');
-                    if (mounted) setState(() => _nativeAlertResult = result ?? 'null');
-                    developer.log('native alert result: $result', name: 'fdb_test');
+                    if (mounted)
+                      setState(() => _nativeAlertResult = result ?? 'null');
+                    developer.log('native alert result: $result',
+                        name: 'fdb_test');
                   } catch (e) {
-                    if (mounted) setState(() => _nativeAlertResult = 'ERROR: $e');
+                    if (mounted)
+                      setState(() => _nativeAlertResult = 'ERROR: $e');
                   }
                 },
                 child: const Text('Show Native Alert'),

--- a/example/test_app/lib/native_view_test_screen.dart
+++ b/example/test_app/lib/native_view_test_screen.dart
@@ -112,7 +112,9 @@ class _NativeViewTestScreenState extends State<NativeViewTestScreen> {
             key: const Key('native_tap_status'),
             width: double.infinity,
             padding: const EdgeInsets.all(12),
-            color: _pageTitle == 'TAPPED' ? Colors.green.shade100 : Colors.grey.shade200,
+            color: _pageTitle == 'TAPPED'
+                ? Colors.green.shade100
+                : Colors.grey.shade200,
             child: Text(
               'WebView title: $_pageTitle',
               key: const Key('native_tap_status_text'),

--- a/lib/commands/status.dart
+++ b/lib/commands/status.dart
@@ -7,7 +7,8 @@ Future<int> runStatus(List<String> args) async {
   final vmUri = readVmUri();
 
   // Primary check: PID file exists and process is alive.
-  var running = pid != null && isProcessAlive(pid);
+  final pidAlive = pid != null && isProcessAlive(pid);
+  var running = pidAlive;
 
   // Fallback: the PID file may be absent or stale (e.g. fdb launch was killed
   // by an agent timeout after the Flutter app started but before APP_STARTED
@@ -19,8 +20,8 @@ Future<int> runStatus(List<String> args) async {
   }
 
   stdout.writeln('RUNNING=$running');
-  if (pid != null) stdout.writeln('PID=$pid');
-  if (vmUri != null) stdout.writeln('VM_SERVICE_URI=$vmUri');
+  if (pidAlive) stdout.writeln('PID=$pid');
+  if (running && vmUri != null) stdout.writeln('VM_SERVICE_URI=$vmUri');
 
   return 0;
 }

--- a/lib/commands/status.dart
+++ b/lib/commands/status.dart
@@ -5,7 +5,18 @@ import 'package:fdb/process_utils.dart';
 Future<int> runStatus(List<String> args) async {
   final pid = readPid();
   final vmUri = readVmUri();
-  final running = pid != null && isProcessAlive(pid);
+
+  // Primary check: PID file exists and process is alive.
+  var running = pid != null && isProcessAlive(pid);
+
+  // Fallback: the PID file may be absent or stale (e.g. fdb launch was killed
+  // by an agent timeout after the Flutter app started but before APP_STARTED
+  // was printed, or before --pid-file was written by flutter run). In that
+  // case, probe the VM service URI directly. If the WebSocket connects, the
+  // app is alive even though the PID check failed.
+  if (!running && vmUri != null) {
+    running = await isVmServiceReachable(vmUri);
+  }
 
   stdout.writeln('RUNNING=$running');
   if (pid != null) stdout.writeln('PID=$pid');

--- a/lib/process_utils.dart
+++ b/lib/process_utils.dart
@@ -80,7 +80,7 @@ bool isProcessAlive(int pid) {
 Future<bool> isVmServiceReachable(String uri) async {
   try {
     final ws = await WebSocket.connect(uri).timeout(const Duration(seconds: 3));
-    await ws.close();
+    unawaited(ws.close());
     return true;
   } catch (_) {
     // Intentional: timeout and all network errors mean "not reachable = false".

--- a/lib/process_utils.dart
+++ b/lib/process_utils.dart
@@ -13,7 +13,8 @@ int? readPid() {
 String? readVmUri() {
   final file = File(vmUriFile);
   if (!file.existsSync()) return null;
-  return file.readAsStringSync().trim();
+  final content = file.readAsStringSync().trim();
+  return content.isEmpty ? null : content;
 }
 
 String? readDevice() {
@@ -81,6 +82,8 @@ Future<bool> isVmServiceReachable(String uri) async {
     final ws = await WebSocket.connect(uri).timeout(const Duration(seconds: 3));
     await ws.close();
     return true;
+  } on TimeoutException {
+    rethrow;
   } catch (_) {
     return false;
   }

--- a/lib/process_utils.dart
+++ b/lib/process_utils.dart
@@ -82,9 +82,10 @@ Future<bool> isVmServiceReachable(String uri) async {
     final ws = await WebSocket.connect(uri).timeout(const Duration(seconds: 3));
     await ws.close();
     return true;
-  } on TimeoutException {
-    rethrow;
   } catch (_) {
+    // Intentional: timeout and all network errors mean "not reachable = false".
+    // This probe function is an explicit exception to the general
+    // "rethrow TimeoutException" rule — a timeout here is the probe's false case.
     return false;
   }
 }

--- a/lib/process_utils.dart
+++ b/lib/process_utils.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:fdb/constants.dart';
@@ -63,6 +64,23 @@ bool isProcessAlive(int pid) {
   try {
     final result = Process.runSync('kill', ['-0', pid.toString()]);
     return result.exitCode == 0;
+  } catch (_) {
+    return false;
+  }
+}
+
+/// Returns true if the VM service at [uri] is reachable by opening a WebSocket
+/// and waiting for the first byte (or a clean open). Times out quickly so
+/// `fdb status` does not block for long when the app is truly dead.
+///
+/// This is used as a fallback by `fdb status` when the PID file is missing or
+/// points to a dead process — a common scenario when `fdb launch` was killed by
+/// an agent timeout after the app started but before `APP_STARTED` was printed.
+Future<bool> isVmServiceReachable(String uri) async {
+  try {
+    final ws = await WebSocket.connect(uri).timeout(const Duration(seconds: 3));
+    await ws.close();
+    return true;
   } catch (_) {
     return false;
   }


### PR DESCRIPTION
When an agent's tool wrapper times out during fdb launch, the launch process is killed before APP_STARTED is printed — but the Flutter app keeps running. In this state, fdb status was reporting RUNNING=false because the PID file was either absent or pointed at the dead launcher process.

fdb status now falls back to probing the VM service URI via WebSocket when the PID check fails. If the connection succeeds, the app is alive and RUNNING=true is reported. This eliminates the false-negative that caused agents to restart a perfectly healthy app.

Closes #61