### PR TITLE
fix: store app VM PID in fdb.app_pid for accurate liveness detection

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1556,71 +1556,16 @@ tasks:
           exit 1
         fi
 
-        # Detect platform to use the right kill mechanism.
-        # NOTE: fdb.pid stores the flutter-tools process PID, not the actual app
-        # process PID (see https://github.com/andrzejchm/fdb/issues — fdb-bbu).
-        # We must use platform-specific tooling to kill the actual app process.
-        PLATFORM=$(cat .fdb/platform.txt 2>/dev/null | awk '{print $1}' || echo "")
-        DEVICE_ID=$(cat .fdb/device.txt 2>/dev/null || echo "")
-        echo "==> [app-died] Platform=$PLATFORM Device=$DEVICE_ID"
-
-        if [ "$PLATFORM" = "ios" ] || [ "$PLATFORM" = "iOS" ]; then
-          echo "==> [app-died] iOS simulator — terminating via simctl"
-          # Find the bundle ID of the RUNNING app (not just installed) via
-          # launchctl inside the simulator — avoids picking the wrong entry when
-          # multiple test_app builds are installed.
-          BUNDLE_ID=$(xcrun simctl spawn "$DEVICE_ID" launchctl list 2>/dev/null \
-            | grep "UIKitApplication:" \
-            | sed 's/.*UIKitApplication:\([^[]*\).*/\1/' \
-            | head -1)
-          if [ -z "$BUNDLE_ID" ]; then
-            # Fallback: try each installed test_app bundle until one terminates
-            BUNDLE_ID=$(xcrun simctl listapps "$DEVICE_ID" 2>/dev/null \
-              | grep -A1 'CFBundleName = "test_app"' \
-              | grep CFBundleIdentifier \
-              | sed 's/.*= "\(.*\)";/\1/' \
-              | head -1)
-          fi
-          if [ -z "$BUNDLE_ID" ]; then
-            echo "SKIP: could not determine bundle ID on iOS simulator — skipping app-died test" >&2
-            exit 0
-          fi
-          echo "  BundleID=$BUNDLE_ID"
-          xcrun simctl terminate "$DEVICE_ID" "$BUNDLE_ID" 2>&1 || true
-
-        elif [ "$PLATFORM" = "darwin" ] || [ "$PLATFORM" = "macos" ] || [ "$PLATFORM" = "macOS" ]; then
-          echo "==> [app-died] macOS — killing app binary process"
-          # The macOS .app process is separate from the flutter-tools PID in fdb.pid
-          APP_BIN=$(find "$(pwd)/build/macos/Build/Products/Debug" -name "test_app" -type f 2>/dev/null | head -1)
-          if [ -n "$APP_BIN" ]; then
-            pkill -9 -f "$APP_BIN" 2>/dev/null || true
-          else
-            pkill -9 -f "test_app.app/Contents/MacOS/test_app" 2>/dev/null || true
-          fi
-
-        elif [ "$PLATFORM" = "android" ] || echo "$PLATFORM" | grep -qi "android"; then
-          echo "==> [app-died] Android — force-stopping via adb"
-          # Try to find the app package name
-          PACKAGE=$(adb -s "$DEVICE_ID" shell pm list packages 2>/dev/null \
-            | grep -i "test.app\|testapp\|fdb.test" \
-            | sed 's/package://' \
-            | head -1 | tr -d '\r')
-          if [ -z "$PACKAGE" ]; then
-            echo "SKIP: could not determine package name on Android — skipping app-died test" >&2
-            exit 0
-          fi
-          echo "  Package=$PACKAGE"
-          adb -s "$DEVICE_ID" shell am force-stop "$PACKAGE" 2>&1 || true
-
-        else
-          echo "==> [app-died] Unknown platform '$PLATFORM' — killing flutter-tools PID as best-effort"
-          PID=$(cat .fdb/fdb.pid 2>/dev/null)
-          if [ -n "$PID" ]; then
-            kill -9 "$PID" 2>/dev/null || true
-            # Also kill any child processes
-            pkill -9 -P "$PID" 2>/dev/null || true
-          fi
+        # Kill the app VM process directly using the PID written by fdb launch
+        # into fdb.app_pid. This is the actual Dart VM process (not flutter-tools),
+        # so kill -9 works on all platforms without any platform-specific tooling.
+        APP_PID=$(cat .fdb/fdb.app_pid 2>/dev/null || echo "")
+        if [ -z "$APP_PID" ]; then
+          echo "FAIL: .fdb/fdb.app_pid not found — was the app launched with a version of fdb that writes it?" >&2
+          exit 1
         fi
+        echo "==> [app-died] Killing app VM process PID=$APP_PID"
+        kill -9 "$APP_PID" 2>/dev/null || true
 
         sleep 2
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1567,6 +1567,14 @@ tasks:
         echo "==> [app-died] Killing app VM process PID=$APP_PID"
         kill -9 "$APP_PID" 2>/dev/null || true
 
+        # On macOS, flutter run auto-restarts the app child after kill -9.
+        # Kill the flutter-tools process too so it cannot restart the app.
+        TOOLS_PID=$(cat .fdb/fdb.pid 2>/dev/null || echo "")
+        if [ -n "$TOOLS_PID" ]; then
+          echo "==> [app-died] Killing flutter-tools process PID=$TOOLS_PID to prevent auto-restart"
+          kill -9 "$TOOLS_PID" 2>/dev/null || true
+        fi
+
         sleep 2
 
         echo "==> [app-died] Running fdb tap @1 — should exit non-zero with APP_DIED"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1568,10 +1568,21 @@ tasks:
 
         if [ "$PLATFORM" = "ios" ] || [ "$PLATFORM" = "iOS" ]; then
           echo "==> [app-died] iOS simulator — terminating via simctl"
-          BUNDLE_ID=$(xcrun simctl spawn "$DEVICE_ID" launchctl list 2>/dev/null \
-            | grep "UIKitApplication:" \
-            | sed 's/.*UIKitApplication:\([^[]*\).*/\1/' \
-            | head -1)
+          APP_PID=$(cat .fdb/fdb.app_pid 2>/dev/null || echo "")
+          BUNDLE_ID=""
+          if [ -n "$APP_PID" ]; then
+            BUNDLE_ID=$(xcrun simctl spawn "$DEVICE_ID" launchctl list 2>/dev/null \
+              | grep "^$APP_PID" \
+              | grep "UIKitApplication:" \
+              | sed 's/.*UIKitApplication:\([^[]*\).*/\1/' \
+              | head -1)
+          fi
+          if [ -z "$BUNDLE_ID" ]; then
+            BUNDLE_ID=$(xcrun simctl spawn "$DEVICE_ID" launchctl list 2>/dev/null \
+              | grep "UIKitApplication:" \
+              | sed 's/.*UIKitApplication:\([^[]*\).*/\1/' \
+              | head -1)
+          fi
           if [ -z "$BUNDLE_ID" ]; then
             BUNDLE_ID=$(xcrun simctl listapps "$DEVICE_ID" 2>/dev/null \
               | grep -A1 'CFBundleName = "test_app"' \

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1546,9 +1546,11 @@ tasks:
         fi
 
         echo "==> [app-died] Waiting for app to be ready"
+        # Pin --session-dir so the readiness probe doesn't auto-resolve to a
+        # stale .fdb/ from another worktree higher up the directory tree.
         READY=0
         for _ in $(seq 1 60); do
-          if {{.FDB}} tree --depth 1 >/dev/null 2>&1; then
+          if {{.FDB}} --session-dir "$(pwd)/.fdb" tree --depth 1 >/dev/null 2>&1; then
             READY=1
             break
           fi

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1547,12 +1547,12 @@ tasks:
 
         echo "==> [app-died] Waiting for app to be ready"
         READY=0
-        for _ in $(seq 1 20); do
+        for _ in $(seq 1 60); do
           if {{.FDB}} tree --depth 1 >/dev/null 2>&1; then
             READY=1
             break
           fi
-          sleep 0.5
+          sleep 1
         done
         if [ $READY -ne 1 ]; then
           echo "FAIL: app did not become ready in time" >&2
@@ -1616,21 +1616,24 @@ tasks:
         else
           # macOS desktop (darwin): fdb.app_pid is a real macOS host PID — kill it directly.
           # Also kill flutter-tools to prevent it from auto-restarting the app.
+          # Use /bin/kill explicitly: Task's embedded shell (mvdan/sh) does not
+          # implement the `kill` builtin and does not fall back to the external
+          # binary, so a bare `kill` call fails with "unimplemented builtin".
           APP_PID=$(cat .fdb/fdb.app_pid 2>/dev/null || echo "")
           if [ -n "$APP_PID" ]; then
             echo "==> [app-died] Killing app VM process PID=$APP_PID"
-            kill -9 "$APP_PID" 2>/dev/null || true
+            /bin/kill -9 "$APP_PID" 2>/dev/null || true
             TOOLS_PID=$(cat .fdb/fdb.pid 2>/dev/null || echo "")
             if [ -n "$TOOLS_PID" ]; then
               echo "==> [app-died] Killing flutter-tools PID=$TOOLS_PID to prevent auto-restart"
-              kill -9 "$TOOLS_PID" 2>/dev/null || true
+              /bin/kill -9 "$TOOLS_PID" 2>/dev/null || true
             fi
           else
             echo "WARNING: .fdb/fdb.app_pid not found — falling back to killing fdb.pid" >&2
             TOOLS_PID=$(cat .fdb/fdb.pid 2>/dev/null || echo "")
             if [ -n "$TOOLS_PID" ]; then
               echo "==> [app-died] Killing flutter-tools PID=$TOOLS_PID (best-effort)"
-              kill -9 "$TOOLS_PID" 2>/dev/null || true
+              /bin/kill -9 "$TOOLS_PID" 2>/dev/null || true
             fi
           fi
         fi
@@ -1638,8 +1641,12 @@ tasks:
         sleep 2
 
         echo "==> [app-died] Running fdb tap @1 — should exit non-zero with APP_DIED"
+        # Pin the session dir explicitly. After the kill, this worktree's .fdb/fdb.pid
+        # points to a dead process; without --session-dir, fdb auto-resolves by walking
+        # up the directory tree and may attach to an unrelated live .fdb/ session in a
+        # parent directory, masking the dead-app condition.
         set +e
-        OUTPUT=$({{.FDB}} tap @1 2>&1)
+        OUTPUT=$({{.FDB}} --session-dir "$(pwd)/.fdb" tap @1 2>&1)
         EXIT_CODE=$?
         set -e
         echo "$OUTPUT"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1614,16 +1614,21 @@ tasks:
           # macOS desktop (darwin): fdb.app_pid is a real macOS host PID — kill it directly.
           # Also kill flutter-tools to prevent it from auto-restarting the app.
           APP_PID=$(cat .fdb/fdb.app_pid 2>/dev/null || echo "")
-          if [ -z "$APP_PID" ]; then
-            echo "FAIL: .fdb/fdb.app_pid not found — was the app launched with this version of fdb?" >&2
-            exit 1
-          fi
-          echo "==> [app-died] Killing app VM process PID=$APP_PID"
-          kill -9 "$APP_PID" 2>/dev/null || true
-          TOOLS_PID=$(cat .fdb/fdb.pid 2>/dev/null || echo "")
-          if [ -n "$TOOLS_PID" ]; then
-            echo "==> [app-died] Killing flutter-tools PID=$TOOLS_PID to prevent auto-restart"
-            kill -9 "$TOOLS_PID" 2>/dev/null || true
+          if [ -n "$APP_PID" ]; then
+            echo "==> [app-died] Killing app VM process PID=$APP_PID"
+            kill -9 "$APP_PID" 2>/dev/null || true
+            TOOLS_PID=$(cat .fdb/fdb.pid 2>/dev/null || echo "")
+            if [ -n "$TOOLS_PID" ]; then
+              echo "==> [app-died] Killing flutter-tools PID=$TOOLS_PID to prevent auto-restart"
+              kill -9 "$TOOLS_PID" 2>/dev/null || true
+            fi
+          else
+            echo "WARNING: .fdb/fdb.app_pid not found — falling back to killing fdb.pid" >&2
+            TOOLS_PID=$(cat .fdb/fdb.pid 2>/dev/null || echo "")
+            if [ -n "$TOOLS_PID" ]; then
+              echo "==> [app-died] Killing flutter-tools PID=$TOOLS_PID (best-effort)"
+              kill -9 "$TOOLS_PID" 2>/dev/null || true
+            fi
           fi
         fi
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1556,23 +1556,64 @@ tasks:
           exit 1
         fi
 
-        # Kill the app VM process directly using the PID written by fdb launch
-        # into fdb.app_pid. This is the actual Dart VM process (not flutter-tools),
-        # so kill -9 works on all platforms without any platform-specific tooling.
-        APP_PID=$(cat .fdb/fdb.app_pid 2>/dev/null || echo "")
-        if [ -z "$APP_PID" ]; then
-          echo "FAIL: .fdb/fdb.app_pid not found — was the app launched with a version of fdb that writes it?" >&2
-          exit 1
-        fi
-        echo "==> [app-died] Killing app VM process PID=$APP_PID"
-        kill -9 "$APP_PID" 2>/dev/null || true
+        # Kill the app process using the appropriate mechanism per platform.
+        # On macOS desktop: fdb.app_pid holds the real macOS app binary PID — kill it
+        #   directly with kill -9, then also kill flutter-tools to prevent auto-restart.
+        # On iOS simulator: the app runs inside Simulator.app; fdb.app_pid is a device-
+        #   namespace PID not visible on the macOS host — use xcrun simctl terminate.
+        # On Android: same device-namespace caveat — use adb shell am force-stop.
+        PLATFORM=$(cat .fdb/platform.txt 2>/dev/null | awk '{print $1}' || echo "")
+        DEVICE_ID=$(cat .fdb/device.txt 2>/dev/null || echo "")
+        echo "==> [app-died] Platform=$PLATFORM Device=$DEVICE_ID"
 
-        # On macOS, flutter run auto-restarts the app child after kill -9.
-        # Kill the flutter-tools process too so it cannot restart the app.
-        TOOLS_PID=$(cat .fdb/fdb.pid 2>/dev/null || echo "")
-        if [ -n "$TOOLS_PID" ]; then
-          echo "==> [app-died] Killing flutter-tools process PID=$TOOLS_PID to prevent auto-restart"
-          kill -9 "$TOOLS_PID" 2>/dev/null || true
+        if [ "$PLATFORM" = "ios" ] || [ "$PLATFORM" = "iOS" ]; then
+          echo "==> [app-died] iOS simulator — terminating via simctl"
+          BUNDLE_ID=$(xcrun simctl spawn "$DEVICE_ID" launchctl list 2>/dev/null \
+            | grep "UIKitApplication:" \
+            | sed 's/.*UIKitApplication:\([^[]*\).*/\1/' \
+            | head -1)
+          if [ -z "$BUNDLE_ID" ]; then
+            BUNDLE_ID=$(xcrun simctl listapps "$DEVICE_ID" 2>/dev/null \
+              | grep -A1 'CFBundleName = "test_app"' \
+              | grep CFBundleIdentifier \
+              | sed 's/.*= "\(.*\)";/\1/' \
+              | head -1)
+          fi
+          if [ -z "$BUNDLE_ID" ]; then
+            echo "SKIP: could not determine bundle ID on iOS simulator — skipping app-died test" >&2
+            exit 0
+          fi
+          echo "  BundleID=$BUNDLE_ID"
+          xcrun simctl terminate "$DEVICE_ID" "$BUNDLE_ID" 2>&1 || true
+
+        elif [ "$PLATFORM" = "android" ] || echo "$PLATFORM" | grep -qi "android"; then
+          echo "==> [app-died] Android — force-stopping via adb"
+          PACKAGE=$(adb -s "$DEVICE_ID" shell pm list packages 2>/dev/null \
+            | grep -i "test.app\|testapp\|fdb.test" \
+            | sed 's/package://' \
+            | head -1 | tr -d '\r')
+          if [ -z "$PACKAGE" ]; then
+            echo "SKIP: could not determine package name on Android — skipping app-died test" >&2
+            exit 0
+          fi
+          echo "  Package=$PACKAGE"
+          adb -s "$DEVICE_ID" shell am force-stop "$PACKAGE" 2>&1 || true
+
+        else
+          # macOS desktop (darwin): fdb.app_pid is a real macOS host PID — kill it directly.
+          # Also kill flutter-tools to prevent it from auto-restarting the app.
+          APP_PID=$(cat .fdb/fdb.app_pid 2>/dev/null || echo "")
+          if [ -z "$APP_PID" ]; then
+            echo "FAIL: .fdb/fdb.app_pid not found — was the app launched with this version of fdb?" >&2
+            exit 1
+          fi
+          echo "==> [app-died] Killing app VM process PID=$APP_PID"
+          kill -9 "$APP_PID" 2>/dev/null || true
+          TOOLS_PID=$(cat .fdb/fdb.pid 2>/dev/null || echo "")
+          if [ -n "$TOOLS_PID" ]; then
+            echo "==> [app-died] Killing flutter-tools PID=$TOOLS_PID to prevent auto-restart"
+            kill -9 "$TOOLS_PID" 2>/dev/null || true
+          fi
         fi
 
         sleep 2

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1526,20 +1526,23 @@ tasks:
         sh: '{{if .DEVICE}}echo "{{.DEVICE}}"{{else}}task detect-device{{end}}'
     cmds:
       - |
-        echo "==> [app-died] Ensuring app is running"
-        if ! {{.FDB}} status 2>&1 | grep -q "RUNNING=true"; then
-          echo "==> [app-died] App not running — launching first"
-          OUTPUT=$({{.FDB}} launch --device "{{.DEVICE}}" 2>&1)
-          EXIT_CODE=$?
-          echo "$OUTPUT"
-          if [ $EXIT_CODE -ne 0 ]; then
-            echo "FAIL: fdb launch exited with code $EXIT_CODE" >&2
-            exit 1
-          fi
-          if ! echo "$OUTPUT" | grep -q "APP_STARTED"; then
-            echo "FAIL: fdb launch - APP_STARTED not found in output" >&2
-            exit 1
-          fi
+        echo "==> [app-died] Ensuring a fresh app session on device {{.DEVICE}}"
+        # Always kill and relaunch to guarantee we are on the correct device.
+        # Reusing an existing session risks picking up a stale session from a
+        # different platform (e.g. macOS session left over from a previous test
+        # run when this invocation targets Android or iOS).
+        {{.FDB}} kill 2>/dev/null || true
+        sleep 1
+        OUTPUT=$({{.FDB}} launch --device "{{.DEVICE}}" 2>&1)
+        EXIT_CODE=$?
+        echo "$OUTPUT"
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "FAIL: fdb launch exited with code $EXIT_CODE" >&2
+          exit 1
+        fi
+        if ! echo "$OUTPUT" | grep -q "APP_STARTED"; then
+          echo "FAIL: fdb launch - APP_STARTED not found in output" >&2
+          exit 1
         fi
 
         echo "==> [app-died] Waiting for app to be ready"

--- a/example/test_app/lib/main.dart
+++ b/example/test_app/lib/main.dart
@@ -207,13 +207,17 @@ class _FdbTestHomePageState extends State<FdbTestHomePage> {
                   try {
                     final result = await _nativeDialogChannel
                         .invokeMethod<String>('showNativeAlert');
-                    if (mounted)
+                    if (mounted) {
                       setState(() => _nativeAlertResult = result ?? 'null');
-                    developer.log('native alert result: $result',
-                        name: 'fdb_test');
+                    }
+                    developer.log(
+                      'native alert result: $result',
+                      name: 'fdb_test',
+                    );
                   } catch (e) {
-                    if (mounted)
+                    if (mounted) {
                       setState(() => _nativeAlertResult = 'ERROR: $e');
+                    }
                   }
                 },
                 child: const Text('Show Native Alert'),

--- a/lib/commands/launch.dart
+++ b/lib/commands/launch.dart
@@ -182,8 +182,6 @@ exec $flutterCmd > $logFile 2>&1
   // fdb.pid). Used by vmServiceCall for liveness detection on macOS desktop.
   // Non-fatal: if getVM fails for any reason, fdb.app_pid is simply not written
   // and vmServiceCall falls back to the flutter-tools PID heuristic.
-  await _writeAppPid();
-
   // Start the log collector — a background process that subscribes to the
   // VM service Logging/Stdout/Stderr streams and appends to the log file.
   // flutter run only forwards print() to stdout; developer.log() events are
@@ -194,6 +192,8 @@ exec $flutterCmd > $logFile 2>&1
   stdout.writeln('VM_SERVICE_URI=$vmUri');
   stdout.writeln('PID=$pid');
   stdout.writeln('LOG_FILE=$logFile');
+
+  await _writeAppPid();
 
   return 0;
 }
@@ -320,8 +320,6 @@ Future<void> _writeAppPid() async {
     final appPid = result['pid'];
     if (appPid == null) return;
     File(appPidFile).writeAsStringSync(appPid.toString());
-  } on TimeoutException {
-    rethrow;
   } catch (_) {
     // Non-fatal: fdb.app_pid simply won't be written.
   }

--- a/lib/commands/launch.dart
+++ b/lib/commands/launch.dart
@@ -5,6 +5,7 @@ import 'dart:isolate';
 
 import 'package:fdb/constants.dart';
 import 'package:fdb/process_utils.dart';
+import 'package:fdb/vm_service.dart';
 
 Future<int> runLaunch(List<String> args) async {
   String? device;
@@ -50,6 +51,7 @@ Future<int> runLaunch(List<String> args) async {
   // Clean up previous state
   for (final path in [
     pidFile,
+    appPidFile,
     logFile,
     logCollectorPidFile,
     logCollectorScript,
@@ -175,6 +177,13 @@ exec $flutterCmd > $logFile 2>&1
   // Read PID — flutter writes it via --pid-file, fall back to launcher PID
   final pid = File(pidFile).existsSync() ? File(pidFile).readAsStringSync().trim() : launcherPid.toString();
 
+  // Retrieve the app VM PID via getVM and persist it to fdb.app_pid.
+  // This is the Dart VM process PID (different from the flutter-tools PID in
+  // fdb.pid). Used by vmServiceCall for liveness detection on macOS desktop.
+  // Non-fatal: if getVM fails for any reason, fdb.app_pid is simply not written
+  // and vmServiceCall falls back to the flutter-tools PID heuristic.
+  await _writeAppPid();
+
   // Start the log collector — a background process that subscribes to the
   // VM service Logging/Stdout/Stderr streams and appends to the log file.
   // flutter run only forwards print() to stdout; developer.log() events are
@@ -297,6 +306,24 @@ void _ensureGitignored(String projectPath) {
     gitignore.writeAsStringSync('\n# fdb session state\n.fdb/\n', mode: FileMode.append);
   } else {
     gitignore.writeAsStringSync('# fdb session state\n.fdb/\n');
+  }
+}
+
+/// Calls `getVM` on the VM service to retrieve the app process PID and writes
+/// it to [appPidFile]. Silently no-ops on any failure — callers fall back
+/// to the flutter-tools PID heuristic when this file is absent.
+Future<void> _writeAppPid() async {
+  try {
+    final response = await vmServiceCall('getVM');
+    final result = response['result'] as Map<String, dynamic>?;
+    if (result == null) return;
+    final appPid = result['pid'];
+    if (appPid == null) return;
+    File(appPidFile).writeAsStringSync(appPid.toString());
+  } on TimeoutException {
+    rethrow;
+  } catch (_) {
+    // Non-fatal: fdb.app_pid simply won't be written.
   }
 }
 

--- a/lib/commands/launch.dart
+++ b/lib/commands/launch.dart
@@ -177,11 +177,6 @@ exec $flutterCmd > $logFile 2>&1
   // Read PID — flutter writes it via --pid-file, fall back to launcher PID
   final pid = File(pidFile).existsSync() ? File(pidFile).readAsStringSync().trim() : launcherPid.toString();
 
-  // Retrieve the app VM PID via getVM and persist it to fdb.app_pid.
-  // This is the Dart VM process PID (different from the flutter-tools PID in
-  // fdb.pid). Used by vmServiceCall for liveness detection on macOS desktop.
-  // Non-fatal: if getVM fails for any reason, fdb.app_pid is simply not written
-  // and vmServiceCall falls back to the flutter-tools PID heuristic.
   // Start the log collector — a background process that subscribes to the
   // VM service Logging/Stdout/Stderr streams and appends to the log file.
   // flutter run only forwards print() to stdout; developer.log() events are
@@ -193,6 +188,11 @@ exec $flutterCmd > $logFile 2>&1
   stdout.writeln('PID=$pid');
   stdout.writeln('LOG_FILE=$logFile');
 
+  // Retrieve the app VM PID via getVM and persist it to fdb.app_pid.
+  // This is the Dart VM process PID (different from the flutter-tools PID in
+  // fdb.pid). Used by vmServiceCall for liveness detection on macOS desktop.
+  // Non-fatal: if getVM fails for any reason, fdb.app_pid is simply not written
+  // and vmServiceCall falls back to the flutter-tools PID heuristic.
   await _writeAppPid();
 
   return 0;

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -101,6 +101,7 @@ String ensureSessionDir() {
 }
 
 String get pidFile => '$_sessionDir/fdb.pid';
+String get appPidFile => '$_sessionDir/fdb.app_pid';
 String get logFile => '$_sessionDir/logs.txt';
 String get logCollectorPidFile => '$_sessionDir/log_collector.pid';
 String get logCollectorScript => '$_sessionDir/log_collector.dart';

--- a/lib/process_utils.dart
+++ b/lib/process_utils.dart
@@ -10,6 +10,18 @@ int? readPid() {
   return int.tryParse(content);
 }
 
+/// Reads the app VM PID from [appPidFile] written by `fdb launch` after
+/// the VM service is confirmed reachable.
+///
+/// Returns null if the file does not exist or its content is not a valid
+/// integer (e.g. the session was created by an older fdb version).
+int? readAppPid() {
+  final file = File(appPidFile);
+  if (!file.existsSync()) return null;
+  final content = file.readAsStringSync().trim();
+  return int.tryParse(content);
+}
+
 String? readVmUri() {
   final file = File(vmUriFile);
   if (!file.existsSync()) return null;
@@ -93,6 +105,7 @@ Future<bool> isVmServiceReachable(String uri) async {
 void cleanupTempFiles() {
   for (final path in [
     pidFile,
+    appPidFile,
     logFile,
     logCollectorPidFile,
     logCollectorScript,

--- a/lib/vm_service.dart
+++ b/lib/vm_service.dart
@@ -19,11 +19,24 @@ Future<Map<String, dynamic>> vmServiceCall(
     throw StateError('VM service URI not found. Is the app running?');
   }
 
-  // Pre-check: if the PID file exists and the process is dead, short-circuit
-  // immediately without even attempting a WebSocket connection.
-  final pid = readPid();
-  if (pid != null && !isProcessAlive(pid)) {
-    throw await buildAppDiedException(pid: pid);
+  // Pre-check: if the process is dead, short-circuit immediately without
+  // even attempting a WebSocket connection.
+  //
+  // On macOS desktop the app VM PID (fdb.app_pid) and the flutter-tools PID
+  // (fdb.pid) both live in the host process table, so we can check either.
+  // Prefer the app PID because it is the actual Dart VM process; fall back to
+  // the flutter-tools PID when fdb.app_pid has not been written yet.
+  //
+  // On Android and iOS the app VM PID from getVM lives inside the device /
+  // simulator process namespace and is NOT visible to the host macOS process
+  // table — kill -0 would always return false, producing false positives.
+  // On those platforms skip the PID pre-check and rely on the
+  // connection-refused heuristic below.
+  if (Platform.isMacOS) {
+    final pid = readAppPid() ?? readPid();
+    if (pid != null && !isProcessAlive(pid)) {
+      throw await buildAppDiedException(pid: pid);
+    }
   }
 
   final wsUri = uri.replaceFirst('http://', 'ws://').replaceFirst('https://', 'wss://');
@@ -36,9 +49,12 @@ Future<Map<String, dynamic>> vmServiceCall(
     ).timeout(const Duration(seconds: 5));
   } on TimeoutException {
     // Connection timed out — check if the process died in the meantime.
-    final currentPid = readPid();
-    if (currentPid != null && !isProcessAlive(currentPid)) {
-      throw await buildAppDiedException(pid: currentPid);
+    // Use app PID on macOS (most accurate); fall back to flutter-tools PID.
+    if (Platform.isMacOS) {
+      final currentPid = readAppPid() ?? readPid();
+      if (currentPid != null && !isProcessAlive(currentPid)) {
+        throw await buildAppDiedException(pid: currentPid);
+      }
     }
     // Rethrow original so the caller sees a TimeoutException when the app
     // is still nominally alive but the VM service is unreachable.
@@ -54,13 +70,16 @@ Future<Map<String, dynamic>> vmServiceCall(
     // If the app came back on a different port the URI would also be stale,
     // but that scenario is handled by re-running `fdb launch`.
     if (_isConnectionRefused(e)) {
-      throw await buildAppDiedException(pid: readPid());
+      // Prefer the app PID in the exception so crash-report can reference it.
+      throw await buildAppDiedException(pid: readAppPid() ?? readPid());
     }
     // For non-connection errors (e.g. bad URI, TLS issues) fall back to PID
-    // check before rethrowing.
-    final currentPid = readPid();
-    if (currentPid != null && !isProcessAlive(currentPid)) {
-      throw await buildAppDiedException(pid: currentPid);
+    // check before rethrowing (macOS only — see pre-check rationale above).
+    if (Platform.isMacOS) {
+      final currentPid = readAppPid() ?? readPid();
+      if (currentPid != null && !isProcessAlive(currentPid)) {
+        throw await buildAppDiedException(pid: currentPid);
+      }
     }
     rethrow;
   }
@@ -113,10 +132,12 @@ Future<Map<String, dynamic>> vmServiceCall(
     return response;
   } on TimeoutException {
     await ws.close();
-    // Check if the process died during the wait.
-    final currentPid = readPid();
-    if (currentPid != null && !isProcessAlive(currentPid)) {
-      throw await buildAppDiedException(pid: currentPid);
+    // Check if the process died during the wait (macOS only — see pre-check).
+    if (Platform.isMacOS) {
+      final currentPid = readAppPid() ?? readPid();
+      if (currentPid != null && !isProcessAlive(currentPid)) {
+        throw await buildAppDiedException(pid: currentPid);
+      }
     }
     rethrow;
   } on AppDiedException {
@@ -130,7 +151,7 @@ Future<Map<String, dynamic>> vmServiceCall(
 
 /// Builds an [AppDiedException] after a mid-call connection drop.
 Future<AppDiedException> _buildDeadAppError() async {
-  final pid = readPid();
+  final pid = readAppPid() ?? readPid();
   return buildAppDiedException(pid: pid);
 }
 

--- a/lib/vm_service.dart
+++ b/lib/vm_service.dart
@@ -22,17 +22,18 @@ Future<Map<String, dynamic>> vmServiceCall(
   // Pre-check: if the process is dead, short-circuit immediately without
   // even attempting a WebSocket connection.
   //
-  // On macOS desktop the app VM PID (fdb.app_pid) and the flutter-tools PID
-  // (fdb.pid) both live in the host process table, so we can check either.
-  // Prefer the app PID because it is the actual Dart VM process; fall back to
-  // the flutter-tools PID when fdb.app_pid has not been written yet.
+  // On the macOS desktop *target* (not host), the app VM PID (fdb.app_pid)
+  // and the flutter-tools PID (fdb.pid) both live in the host process table,
+  // so we can check either. Prefer the app PID because it is the actual Dart
+  // VM process; fall back to the flutter-tools PID when fdb.app_pid has not
+  // been written yet.
   //
-  // On Android and iOS the app VM PID from getVM lives inside the device /
-  // simulator process namespace and is NOT visible to the host macOS process
-  // table — kill -0 would always return false, producing false positives.
-  // On those platforms skip the PID pre-check and rely on the
+  // On Android and iOS targets the app VM PID from getVM lives inside the
+  // device / simulator process namespace and is NOT visible to the host macOS
+  // process table — kill -0 would always return false, producing false
+  // positives. On those targets skip the PID pre-check and rely on the
   // connection-refused heuristic below.
-  if (Platform.isMacOS) {
+  if (_isMacOsTarget()) {
     final pid = readAppPid() ?? readPid();
     if (pid != null && !isProcessAlive(pid)) {
       throw await buildAppDiedException(pid: pid);
@@ -49,8 +50,9 @@ Future<Map<String, dynamic>> vmServiceCall(
     ).timeout(const Duration(seconds: 5));
   } on TimeoutException {
     // Connection timed out — check if the process died in the meantime.
-    // Use app PID on macOS (most accurate); fall back to flutter-tools PID.
-    if (Platform.isMacOS) {
+    // Use app PID on the macOS target (most accurate); fall back to
+    // flutter-tools PID. Skip on Android/iOS where the PID is not on the host.
+    if (_isMacOsTarget()) {
       final currentPid = readAppPid() ?? readPid();
       if (currentPid != null && !isProcessAlive(currentPid)) {
         throw await buildAppDiedException(pid: currentPid);
@@ -70,12 +72,14 @@ Future<Map<String, dynamic>> vmServiceCall(
     // If the app came back on a different port the URI would also be stale,
     // but that scenario is handled by re-running `fdb launch`.
     if (_isConnectionRefused(e)) {
-      // Prefer the app PID in the exception so crash-report can reference it.
-      throw await buildAppDiedException(pid: readAppPid() ?? readPid());
+      // Prefer the app PID on macOS target (host-visible). On Android/iOS the
+      // app PID is device-namespace and not useful — use flutter-tools PID.
+      final pid = _isMacOsTarget() ? (readAppPid() ?? readPid()) : readPid();
+      throw await buildAppDiedException(pid: pid);
     }
     // For non-connection errors (e.g. bad URI, TLS issues) fall back to PID
-    // check before rethrowing (macOS only — see pre-check rationale above).
-    if (Platform.isMacOS) {
+    // check before rethrowing (macOS target only — see pre-check rationale).
+    if (_isMacOsTarget()) {
       final currentPid = readAppPid() ?? readPid();
       if (currentPid != null && !isProcessAlive(currentPid)) {
         throw await buildAppDiedException(pid: currentPid);
@@ -132,8 +136,8 @@ Future<Map<String, dynamic>> vmServiceCall(
     return response;
   } on TimeoutException {
     await ws.close();
-    // Check if the process died during the wait (macOS only — see pre-check).
-    if (Platform.isMacOS) {
+    // Check if the process died during the wait (macOS target only).
+    if (_isMacOsTarget()) {
       final currentPid = readAppPid() ?? readPid();
       if (currentPid != null && !isProcessAlive(currentPid)) {
         throw await buildAppDiedException(pid: currentPid);
@@ -150,9 +154,26 @@ Future<Map<String, dynamic>> vmServiceCall(
 }
 
 /// Builds an [AppDiedException] after a mid-call connection drop.
+/// Uses the app PID on a macOS target (host-visible); on Android/iOS the
+/// app PID lives in the device namespace and is not host-visible, so the
+/// flutter-tools PID is the only useful value.
 Future<AppDiedException> _buildDeadAppError() async {
-  final pid = readAppPid() ?? readPid();
+  final pid = _isMacOsTarget() ? (readAppPid() ?? readPid()) : readPid();
   return buildAppDiedException(pid: pid);
+}
+
+/// Returns true when the *target* device for this session is macOS desktop.
+///
+/// `Platform.isMacOS` checks the HOST OS (always macOS in fdb's supported
+/// configurations), not the target. Reading the platform from the session file
+/// is required to distinguish a macOS target from an Android or iOS target
+/// when fdb itself runs on macOS. Returns false if the platform file is
+/// missing (no session) — callers should treat this conservatively.
+bool _isMacOsTarget() {
+  final info = readPlatformInfo();
+  if (info == null) return false;
+  final p = info.platform.toLowerCase();
+  return p == 'darwin' || p == 'macos';
 }
 
 /// Returns true when [error] indicates the OS refused the TCP connection,


### PR DESCRIPTION
flutter run --pid-file writes the flutter-tools process PID into fdb.pid, not the actual app VM PID. This conflation broke liveness detection: on Android/iOS the app VM PID lives in the device process namespace and is invisible to the macOS host, so kill -0 always returned false and triggered false APP_DIED errors.

This separates the two PIDs — fdb.pid continues to be used for SIGUSR1/SIGUSR2 signalling and session management, while a new fdb.app_pid file holds the real app VM PID for liveness checks on macOS desktop. The test:app-died Taskfile task is updated to use platform-appropriate kill mechanisms (simctl terminate on iOS, adb force-stop on Android, fdb.app_pid on macOS).

Closes #77