### PR TITLE
fix: auto-locate .fdb/ by walking up directory tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,14 @@ fdb kill
 | `fdb skill` | Print the AI agent skill file (SKILL.md) |
 | `fdb --version` | Print the fdb version |
 
+### Global options
+
+| Option | Description |
+|--------|-------------|
+| `fdb --session-dir <path> <command>` | Use a specific `.fdb/` session directory instead of auto-resolving |
+
+fdb automatically locates the active `.fdb/` session by walking up from the current directory, so you can run any command from a subdirectory without changing to the project root. Pass `--session-dir` to override this and point at a specific session directory.
+
 ### Widget Interaction (tap, input, scroll)
 
 Requires `fdb_helper` in your app:
@@ -186,6 +194,8 @@ void main() {
 **Empty widget tree** - App may still be starting. Retry, or use `fdb describe` instead.
 
 **`RUNNING=false` right after launch** - The process crashed. Check `fdb logs --last 50`.
+
+**`RUNNING=false` when running from a subdirectory** - fdb walks up the directory tree to find the nearest `.fdb/` session automatically. If it still shows `RUNNING=false`, the app may not be running or the session has a stale PID. Use `fdb --session-dir <project>/.fdb status` to point directly at the session directory.
 
 **Widget interaction fails** - `fdb_helper` missing from `pubspec.yaml`, or `FdbBinding.ensureInitialized()` not called.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1669,6 +1669,159 @@ tasks:
           exit 1
         fi
 
+  test:session-dir:
+    desc: Verify session dir auto-resolution by walking up from a subdirectory
+    vars:
+      DEVICE:
+        sh: '{{if .DEVICE}}echo "{{.DEVICE}}"{{else}}task detect-device{{end}}'
+    cmds:
+      - |
+        # Ensure a clean state: launch the test app so a live .fdb/ exists.
+        echo "==> Launching test app for session-dir walk-up test"
+        cd "{{.TEST_APP}}"
+        OUTPUT=$({{.FDB}} launch --device "{{.DEVICE}}" 2>&1)
+        EXIT_CODE=$?
+        echo "$OUTPUT"
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "FAIL: fdb launch exited with code $EXIT_CODE" >&2
+          exit 1
+        fi
+        if ! echo "$OUTPUT" | grep -q "APP_STARTED"; then
+          echo "FAIL: fdb launch - APP_STARTED not found in output" >&2
+          exit 1
+        fi
+
+        # ---------------------------------------------------------------
+        # Scenario 1: CWD is project root — works as before (baseline).
+        # ---------------------------------------------------------------
+        echo "==> Scenario 1: CWD is project root — status should work"
+        OUTPUT=$({{.FDB}} status 2>&1)
+        echo "$OUTPUT"
+        if echo "$OUTPUT" | grep -q "RUNNING=true"; then
+          echo "PASS: Scenario 1 - status from project root"
+        else
+          echo "FAIL: Scenario 1 - expected RUNNING=true from project root" >&2
+          {{.FDB}} kill >/dev/null 2>&1 || true
+          exit 1
+        fi
+
+        # ---------------------------------------------------------------
+        # Scenario 2: CWD is a subdirectory — walk-up finds .fdb/.
+        # ---------------------------------------------------------------
+        echo "==> Scenario 2: CWD is subdirectory — walk-up finds .fdb/"
+        mkdir -p "{{.TEST_APP}}/lib/features/checkout"
+        OUTPUT=$(cd "{{.TEST_APP}}/lib/features/checkout" && {{.FDB}} status 2>&1)
+        EXIT_CODE=$?
+        echo "$OUTPUT"
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "FAIL: Scenario 2 - fdb status from subdirectory exited with code $EXIT_CODE" >&2
+          {{.FDB}} kill >/dev/null 2>&1 || true
+          exit 1
+        fi
+        if echo "$OUTPUT" | grep -q "RUNNING=true"; then
+          echo "PASS: Scenario 2 - walk-up resolved session dir from subdirectory"
+        else
+          echo "FAIL: Scenario 2 - expected RUNNING=true from subdirectory (walk-up should find .fdb/)" >&2
+          {{.FDB}} kill >/dev/null 2>&1 || true
+          exit 1
+        fi
+        # Verify the INFO line was emitted to stderr (stdout+stderr merged above).
+        if echo "$OUTPUT" | grep -q "INFO: Using session dir from"; then
+          echo "PASS: Scenario 2 - INFO line emitted when resolving from parent"
+        else
+          echo "FAIL: Scenario 2 - INFO: line not found in output" >&2
+          {{.FDB}} kill >/dev/null 2>&1 || true
+          exit 1
+        fi
+
+        # ---------------------------------------------------------------
+        # Scenario 3: --session-dir bypasses auto-resolution.
+        # ---------------------------------------------------------------
+        echo "==> Scenario 3: --session-dir flag bypasses auto-resolution"
+        SESSION_DIR="{{.TEST_APP}}/.fdb"
+        OUTPUT=$(cd /tmp && {{.FDB}} --session-dir "$SESSION_DIR" status 2>&1)
+        EXIT_CODE=$?
+        echo "$OUTPUT"
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "FAIL: Scenario 3 - fdb --session-dir status exited with code $EXIT_CODE" >&2
+          {{.FDB}} kill >/dev/null 2>&1 || true
+          exit 1
+        fi
+        if echo "$OUTPUT" | grep -q "RUNNING=true"; then
+          echo "PASS: Scenario 3 - --session-dir flag works"
+        else
+          echo "FAIL: Scenario 3 - expected RUNNING=true with explicit --session-dir" >&2
+          {{.FDB}} kill >/dev/null 2>&1 || true
+          exit 1
+        fi
+
+        # ---------------------------------------------------------------
+        # Scenario 4: unrelated directory — clear error, exit 1.
+        # ---------------------------------------------------------------
+        echo "==> Scenario 4: unrelated directory — clear error"
+        TMPDIR=$(mktemp -d)
+        set +e
+        OUTPUT=$(cd "$TMPDIR" && {{.FDB}} reload 2>&1)
+        EXIT_CODE=$?
+        set -e
+        rm -rf "$TMPDIR"
+        echo "$OUTPUT"
+        if [ "$EXIT_CODE" -ne 1 ]; then
+          echo "FAIL: Scenario 4 - expected exit code 1, got $EXIT_CODE" >&2
+          {{.FDB}} kill >/dev/null 2>&1 || true
+          exit 1
+        fi
+        if ! echo "$OUTPUT" | grep -q "ERROR:"; then
+          echo "FAIL: Scenario 4 - expected ERROR: message in output" >&2
+          {{.FDB}} kill >/dev/null 2>&1 || true
+          exit 1
+        fi
+        echo "PASS: Scenario 4 - exit 1 with ERROR: from unrelated directory"
+
+        # ---------------------------------------------------------------
+        # Scenario 5: fdb status with no running app — RUNNING=false, exit 0.
+        # ---------------------------------------------------------------
+        echo "==> Scenario 5: status with no running app"
+        {{.FDB}} kill >/dev/null 2>&1 || true
+        set +e
+        OUTPUT=$({{.FDB}} status 2>&1)
+        EXIT_CODE=$?
+        set -e
+        echo "$OUTPUT"
+        if [ "$EXIT_CODE" -ne 0 ]; then
+          echo "FAIL: Scenario 5 - expected exit code 0, got $EXIT_CODE" >&2
+          exit 1
+        fi
+        if ! echo "$OUTPUT" | grep -q "RUNNING=false"; then
+          echo "FAIL: Scenario 5 - expected RUNNING=false when app not running" >&2
+          exit 1
+        fi
+        echo "PASS: Scenario 5 - status returns RUNNING=false with exit 0 when app not running"
+
+        # ---------------------------------------------------------------
+        # Scenario 6: stale .fdb/ (dead PID, dir still on disk) — exit 1.
+        # ---------------------------------------------------------------
+        echo "==> Scenario 6: stale .fdb/ does not bypass exit-1 guard"
+        # The app is already killed from Scenario 5; .fdb/ dir remains on disk.
+        set +e
+        OUTPUT=$({{.FDB}} reload 2>&1)
+        EXIT_CODE=$?
+        set -e
+        echo "$OUTPUT"
+        if [ "$EXIT_CODE" -ne 1 ]; then
+          echo "FAIL: Scenario 6 - expected exit code 1, got $EXIT_CODE" >&2
+          exit 1
+        fi
+        if ! echo "$OUTPUT" | grep -q "ERROR:"; then
+          echo "FAIL: Scenario 6 - expected ERROR: message in output" >&2
+          exit 1
+        fi
+        echo "PASS: Scenario 6 - stale .fdb/ correctly produces ERROR: and exit 1"
+
+        # Clean up.
+        {{.FDB}} kill >/dev/null 2>&1 || true
+        echo "PASS: fdb session-dir walk-up"
+
   # ---------------------------------------------------------------------------
   # Cleanup
   # ---------------------------------------------------------------------------
@@ -1729,6 +1882,9 @@ tasks:
       - task: test:shared-prefs
       - task: test:kill
       - task: test:status-stopped
+      - task: test:session-dir
+        vars:
+          DEVICE: '{{.DEVICE}}'
 
   # ---------------------------------------------------------------------------
   # Code quality — individual steps

--- a/bin/fdb.dart
+++ b/bin/fdb.dart
@@ -30,7 +30,7 @@ import 'package:fdb/commands/wait.dart';
 import 'package:fdb/constants.dart';
 
 const usage = '''
-Usage: fdb <command> [args]
+Usage: fdb [--session-dir <path>] <command> [args]
 
 Commands:
   devices     List connected devices
@@ -61,8 +61,9 @@ Commands:
   kill        Stop the running app
   skill       Print the AI agent skill file (SKILL.md)
 
-Options:
-  --version   Print the fdb version
+Global options:
+  --session-dir <path>  Use this .fdb/ session directory instead of auto-resolving
+  --version             Print the fdb version
 ''';
 
 Future<void> main(List<String> args) async {
@@ -76,14 +77,48 @@ Future<void> main(List<String> args) async {
     exit(0);
   }
 
-  final command = args[0];
+  // Strip global flags before the command word.
+  var remaining = args.toList();
+  String? explicitSessionDir;
 
-  if (command == '--version' || command == '-v') {
-    stdout.writeln('fdb $version');
-    exit(0);
+  while (remaining.isNotEmpty && remaining[0].startsWith('-')) {
+    if (remaining[0] == '--session-dir' && remaining.length > 1) {
+      explicitSessionDir = remaining[1];
+      remaining = remaining.sublist(2);
+    } else if (remaining[0] == '--version' || remaining[0] == '-v') {
+      stdout.writeln('fdb $version');
+      exit(0);
+    } else {
+      // Unknown global flag — leave it for the command to handle or reject.
+      break;
+    }
   }
 
-  final commandArgs = args.sublist(1);
+  if (remaining.isEmpty) {
+    stderr.writeln(usage);
+    exit(1);
+  }
+
+  final command = remaining[0];
+
+  final commandArgs = remaining.sublist(1);
+
+  // Resolve session directory.
+  // `launch` manages its own session dir via --project; skip auto-resolution.
+  // All other commands benefit from walking up to find an active .fdb/.
+  if (command != 'launch' && command != 'devices' && command != 'skill') {
+    if (explicitSessionDir != null) {
+      initSessionDirFromPath(explicitSessionDir);
+    } else {
+      final resolved = resolveSessionDir();
+      if (command != 'status' && resolved == null) {
+        stderr.writeln(
+          'ERROR: No .fdb/ session found. Run from the project root or pass --session-dir <path>.',
+        );
+        exit(1);
+      }
+    }
+  }
 
   try {
     final exitCode = await _runCommand(command, commandArgs);

--- a/doc/README.agents.md
+++ b/doc/README.agents.md
@@ -128,6 +128,7 @@ curl -fsSL https://raw.githubusercontent.com/andrzejchm/fdb/main/skills/using-fd
 | `fdb kill` | Stop app |
 | `fdb skill` | Print the AI agent skill file (SKILL.md) |
 | `fdb --version` | Print the fdb version |
+| `fdb --session-dir <path> <command>` | Use a specific `.fdb/` session directory instead of auto-resolving |
 
 ### Launch
 
@@ -317,3 +318,5 @@ fdb logs --tag "fdb_test" --last 20       # check logs after interaction
 **Screenshot fails** -- Check the tool for your platform is on PATH: `adb` (Android), `xcrun` (iOS simulator), `screencapture` (macOS), `xdotool`+`import` (Linux X11). Physical iOS, Windows, and Wayland use `fdb_helper` — add it to your app and call `FdbBinding.ensureInitialized()`.
 
 **Status shows RUNNING=false after launch** -- The Flutter process may have crashed. Check `fdb logs --last 50` for errors.
+
+**Commands report RUNNING=false when run from a subdirectory** -- fdb automatically walks up the directory tree to find the nearest live `.fdb/` session, so you don't need to be in the project root. If it still fails, use `fdb --session-dir <project>/.fdb status` to point directly at the session directory.

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -9,6 +9,7 @@ const sessionDirName = '.fdb';
 /// The active session directory. Defaults to `<CWD>/.fdb/`.
 /// [initSessionDir] overrides this for commands like `launch` that receive an
 /// explicit `--project` path.
+/// [resolveSessionDir] auto-locates an existing `.fdb/` by walking up the tree.
 String _sessionDir = '${Directory.current.path}/$sessionDirName';
 
 /// Override the session directory (e.g. from `--project`).
@@ -17,6 +18,79 @@ String _sessionDir = '${Directory.current.path}/$sessionDirName';
 void initSessionDir(String projectPath) {
   final absolute = Directory(projectPath).absolute.path;
   _sessionDir = '$absolute/$sessionDirName';
+}
+
+/// Override the session directory from an explicit `--session-dir` flag.
+/// Skips auto-resolution entirely — the caller is responsible for the path.
+void initSessionDirFromPath(String sessionDirPath) {
+  _sessionDir = Directory(sessionDirPath).absolute.path;
+}
+
+/// Auto-locate the session directory by walking up from [start] (defaults to
+/// CWD) looking for an existing `.fdb/` directory whose PID file points at a
+/// live process.
+///
+/// Walk stops at `$HOME` or the filesystem root, whichever comes first.
+///
+/// - If a live `.fdb/` is found in a *parent* of [start], logs one `INFO:`
+///   line to stderr so the user knows which directory was picked.
+/// - If no live `.fdb/` is found anywhere, returns `null` and leaves
+///   `_sessionDir` at the CWD default so commands like `status` can handle
+///   the missing-session case themselves.
+///
+/// Returns the resolved session-dir path, or `null` if no live session was found.
+String? resolveSessionDir({Directory? start}) {
+  final cwd = (start ?? Directory.current).absolute.path;
+  final home = Platform.environment['HOME'] ?? '/';
+
+  var current = Directory(cwd);
+
+  while (true) {
+    final candidate = Directory('${current.path}/$sessionDirName');
+    if (candidate.existsSync()) {
+      final pidPath = '${candidate.path}/fdb.pid';
+      final pidFile = File(pidPath);
+      bool alive;
+      if (pidFile.existsSync()) {
+        final raw = pidFile.readAsStringSync().trim();
+        final pid = int.tryParse(raw);
+        if (pid != null) {
+          try {
+            alive = Process.runSync('kill', ['-0', pid.toString()]).exitCode == 0;
+          } catch (_) {
+            alive = false;
+          }
+        } else {
+          alive = false;
+        }
+      } else {
+        // No PID file — directory exists but was never fully initialised;
+        // treat as a valid candidate.
+        alive = true;
+      }
+
+      if (alive) {
+        final resolved = candidate.absolute.path;
+        if (resolved != Directory('$cwd/$sessionDirName').absolute.path) {
+          stderr.writeln('INFO: Using session dir from ${current.path}');
+        }
+        _sessionDir = resolved;
+        return resolved;
+      }
+    }
+
+    // Stop at $HOME or filesystem root — never walk past either.
+    final parent = current.parent;
+    final atHome = current.absolute.path == Directory(home).absolute.path;
+    final atRoot = parent.path == current.path;
+    if (atHome || atRoot) break;
+    current = parent;
+  }
+
+  // No live session found — keep _sessionDir at <CWD>/.fdb/ so commands like
+  // `status` can handle the missing-session case themselves.
+  _sessionDir = '$cwd/$sessionDirName';
+  return null;
 }
 
 /// Ensure the session directory exists and return its path.

--- a/skills/using-fdb/SKILL.md
+++ b/skills/using-fdb/SKILL.md
@@ -337,6 +337,12 @@ fdb status    # RUNNING=true/false, PID, VM_SERVICE_URI
 fdb kill      # stop app, clean up temp files
 ```
 
+fdb auto-locates the active `.fdb/` session by walking up from the current directory, so you can run any command from a subdirectory without switching to the project root. Use `--session-dir` to override:
+
+```bash
+fdb --session-dir /path/to/project/.fdb status   # explicit session directory
+```
+
 ## Deep links
 
 ```bash
@@ -446,7 +452,7 @@ fdb screenshot
 
 ## State files
 
-All state lives in `<project>/.fdb/`:
+All state lives in `<project>/.fdb/`. fdb resolves this directory automatically by walking up from the current working directory to the nearest ancestor that contains a live `.fdb/` — so you never need to `cd` to the project root before running a command. Pass `--session-dir <path>` to bypass auto-resolution entirely.
 - `<project>/.fdb/fdb.pid` - flutter run process ID
 - `<project>/.fdb/logs.txt` - full app output
 - `<project>/.fdb/vm_uri.txt` - VM service websocket URI


### PR DESCRIPTION
Running any fdb command from a subdirectory silently reports RUNNING=false because the session dir was always resolved as <CWD>/.fdb/. This fixes the footgun by walking up from CWD to the first ancestor that contains a live .fdb/ directory, so agents and users no longer need to be in the exact project root.

Adds a --session-dir global flag to bypass auto-resolution when the caller knows the path explicitly. Closes #54.