### PR TITLE
feat: detect app death and surface APP_DIED instead of hanging

### DIFF
--- a/.agents/skills/testing-fdb/SKILL.md
+++ b/.agents/skills/testing-fdb/SKILL.md
@@ -51,6 +51,7 @@ task test:select
 task test:tap
 task test:input
 task test:scroll
+task test:app-died
 task test:kill
 task test:status-stopped
 ```

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1518,6 +1518,147 @@ tasks:
           exit 1
         fi
 
+  test:app-died:
+    desc: "Verify fdb exits with APP_DIED and non-zero code when the app process is killed"
+    dir: '{{.TEST_APP}}'
+    vars:
+      DEVICE:
+        sh: '{{if .DEVICE}}echo "{{.DEVICE}}"{{else}}task detect-device{{end}}'
+    cmds:
+      - |
+        echo "==> [app-died] Ensuring app is running"
+        if ! {{.FDB}} status 2>&1 | grep -q "RUNNING=true"; then
+          echo "==> [app-died] App not running — launching first"
+          OUTPUT=$({{.FDB}} launch --device "{{.DEVICE}}" 2>&1)
+          EXIT_CODE=$?
+          echo "$OUTPUT"
+          if [ $EXIT_CODE -ne 0 ]; then
+            echo "FAIL: fdb launch exited with code $EXIT_CODE" >&2
+            exit 1
+          fi
+          if ! echo "$OUTPUT" | grep -q "APP_STARTED"; then
+            echo "FAIL: fdb launch - APP_STARTED not found in output" >&2
+            exit 1
+          fi
+        fi
+
+        echo "==> [app-died] Waiting for app to be ready"
+        READY=0
+        for _ in $(seq 1 20); do
+          if {{.FDB}} tree --depth 1 >/dev/null 2>&1; then
+            READY=1
+            break
+          fi
+          sleep 0.5
+        done
+        if [ $READY -ne 1 ]; then
+          echo "FAIL: app did not become ready in time" >&2
+          exit 1
+        fi
+
+        # Detect platform to use the right kill mechanism.
+        # NOTE: fdb.pid stores the flutter-tools process PID, not the actual app
+        # process PID (see https://github.com/andrzejchm/fdb/issues — fdb-bbu).
+        # We must use platform-specific tooling to kill the actual app process.
+        PLATFORM=$(cat .fdb/platform.txt 2>/dev/null | awk '{print $1}' || echo "")
+        DEVICE_ID=$(cat .fdb/device.txt 2>/dev/null || echo "")
+        echo "==> [app-died] Platform=$PLATFORM Device=$DEVICE_ID"
+
+        if [ "$PLATFORM" = "ios" ] || [ "$PLATFORM" = "iOS" ]; then
+          echo "==> [app-died] iOS simulator — terminating via simctl"
+          # Find the bundle ID of the RUNNING app (not just installed) via
+          # launchctl inside the simulator — avoids picking the wrong entry when
+          # multiple test_app builds are installed.
+          BUNDLE_ID=$(xcrun simctl spawn "$DEVICE_ID" launchctl list 2>/dev/null \
+            | grep "UIKitApplication:" \
+            | sed 's/.*UIKitApplication:\([^[]*\).*/\1/' \
+            | head -1)
+          if [ -z "$BUNDLE_ID" ]; then
+            # Fallback: try each installed test_app bundle until one terminates
+            BUNDLE_ID=$(xcrun simctl listapps "$DEVICE_ID" 2>/dev/null \
+              | grep -A1 'CFBundleName = "test_app"' \
+              | grep CFBundleIdentifier \
+              | sed 's/.*= "\(.*\)";/\1/' \
+              | head -1)
+          fi
+          if [ -z "$BUNDLE_ID" ]; then
+            echo "SKIP: could not determine bundle ID on iOS simulator — skipping app-died test" >&2
+            exit 0
+          fi
+          echo "  BundleID=$BUNDLE_ID"
+          xcrun simctl terminate "$DEVICE_ID" "$BUNDLE_ID" 2>&1 || true
+
+        elif [ "$PLATFORM" = "darwin" ] || [ "$PLATFORM" = "macos" ] || [ "$PLATFORM" = "macOS" ]; then
+          echo "==> [app-died] macOS — killing app binary process"
+          # The macOS .app process is separate from the flutter-tools PID in fdb.pid
+          APP_BIN=$(find "$(pwd)/build/macos/Build/Products/Debug" -name "test_app" -type f 2>/dev/null | head -1)
+          if [ -n "$APP_BIN" ]; then
+            pkill -9 -f "$APP_BIN" 2>/dev/null || true
+          else
+            pkill -9 -f "test_app.app/Contents/MacOS/test_app" 2>/dev/null || true
+          fi
+
+        elif [ "$PLATFORM" = "android" ] || echo "$PLATFORM" | grep -qi "android"; then
+          echo "==> [app-died] Android — force-stopping via adb"
+          # Try to find the app package name
+          PACKAGE=$(adb -s "$DEVICE_ID" shell pm list packages 2>/dev/null \
+            | grep -i "test.app\|testapp\|fdb.test" \
+            | sed 's/package://' \
+            | head -1 | tr -d '\r')
+          if [ -z "$PACKAGE" ]; then
+            echo "SKIP: could not determine package name on Android — skipping app-died test" >&2
+            exit 0
+          fi
+          echo "  Package=$PACKAGE"
+          adb -s "$DEVICE_ID" shell am force-stop "$PACKAGE" 2>&1 || true
+
+        else
+          echo "==> [app-died] Unknown platform '$PLATFORM' — killing flutter-tools PID as best-effort"
+          PID=$(cat .fdb/fdb.pid 2>/dev/null)
+          if [ -n "$PID" ]; then
+            kill -9 "$PID" 2>/dev/null || true
+            # Also kill any child processes
+            pkill -9 -P "$PID" 2>/dev/null || true
+          fi
+        fi
+
+        sleep 2
+
+        echo "==> [app-died] Running fdb tap @1 — should exit non-zero with APP_DIED"
+        set +e
+        OUTPUT=$({{.FDB}} tap @1 2>&1)
+        EXIT_CODE=$?
+        set -e
+        echo "$OUTPUT"
+
+        if [ $EXIT_CODE -eq 0 ]; then
+          echo "FAIL: fdb tap should have exited non-zero after app death, got 0" >&2
+          exit 1
+        fi
+
+        if echo "$OUTPUT" | grep -q "APP_DIED"; then
+          echo "PASS: APP_DIED detected in output"
+        else
+          echo "FAIL: APP_DIED not found in output (got exit $EXIT_CODE)" >&2
+          exit 1
+        fi
+
+        if echo "$OUTPUT" | grep -q "See: fdb crash-report"; then
+          echo "PASS: See: fdb crash-report hint present"
+        else
+          echo "FAIL: 'See: fdb crash-report' hint not found in output" >&2
+          exit 1
+        fi
+
+        if echo "$OUTPUT" | grep -qE "Last [0-9]+ log lines:"; then
+          echo "PASS: log tail present in APP_DIED output"
+        else
+          echo "FAIL: log tail 'Last N log lines:' not found in output" >&2
+          exit 1
+        fi
+
+        echo "PASS: fdb app-died"
+
   test:kill:
     desc: Kill the running app
     dir: '{{.TEST_APP}}'
@@ -1880,6 +2021,9 @@ tasks:
       - task: test:back
       - task: test:clean
       - task: test:shared-prefs
+      - task: test:app-died
+        vars:
+          DEVICE: '{{.DEVICE}}'
       - task: test:kill
       - task: test:status-stopped
       - task: test:session-dir

--- a/bin/fdb.dart
+++ b/bin/fdb.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:fdb/app_died_exception.dart';
 import 'package:fdb/commands/back.dart';
 import 'package:fdb/commands/clean.dart';
 import 'package:fdb/commands/shared_prefs.dart';
@@ -123,6 +124,9 @@ Future<void> main(List<String> args) async {
   try {
     final exitCode = await _runCommand(command, commandArgs);
     exit(exitCode);
+  } on AppDiedException catch (e) {
+    _formatAppDied(e);
+    exit(1);
   } catch (e) {
     stderr.writeln('ERROR: $e');
     exit(1);
@@ -190,4 +194,27 @@ Future<int> _runCommand(String command, List<String> args) {
       stderr.writeln(usage);
       return Future.value(1);
   }
+}
+
+/// Formats an [AppDiedException] to stderr in the standard fdb error style:
+///
+/// ```
+/// ERROR: APP_DIED REASON=jetsam_highwater
+/// Last 20 log lines:
+///   <line>
+///   ...
+/// See: fdb crash-report
+/// ```
+void _formatAppDied(AppDiedException e) {
+  final reasonSuffix = e.reason != null ? ' REASON=${e.reason}' : '';
+  stderr.writeln('ERROR: APP_DIED$reasonSuffix');
+
+  if (e.logLines.isNotEmpty) {
+    stderr.writeln('Last ${e.logLines.length} log lines:');
+    for (final line in e.logLines) {
+      stderr.writeln('  $line');
+    }
+  }
+
+  stderr.writeln('See: fdb crash-report');
 }

--- a/doc/README.agents.md
+++ b/doc/README.agents.md
@@ -320,3 +320,10 @@ fdb logs --tag "fdb_test" --last 20       # check logs after interaction
 **Status shows RUNNING=false after launch** -- If `fdb launch` was killed by a tool timeout but the Flutter app is still running, `fdb status` will probe the VM service URI directly and report `RUNNING=true`. If it still reports `RUNNING=false`, the Flutter process may have crashed — check `fdb logs --last 50` for errors.
 
 **Commands report RUNNING=false when run from a subdirectory** -- fdb automatically walks up the directory tree to find the nearest live `.fdb/` session, so you don't need to be in the project root. If it still fails, use `fdb --session-dir <project>/.fdb status` to point directly at the session directory.
+
+**`ERROR: APP_DIED` instead of a result** -- The target Flutter app process has died while fdb was communicating with it. fdb detects this and exits immediately with a non-zero code rather than hanging. The error output includes:
+- An optional `REASON=` field (e.g. `jetsam_highwater`, `lmk`, `crash_NullPointerException`) from OS-level logs when the cause can be determined automatically.
+- The last 20 lines of `.fdb/logs.txt` so you can see recent app output.
+- A `See: fdb crash-report` hint when a structured reason is available.
+
+To investigate further, run `fdb logs --last 50` or `fdb crash-report` (when available). Then relaunch with `fdb launch`.

--- a/lib/app_died_exception.dart
+++ b/lib/app_died_exception.dart
@@ -1,0 +1,208 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:fdb/constants.dart';
+import 'package:fdb/process_utils.dart';
+
+/// Thrown when the target Flutter app process has died while fdb is trying to
+/// communicate with it via the VM service.
+///
+/// Carries the last [logLines] from `.fdb/logs.txt` and an optional structured
+/// [reason] string (e.g. `jetsam_highwater`, `lmk`, `crash_NullPointerException`)
+/// obtained from OS-level log queries.
+///
+/// Formatted by the top-level error handler in `bin/fdb.dart`.
+class AppDiedException implements Exception {
+  AppDiedException({required this.logLines, this.reason});
+
+  /// Last N lines from `.fdb/logs.txt`.
+  final List<String> logLines;
+
+  /// Optional OS-level reason (jetsam/LMK/native crash). Null if unavailable.
+  final String? reason;
+
+  @override
+  String toString() => 'AppDiedException(reason: $reason)';
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+const _logTailLines = 20;
+const _reasonTimeoutSeconds = 3;
+
+/// Reads the last [_logTailLines] lines from `.fdb/logs.txt`.
+List<String> readLastLogLines() {
+  try {
+    final file = File(logFile);
+    if (!file.existsSync()) return [];
+    final lines = file.readAsLinesSync();
+    if (lines.length <= _logTailLines) return lines;
+    return lines.sublist(lines.length - _logTailLines);
+  } catch (_) {
+    return [];
+  }
+}
+
+/// Builds an [AppDiedException] by reading the log tail and, when possible,
+/// performing a best-effort OS-level reason lookup.
+///
+/// [pid] is used on some platforms; may be null if the PID file was absent.
+///
+/// This is a shared helper reused by #58 (`fdb crash-report`).
+Future<AppDiedException> buildAppDiedException({int? pid}) async {
+  final logLines = readLastLogLines();
+  final reason = await _lookupCrashReason(pid: pid);
+  return AppDiedException(logLines: logLines, reason: reason);
+}
+
+/// Tries to determine why the app died from OS-level log sources.
+///
+/// Returns a compact reason string on success, null on any failure (including
+/// the [_reasonTimeoutSeconds] time limit).
+///
+/// Per-platform strategy:
+/// - **iOS simulator**: `xcrun simctl spawn <udid> log show` for jetsam entries.
+/// - **Android**: `adb -s <device> logcat -b crash -d -t 50` for LMK / FATAL.
+/// - **macOS**: `log show` for crash entries matching the app process.
+/// - Others: returns null immediately.
+Future<String?> _lookupCrashReason({int? pid}) async {
+  try {
+    return await _doCrashReasonLookup(pid: pid).timeout(
+      const Duration(seconds: _reasonTimeoutSeconds),
+    );
+  } catch (_) {
+    // Intentional: any failure (timeout, OS error, parse error) → null.
+    // REASON is a bonus, not a requirement.
+    return null;
+  }
+}
+
+Future<String?> _doCrashReasonLookup({int? pid}) async {
+  final info = readPlatformInfo();
+  if (info == null) return null;
+
+  final platform = info.platform.toLowerCase();
+
+  if (platform.startsWith('ios') && info.emulator) {
+    return _lookupIosSimulatorReason();
+  }
+  if (platform.startsWith('android')) {
+    return _lookupAndroidReason();
+  }
+  if (platform == 'darwin' || platform == 'macos') {
+    return _lookupMacOsReason(pid: pid);
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// iOS simulator — jetsam lookup
+// ---------------------------------------------------------------------------
+
+Future<String?> _lookupIosSimulatorReason() async {
+  final device = readDevice();
+  if (device == null) return null;
+
+  final result = await Process.run('xcrun', [
+    'simctl',
+    'spawn',
+    device,
+    'log',
+    'show',
+    '--last',
+    '30s',
+    '--predicate',
+    'eventMessage CONTAINS "jetsam"',
+  ]);
+
+  if (result.exitCode != 0) return null;
+
+  final output = result.stdout as String;
+  // Look for a reason field in jetsam entries, e.g. "jetsam_highwater"
+  final match = RegExp(r'jetsam[_-](\w+)', caseSensitive: false).firstMatch(output);
+  if (match != null) {
+    return 'jetsam_${match.group(1)?.toLowerCase()}';
+  }
+  if (output.toLowerCase().contains('jetsam')) {
+    return 'jetsam';
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Android — LMK / FATAL EXCEPTION
+// ---------------------------------------------------------------------------
+
+Future<String?> _lookupAndroidReason() async {
+  final device = readDevice();
+  if (device == null) return null;
+
+  final result = await Process.run('adb', [
+    '-s',
+    device,
+    'logcat',
+    '-b',
+    'crash',
+    '-d',
+    '-t',
+    '50',
+  ]);
+
+  if (result.exitCode != 0) return null;
+
+  final output = result.stdout as String;
+
+  // Low-memory killer
+  if (RegExp(r'LowMemoryKiller|kill.*to free', caseSensitive: false).hasMatch(output)) {
+    return 'lmk';
+  }
+
+  // Fatal exception — extract the exception class
+  final fatalMatch = RegExp(
+    r'FATAL EXCEPTION.*\n.*\n\s*(\S+Exception|\S+Error)',
+    dotAll: true,
+    caseSensitive: false,
+  ).firstMatch(output);
+  if (fatalMatch != null) {
+    final exClass = fatalMatch.group(1) ?? 'unknown';
+    // Trim package prefix
+    final shortName = exClass.split('.').last;
+    return 'crash_$shortName';
+  }
+
+  if (output.contains('FATAL EXCEPTION')) {
+    return 'crash';
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// macOS — log show
+// ---------------------------------------------------------------------------
+
+Future<String?> _lookupMacOsReason({int? pid}) async {
+  if (pid == null) return null;
+
+  final args = [
+    'show',
+    '--last',
+    '30s',
+    '--process',
+    pid.toString(),
+    '--predicate',
+    'eventMessage CONTAINS "crash" OR eventMessage CONTAINS "killed"',
+  ];
+
+  final result = await Process.run('log', args);
+  if (result.exitCode != 0) return null;
+
+  final output = result.stdout as String;
+  if (output.trim().isEmpty) return null;
+
+  if (output.toLowerCase().contains('killed')) return 'killed';
+  if (output.toLowerCase().contains('crash')) return 'crash';
+  return null;
+}

--- a/lib/commands/back.dart
+++ b/lib/commands/back.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:fdb/app_died_exception.dart';
 import 'package:fdb/vm_service.dart';
 
 /// Triggers Navigator.maybePop() in the running Flutter app.
@@ -47,6 +48,8 @@ Future<int> runBack(List<String> args) async {
 
     stderr.writeln('ERROR: Unexpected response from ext.fdb.back: $result');
     return 1;
+  } on AppDiedException {
+    rethrow;
   } catch (e) {
     stderr.writeln('ERROR: $e');
     return 1;

--- a/lib/commands/describe.dart
+++ b/lib/commands/describe.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:fdb/app_died_exception.dart';
 import 'package:fdb/vm_service.dart';
 
 /// Returns a compact, text-based snapshot of the current screen.
@@ -49,6 +50,8 @@ Future<int> runDescribe(List<String> args) async {
 
     _printDescribeOutput(result);
     return 0;
+  } on AppDiedException {
+    rethrow;
   } catch (e) {
     stderr.writeln('ERROR: $e');
     return 1;

--- a/lib/commands/double_tap.dart
+++ b/lib/commands/double_tap.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:fdb/app_died_exception.dart';
 import 'package:fdb/vm_service.dart';
 
 /// Double-taps a widget identified by selector or absolute coordinates.
@@ -141,6 +142,8 @@ Future<int> runDoubleTap(List<String> args) async {
       stderr.writeln('ERROR: Unexpected response from ext.fdb.doubleTap: $result');
       return 1;
     }
+  } on AppDiedException {
+    rethrow;
   } catch (e) {
     stderr.writeln('ERROR: $e');
     return 1;

--- a/lib/commands/input.dart
+++ b/lib/commands/input.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:fdb/app_died_exception.dart';
 import 'package:fdb/vm_service.dart';
 
 /// Enters text into a field identified by selector or the currently focused field.
@@ -90,6 +91,8 @@ Future<int> runInput(List<String> args) async {
 
     stderr.writeln('ERROR: Unexpected response from ext.fdb.enterText: $result');
     return 1;
+  } on AppDiedException {
+    rethrow;
   } catch (e) {
     stderr.writeln('ERROR: $e');
     return 1;

--- a/lib/commands/longpress.dart
+++ b/lib/commands/longpress.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:fdb/app_died_exception.dart';
 import 'package:fdb/vm_service.dart';
 
 /// Long-presses a widget identified by selector or absolute coordinates.
@@ -165,6 +166,8 @@ Future<int> runLongpress(List<String> args) async {
       );
       return 1;
     }
+  } on AppDiedException {
+    rethrow;
   } catch (e) {
     stderr.writeln('ERROR: $e');
     return 1;

--- a/lib/commands/screenshot.dart
+++ b/lib/commands/screenshot.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:fdb/app_died_exception.dart';
 import 'package:fdb/constants.dart';
 import 'package:fdb/process_utils.dart';
 import 'package:fdb/vm_service.dart';
@@ -229,6 +230,8 @@ Future<int> _captureMacOs(String output) async {
       return _captureViaFdbHelper(output);
     }
     return 0;
+  } on AppDiedException {
+    rethrow;
   } catch (e) {
     stderr.writeln('ERROR: macOS screenshot failed: $e');
     return 1;
@@ -468,6 +471,8 @@ Future<int> _captureViaFdbHelper(String output) async {
 
     File(output).writeAsBytesSync(base64Decode(base64Data));
     return 0;
+  } on AppDiedException {
+    rethrow;
   } catch (e) {
     stderr.writeln('ERROR: fdb_helper screenshot failed: $e');
     return 1;

--- a/lib/commands/scroll.dart
+++ b/lib/commands/scroll.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:fdb/app_died_exception.dart';
 import 'package:fdb/vm_service.dart';
 
 const _directions = ['up', 'down', 'left', 'right'];
@@ -158,6 +159,8 @@ Future<int> runScroll(List<String> args) async {
 
     stderr.writeln('ERROR: Unexpected response from ext.fdb.scroll: $result');
     return 1;
+  } on AppDiedException {
+    rethrow;
   } catch (e) {
     stderr.writeln('ERROR: $e');
     return 1;

--- a/lib/commands/scroll_to.dart
+++ b/lib/commands/scroll_to.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:fdb/app_died_exception.dart';
 import 'package:fdb/vm_service.dart';
 
 /// Scrolls the nearest Scrollable until the target widget becomes visible.
@@ -93,6 +94,8 @@ Future<int> runScrollTo(List<String> args) async {
       'ERROR: Unexpected response from ext.fdb.scrollTo: $result',
     );
     return 1;
+  } on AppDiedException {
+    rethrow;
   } catch (e) {
     stderr.writeln('ERROR: $e');
     return 1;

--- a/lib/commands/select.dart
+++ b/lib/commands/select.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:fdb/app_died_exception.dart';
 import 'package:fdb/vm_service.dart';
 
 Future<int> runSelect(List<String> args) async {
@@ -30,6 +31,8 @@ Future<int> runSelect(List<String> args) async {
 
     stdout.writeln('SELECTION_MODE=${enabled ? "ON" : "OFF"}');
     return 0;
+  } on AppDiedException {
+    rethrow;
   } catch (e) {
     stderr.writeln('ERROR: $e');
     return 1;

--- a/lib/commands/selected.dart
+++ b/lib/commands/selected.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:fdb/app_died_exception.dart';
 import 'package:fdb/vm_service.dart';
 
 Future<int> runSelected(List<String> args) async {
@@ -34,6 +35,8 @@ Future<int> runSelected(List<String> args) async {
     }
 
     return 0;
+  } on AppDiedException {
+    rethrow;
   } catch (e) {
     stderr.writeln('ERROR: $e');
     return 1;

--- a/lib/commands/swipe.dart
+++ b/lib/commands/swipe.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:fdb/app_died_exception.dart';
 import 'package:fdb/vm_service.dart';
 
 /// Swipes in a direction, optionally targeting a specific widget's bounds.
@@ -96,6 +97,8 @@ Future<int> runSwipe(List<String> args) async {
 
     stderr.writeln('ERROR: Unexpected response from ext.fdb.swipe: $result');
     return 1;
+  } on AppDiedException {
+    rethrow;
   } catch (e) {
     stderr.writeln('ERROR: $e');
     return 1;

--- a/lib/commands/tap.dart
+++ b/lib/commands/tap.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:fdb/app_died_exception.dart';
 import 'package:fdb/vm_service.dart';
 
 /// Taps a widget identified by selector, absolute coordinates, or a describe ref.
@@ -167,6 +168,8 @@ Future<int> runTap(List<String> args) async {
       stderr.writeln('ERROR: Unexpected response from ext.fdb.tap: $result');
       return 1;
     }
+  } on AppDiedException {
+    rethrow;
   } catch (e) {
     stderr.writeln('ERROR: $e');
     return 1;
@@ -258,6 +261,8 @@ Future<int> _tapByRef(int ref, int timeoutSeconds) async {
 
     stderr.writeln('ERROR: Unexpected response from ext.fdb.tap: $tapResult');
     return 1;
+  } on AppDiedException {
+    rethrow;
   } catch (e) {
     stderr.writeln('ERROR: $e');
     return 1;

--- a/lib/commands/tree.dart
+++ b/lib/commands/tree.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:fdb/app_died_exception.dart';
 import 'package:fdb/vm_service.dart';
 
 Future<int> runTree(List<String> args) async {
@@ -36,6 +37,8 @@ Future<int> runTree(List<String> args) async {
 
     _printTree(tree, 0, maxDepth, userOnly);
     return 0;
+  } on AppDiedException {
+    rethrow;
   } catch (e) {
     stderr.writeln('ERROR: $e');
     return 1;

--- a/lib/commands/wait.dart
+++ b/lib/commands/wait.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:fdb/app_died_exception.dart';
 import 'package:fdb/vm_service.dart';
 
 Future<int> runWait(List<String> args) async {
@@ -114,6 +115,8 @@ Future<int> runWait(List<String> args) async {
 
     stderr.writeln('ERROR: Unexpected response from ext.fdb.waitFor: $result');
     return 1;
+  } on AppDiedException {
+    rethrow;
   } catch (e) {
     stderr.writeln('ERROR: $e');
     return 1;

--- a/lib/vm_service.dart
+++ b/lib/vm_service.dart
@@ -2,11 +2,13 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:fdb/app_died_exception.dart';
 import 'package:fdb/process_utils.dart';
 
 /// Sends a JSON-RPC request to the Flutter VM service over websocket.
 /// Returns the parsed JSON response.
-/// Throws on connection failure or timeout.
+/// Throws [AppDiedException] when the app process is detected as dead,
+/// or on connection failure / timeout.
 Future<Map<String, dynamic>> vmServiceCall(
   String method, {
   Map<String, dynamic> params = const {},
@@ -17,12 +19,51 @@ Future<Map<String, dynamic>> vmServiceCall(
     throw StateError('VM service URI not found. Is the app running?');
   }
 
+  // Pre-check: if the PID file exists and the process is dead, short-circuit
+  // immediately without even attempting a WebSocket connection.
+  final pid = readPid();
+  if (pid != null && !isProcessAlive(pid)) {
+    throw await buildAppDiedException(pid: pid);
+  }
+
   final wsUri = uri.replaceFirst('http://', 'ws://').replaceFirst('https://', 'wss://');
 
-  final ws = await WebSocket.connect(
-    wsUri,
-    customClient: HttpClient()..maxConnectionsPerHost = 1,
-  );
+  WebSocket ws;
+  try {
+    ws = await WebSocket.connect(
+      wsUri,
+      customClient: HttpClient()..maxConnectionsPerHost = 1,
+    ).timeout(const Duration(seconds: 5));
+  } on TimeoutException {
+    // Connection timed out — check if the process died in the meantime.
+    final currentPid = readPid();
+    if (currentPid != null && !isProcessAlive(currentPid)) {
+      throw await buildAppDiedException(pid: currentPid);
+    }
+    // Rethrow original so the caller sees a TimeoutException when the app
+    // is still nominally alive but the VM service is unreachable.
+    rethrow;
+  } catch (e) {
+    // Connection refused / OS error: the VM service is no longer accepting
+    // connections.  This is the primary signal that the app has died — the
+    // PID liveness check alone is insufficient because fdb.pid stores the
+    // flutter-tools process PID, not the actual app process PID (fdb-bbu).
+    //
+    // We treat ANY connection-refused-like error as APP_DIED, since the VM
+    // service URI was written by `fdb launch` only when the app was healthy.
+    // If the app came back on a different port the URI would also be stale,
+    // but that scenario is handled by re-running `fdb launch`.
+    if (_isConnectionRefused(e)) {
+      throw await buildAppDiedException(pid: readPid());
+    }
+    // For non-connection errors (e.g. bad URI, TLS issues) fall back to PID
+    // check before rethrowing.
+    final currentPid = readPid();
+    if (currentPid != null && !isProcessAlive(currentPid)) {
+      throw await buildAppDiedException(pid: currentPid);
+    }
+    rethrow;
+  }
 
   // Widget trees can be 500KB+, no built-in buffer size limit on dart:io WebSocket
   // but we need to handle large responses properly.
@@ -51,7 +92,15 @@ Future<Map<String, dynamic>> vmServiceCall(
     },
     onDone: () {
       if (!completer.isCompleted) {
-        completer.completeError(StateError('WebSocket closed before response'));
+        // WebSocket closed before we got a response — check if the app died.
+        // We fire off the enrichment asynchronously and complete the error.
+        _buildDeadAppError().then((ex) {
+          if (!completer.isCompleted) completer.completeError(ex);
+        }).catchError((Object _) {
+          if (!completer.isCompleted) {
+            completer.completeError(StateError('WebSocket closed before response'));
+          }
+        });
       }
     },
   );
@@ -64,8 +113,36 @@ Future<Map<String, dynamic>> vmServiceCall(
     return response;
   } on TimeoutException {
     await ws.close();
+    // Check if the process died during the wait.
+    final currentPid = readPid();
+    if (currentPid != null && !isProcessAlive(currentPid)) {
+      throw await buildAppDiedException(pid: currentPid);
+    }
+    rethrow;
+  } on AppDiedException {
+    // Already enriched — rethrow as-is.
+    try {
+      await ws.close();
+    } catch (_) {}
     rethrow;
   }
+}
+
+/// Builds an [AppDiedException] after a mid-call connection drop.
+Future<AppDiedException> _buildDeadAppError() async {
+  final pid = readPid();
+  return buildAppDiedException(pid: pid);
+}
+
+/// Returns true when [error] indicates the OS refused the TCP connection,
+/// which is the reliable signal that the VM service is no longer running.
+bool _isConnectionRefused(Object error) {
+  if (error is SocketException) {
+    // errno 61 = ECONNREFUSED on macOS/Linux
+    final errno = error.osError?.errorCode;
+    return errno == 61 || errno == 111;
+  }
+  return false;
 }
 
 /// Returns all isolate IDs from the VM service.
@@ -97,6 +174,8 @@ Future<String?> findFlutterIsolateId() async {
       );
       final result = response['result'] as Map<String, dynamic>?;
       if (result != null && response['error'] == null) return id;
+    } on AppDiedException {
+      rethrow;
     } catch (_) {
       // This isolate doesn't have Flutter inspector, try next
     }
@@ -177,6 +256,9 @@ dynamic unwrapRawExtensionResult(Map<String, dynamic> response) {
 ///
 /// Returns the Flutter isolate ID if fdb_helper is available, or null if not.
 /// Callers can reuse the returned isolate ID to avoid a second round-trip.
+///
+/// Re-throws [AppDiedException] so the caller can surface a structured error
+/// instead of a misleading "fdb_helper not detected" message.
 Future<String?> checkFdbHelper() async {
   try {
     final isolateId = await findFlutterIsolateId();
@@ -187,6 +269,8 @@ Future<String?> checkFdbHelper() async {
       timeout: const Duration(seconds: 3),
     );
     return isolateId;
+  } on AppDiedException {
+    rethrow;
   } catch (_) {
     return null;
   }


### PR DESCRIPTION
Agents and users had no way to distinguish a slow command from a dead app — fdb would hang until its own timeout with no actionable output. This adds structured `APP_DIED` error detection across all VM-using commands so fdb always exits quickly with a clear error, the last 20 log lines, and an OS-level reason when available (jetsam on iOS, LMK/crash on Android, killed on macOS).

Known limitations tracked as follow-up issues: fdb.pid stores the flutter-tools PID rather than the app's PID (fdb-bbu), which means connection-refused detection is the primary reliable signal rather than PID liveness. The test task works around this by using platform tooling (simctl/pkill/adb) to kill the actual app process.

Closes #47