### PR TITLE
feat: fdb crash-report — fetch OS-level crash and OOM records

### DIFF
--- a/.agents/skills/implementing-fdb-features/SKILL.md
+++ b/.agents/skills/implementing-fdb-features/SKILL.md
@@ -34,7 +34,13 @@ Taskfile tests:
 Docs:
 - [ ] README.md — commands table
 - [ ] .agents/skills/testing-fdb/SKILL.md — individual test list
-- [ ] skills/using-fdb/SKILL.md — usage examples (load creating-opencode-skills skill first)
+- [ ] skills/using-fdb/SKILL.md — usage examples
+
+Platform tests (ALL mandatory before PR):
+- [ ] macOS — task test:<command> passes
+- [ ] Android physical — task test:<command> passes
+- [ ] iOS simulator — task test:<command> passes
+- [ ] Full smoke suite: task smoke (Android)
 
 Review loop (delegated):
 - [ ] Spawn reviewing-fixing-loop agent
@@ -43,12 +49,6 @@ Review loop (delegated):
 Checks (delegated):
 - [ ] Spawn checks agent (dart analyze + flutter analyze + dart format)
 - [ ] All clean
-
-Platform tests (ALL mandatory before PR):
-- [ ] macOS — task test:<command> passes
-- [ ] Android physical — task test:<command> passes
-- [ ] iOS simulator — task test:<command> passes
-- [ ] Full smoke suite: task smoke (Android)
 
 PR:
 - [ ] Load humanizing-ai-text skill before writing PR body
@@ -144,7 +144,7 @@ Read these files before writing any code:
 **Docs to update:**
 - `README.md` — commands table
 - `.agents/skills/testing-fdb/SKILL.md` — add `task test:<command>` to individual test list
-- `skills/using-fdb/SKILL.md` — add usage examples with output tokens; load `creating-opencode-skills` skill before editing to follow spec-sheet style rules
+- `skills/using-fdb/SKILL.md` — add usage examples with output tokens
 
 ---
 
@@ -185,46 +185,7 @@ task analyze
 
 ---
 
-## Step 5 — Spawn review-fix loop agent (DELEGATE)
-
-```
-Spawn a coding subagent with this prompt:
-
-Run a review-fixing loop on the <feature-name> implementation in the git
-worktree at `.worktrees/<feature-name>`.
-
-Review against:
-1. GitHub issue acceptance criteria
-2. CODE-STYLE.md and packages/fdb_helper/AGENTS.md
-3. Edge cases and error handling
-4. Output token format
-5. Taskfile test coverage
-6. Doc completeness (README, testing-fdb/SKILL.md, using-fdb/SKILL.md)
-
-Fix all real findings. Commit and push when the loop converges.
-```
-
----
-
-## Step 6 — Spawn checks agent (DELEGATE)
-
-```
-Spawn a coding subagent with this prompt:
-
-Run all static analysis and format checks on the fdb worktree at
-`.worktrees/<feature-name>`.
-
-1. dart pub get
-2. dart analyze lib/ bin/ test/
-3. dart format --page-width 120 --trailing-commas preserve --set-exit-if-changed lib/ bin/ test/
-4. cd packages/fdb_helper && flutter analyze --suppress-analytics
-
-Fix ALL issues. Commit and push. Return exact output of each check.
-```
-
----
-
-## Step 7 — Manual platform testing (MANDATORY)
+## Step 5 — Manual platform testing (MANDATORY)
 
 All three platforms must pass before opening a PR. No exceptions.
 
@@ -251,6 +212,45 @@ Platform notes:
 **Full smoke suite** (after all three platforms pass):
 ```bash
 task smoke   # runs on Android
+```
+
+---
+
+## Step 6 — Spawn review-fix loop agent (DELEGATE)
+
+```
+Spawn a coding subagent with this prompt:
+
+Run a review-fixing loop on the <feature-name> implementation in the git
+worktree at `.worktrees/<feature-name>`.
+
+Review against:
+1. GitHub issue acceptance criteria
+2. CODE-STYLE.md and packages/fdb_helper/AGENTS.md
+3. Edge cases and error handling
+4. Output token format
+5. Taskfile test coverage
+6. Doc completeness (README, testing-fdb/SKILL.md, using-fdb/SKILL.md)
+
+Fix all real findings. Commit and push when the loop converges.
+```
+
+---
+
+## Step 7 — Spawn checks agent (DELEGATE)
+
+```
+Spawn a coding subagent with this prompt:
+
+Run all static analysis and format checks on the fdb worktree at
+`.worktrees/<feature-name>`.
+
+1. dart pub get
+2. dart analyze lib/ bin/ test/
+3. dart format --page-width 120 --trailing-commas preserve --set-exit-if-changed lib/ bin/ test/
+4. cd packages/fdb_helper && flutter analyze --suppress-analytics
+
+Fix ALL issues. Commit and push. Return exact output of each check.
 ```
 
 ---

--- a/.agents/skills/implementing-fdb-features/SKILL.md
+++ b/.agents/skills/implementing-fdb-features/SKILL.md
@@ -34,13 +34,7 @@ Taskfile tests:
 Docs:
 - [ ] README.md — commands table
 - [ ] .agents/skills/testing-fdb/SKILL.md — individual test list
-- [ ] skills/using-fdb/SKILL.md — usage examples
-
-Platform tests (ALL mandatory before PR):
-- [ ] macOS — task test:<command> passes
-- [ ] Android physical — task test:<command> passes
-- [ ] iOS simulator — task test:<command> passes
-- [ ] Full smoke suite: task smoke (Android)
+- [ ] skills/using-fdb/SKILL.md — usage examples (load creating-opencode-skills skill first)
 
 Review loop (delegated):
 - [ ] Spawn reviewing-fixing-loop agent
@@ -49,6 +43,12 @@ Review loop (delegated):
 Checks (delegated):
 - [ ] Spawn checks agent (dart analyze + flutter analyze + dart format)
 - [ ] All clean
+
+Platform tests (ALL mandatory before PR):
+- [ ] macOS — task test:<command> passes
+- [ ] Android physical — task test:<command> passes
+- [ ] iOS simulator — task test:<command> passes
+- [ ] Full smoke suite: task smoke (Android)
 
 PR:
 - [ ] Load humanizing-ai-text skill before writing PR body
@@ -144,7 +144,7 @@ Read these files before writing any code:
 **Docs to update:**
 - `README.md` — commands table
 - `.agents/skills/testing-fdb/SKILL.md` — add `task test:<command>` to individual test list
-- `skills/using-fdb/SKILL.md` — add usage examples with output tokens
+- `skills/using-fdb/SKILL.md` — add usage examples with output tokens; load `creating-opencode-skills` skill before editing to follow spec-sheet style rules
 
 ---
 
@@ -185,7 +185,46 @@ task analyze
 
 ---
 
-## Step 5 — Manual platform testing (MANDATORY)
+## Step 5 — Spawn review-fix loop agent (DELEGATE)
+
+```
+Spawn a coding subagent with this prompt:
+
+Run a review-fixing loop on the <feature-name> implementation in the git
+worktree at `.worktrees/<feature-name>`.
+
+Review against:
+1. GitHub issue acceptance criteria
+2. CODE-STYLE.md and packages/fdb_helper/AGENTS.md
+3. Edge cases and error handling
+4. Output token format
+5. Taskfile test coverage
+6. Doc completeness (README, testing-fdb/SKILL.md, using-fdb/SKILL.md)
+
+Fix all real findings. Commit and push when the loop converges.
+```
+
+---
+
+## Step 6 — Spawn checks agent (DELEGATE)
+
+```
+Spawn a coding subagent with this prompt:
+
+Run all static analysis and format checks on the fdb worktree at
+`.worktrees/<feature-name>`.
+
+1. dart pub get
+2. dart analyze lib/ bin/ test/
+3. dart format --page-width 120 --trailing-commas preserve --set-exit-if-changed lib/ bin/ test/
+4. cd packages/fdb_helper && flutter analyze --suppress-analytics
+
+Fix ALL issues. Commit and push. Return exact output of each check.
+```
+
+---
+
+## Step 7 — Manual platform testing (MANDATORY)
 
 All three platforms must pass before opening a PR. No exceptions.
 
@@ -212,45 +251,6 @@ Platform notes:
 **Full smoke suite** (after all three platforms pass):
 ```bash
 task smoke   # runs on Android
-```
-
----
-
-## Step 6 — Spawn review-fix loop agent (DELEGATE)
-
-```
-Spawn a coding subagent with this prompt:
-
-Run a review-fixing loop on the <feature-name> implementation in the git
-worktree at `.worktrees/<feature-name>`.
-
-Review against:
-1. GitHub issue acceptance criteria
-2. CODE-STYLE.md and packages/fdb_helper/AGENTS.md
-3. Edge cases and error handling
-4. Output token format
-5. Taskfile test coverage
-6. Doc completeness (README, testing-fdb/SKILL.md, using-fdb/SKILL.md)
-
-Fix all real findings. Commit and push when the loop converges.
-```
-
----
-
-## Step 7 — Spawn checks agent (DELEGATE)
-
-```
-Spawn a coding subagent with this prompt:
-
-Run all static analysis and format checks on the fdb worktree at
-`.worktrees/<feature-name>`.
-
-1. dart pub get
-2. dart analyze lib/ bin/ test/
-3. dart format --page-width 120 --trailing-commas preserve --set-exit-if-changed lib/ bin/ test/
-4. cd packages/fdb_helper && flutter analyze --suppress-analytics
-
-Fix ALL issues. Commit and push. Return exact output of each check.
 ```
 
 ---

--- a/.agents/skills/testing-fdb/SKILL.md
+++ b/.agents/skills/testing-fdb/SKILL.md
@@ -48,6 +48,7 @@ task test:restart
 task test:logs
 task test:logs-tag
 task test:syslog
+task test:crash-report
 task test:tree
 task test:describe
 task test:describe-grid

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ fdb kill
 | `fdb screenshot [--output <path>] [--full]` | Screenshot (all platforms; `--full` skips downscaling) |
 | `fdb logs --tag <tag> --last <n>` | Filtered logs |
 | `fdb syslog [--since <dur>] [--predicate <str>] [--last <n>] [--follow]` | Native system logs (Android logcat, iOS syslog, macOS log) |
+| `fdb crash-report [--app-id <id>] [--last <dur>] [--all]` | Fetch the most recent OS-level crash record (jetsam, LMK, native crashes) |
 | `fdb tree --depth <n> [--user-only]` | Widget tree |
 | `fdb describe` | Compact screen snapshot: interactive elements + visible text *(requires `fdb_helper`)* |
 | `fdb select on/off` | Widget selection mode |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -458,6 +458,90 @@ tasks:
           exit 1
         fi
 
+  test:crash-report:
+    desc: Fetch OS-level crash records for the running app
+    dir: '{{.TEST_APP}}'
+    cmds:
+      - |
+        echo "==> fdb crash-report (default: --last 1h)"
+        OUTPUT=$({{.FDB}} crash-report 2>&1)
+        EXIT_CODE=$?
+        echo "$OUTPUT"
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "FAIL: fdb crash-report exited with code $EXIT_CODE" >&2
+          exit 1
+        fi
+        if echo "$OUTPUT" | grep -qE "CRASH_REPORT_FOUND|CRASH_REPORT_NONE"; then
+          echo "PASS: fdb crash-report"
+        else
+          echo "FAIL: fdb crash-report - expected CRASH_REPORT_FOUND or CRASH_REPORT_NONE" >&2
+          exit 1
+        fi
+
+        echo "==> fdb crash-report --last 5m"
+        OUTPUT=$({{.FDB}} crash-report --last 5m 2>&1)
+        EXIT_CODE=$?
+        echo "$OUTPUT"
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "FAIL: fdb crash-report --last 5m exited with code $EXIT_CODE" >&2
+          exit 1
+        fi
+        if echo "$OUTPUT" | grep -qE "CRASH_REPORT_FOUND|CRASH_REPORT_NONE"; then
+          echo "PASS: fdb crash-report --last 5m"
+        else
+          echo "FAIL: fdb crash-report --last 5m - expected CRASH_REPORT_FOUND or CRASH_REPORT_NONE" >&2
+          exit 1
+        fi
+
+        echo "==> fdb crash-report --all"
+        OUTPUT=$({{.FDB}} crash-report --all 2>&1)
+        EXIT_CODE=$?
+        echo "$OUTPUT"
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "FAIL: fdb crash-report --all exited with code $EXIT_CODE" >&2
+          exit 1
+        fi
+        if echo "$OUTPUT" | grep -qE "CRASH_REPORT_FOUND|CRASH_REPORT_NONE"; then
+          echo "PASS: fdb crash-report --all"
+        else
+          echo "FAIL: fdb crash-report --all - expected CRASH_REPORT_FOUND or CRASH_REPORT_NONE" >&2
+          exit 1
+        fi
+
+        echo "==> fdb crash-report invalid --last format (expect error)"
+        set +e
+        OUTPUT=$({{.FDB}} crash-report --last bad 2>&1)
+        EXIT_CODE=$?
+        set -e
+        echo "$OUTPUT"
+        if [ $EXIT_CODE -eq 0 ]; then
+          echo "FAIL: fdb crash-report --last bad should have failed" >&2
+          exit 1
+        fi
+        if echo "$OUTPUT" | grep -q "ERROR:"; then
+          echo "PASS: fdb crash-report invalid --last rejected"
+        else
+          echo "FAIL: fdb crash-report invalid --last — expected ERROR: in output" >&2
+          exit 1
+        fi
+
+        echo "==> fdb crash-report --app-id com.example.nonexistent"
+        OUTPUT=$({{.FDB}} crash-report --app-id com.example.nonexistent 2>&1)
+        EXIT_CODE=$?
+        echo "$OUTPUT"
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "FAIL: fdb crash-report --app-id nonexistent exited with code $EXIT_CODE" >&2
+          exit 1
+        fi
+        if echo "$OUTPUT" | grep -qE "CRASH_REPORT_FOUND|CRASH_REPORT_NONE"; then
+          echo "PASS: fdb crash-report --app-id (no records expected)"
+        else
+          echo "FAIL: fdb crash-report --app-id nonexistent - expected CRASH_REPORT_FOUND or CRASH_REPORT_NONE" >&2
+          exit 1
+        fi
+
+        echo "PASS: fdb crash-report"
+
   test:tree:
     desc: Inspect widget tree
     dir: '{{.TEST_APP}}'
@@ -2556,6 +2640,7 @@ tasks:
       - task: test:logs
       - task: test:logs-tag
       - task: test:syslog
+      - task: test:crash-report
       - task: test:tree
       - task: test:describe
       - task: test:describe-grid

--- a/bin/fdb.dart
+++ b/bin/fdb.dart
@@ -1,8 +1,8 @@
 import 'dart:io';
 
 import 'package:fdb/cli/adapters/back_cli.dart';
-import 'package:fdb/cli/adapters/crash_report_cli.dart';
 import 'package:fdb/cli/adapters/clean_cli.dart';
+import 'package:fdb/cli/adapters/crash_report_cli.dart';
 import 'package:fdb/cli/adapters/deeplink_cli.dart';
 import 'package:fdb/cli/adapters/describe_cli.dart';
 import 'package:fdb/cli/adapters/devices_cli.dart';

--- a/bin/fdb.dart
+++ b/bin/fdb.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:fdb/cli/adapters/back_cli.dart';
+import 'package:fdb/cli/adapters/crash_report_cli.dart';
 import 'package:fdb/cli/adapters/clean_cli.dart';
 import 'package:fdb/cli/adapters/deeplink_cli.dart';
 import 'package:fdb/cli/adapters/describe_cli.dart';
@@ -52,6 +53,10 @@ Commands:
   screenshot  Take a device screenshot
   logs        Get filtered app logs
   syslog      Read native system logs (Android logcat, iOS syslog, macOS log)
+  crash-report Fetch the most recent OS-level crash record for the app
+               --app-id <id>       Bundle id / package name (auto from .fdb/app_id.txt)
+               --last <duration>   Time window to search (default: 1h)
+               --all               Return all crash records in the window
   tree        Get the widget tree
   describe    Describe the current screen (interactive elements + text)
   doctor      Check app, VM service, fdb_helper, platform tools, and device state
@@ -128,7 +133,7 @@ Future<void> main(List<String> args) async {
   // Commands that manage their own session dir or must run even on unhealthy sessions.
   const sessionResolutionExempt = {'launch', 'devices', 'skill'};
   // Commands that run against a potentially dead/missing session (soft-fail on null).
-  const sessionSoftFail = {'status', 'doctor'};
+  const sessionSoftFail = {'status', 'doctor', 'crash-report'};
   if (!sessionResolutionExempt.contains(command) && !wantsHelp && !isMemDiff) {
     if (explicitSessionDir != null) {
       initSessionDirFromPath(explicitSessionDir);
@@ -173,6 +178,8 @@ Future<int> _runCommand(String command, List<String> args) {
       return runLogsCli(args);
     case 'syslog':
       return runSyslogCli(args);
+    case 'crash-report':
+      return runCrashReportCli(args);
     case 'tree':
       return runTreeCli(args);
     case 'describe':

--- a/lib/cli/adapters/crash_report_cli.dart
+++ b/lib/cli/adapters/crash_report_cli.dart
@@ -60,7 +60,10 @@ Future<int> _execute(ArgResults results) async {
 
 int _format(CrashReportResult result) {
   switch (result) {
-    case CrashReportFound(:final entries):
+    case CrashReportFound(:final entries, :final warnings):
+      for (final w in warnings) {
+        stderr.writeln('WARNING: $w');
+      }
       stdout.writeln('CRASH_REPORT_FOUND ENTRIES=${entries.length}');
       for (final entry in entries) {
         stdout.writeln('---');

--- a/lib/cli/adapters/crash_report_cli.dart
+++ b/lib/cli/adapters/crash_report_cli.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:fdb/cli/args_helpers.dart';
 import 'package:fdb/core/commands/crash_report/crash_report.dart';
+import 'package:fdb/core/process_utils.dart';
 
 /// CLI adapter for `fdb crash-report`.
 ///
@@ -55,15 +56,22 @@ Future<int> _execute(ArgResults results) async {
   );
 
   final result = await fetchCrashReport(input);
+
+  // Warn when the user explicitly passed --last but the platform is Android,
+  // where logcat has no native time filter and the flag is ignored.
+  if (results.wasParsed('last') && result is CrashReportFound) {
+    final platformInfo = readPlatformInfo();
+    if (platformInfo != null && platformInfo.platform.toLowerCase().startsWith('android')) {
+      stderr.writeln('WARNING: --last is not supported on Android, the flag was ignored');
+    }
+  }
+
   return _format(result);
 }
 
 int _format(CrashReportResult result) {
   switch (result) {
-    case CrashReportFound(:final entries, :final warnings):
-      for (final w in warnings) {
-        stderr.writeln('WARNING: $w');
-      }
+    case CrashReportFound(:final entries):
       stdout.writeln('CRASH_REPORT_FOUND ENTRIES=${entries.length}');
       for (final entry in entries) {
         stdout.writeln('---');

--- a/lib/cli/adapters/crash_report_cli.dart
+++ b/lib/cli/adapters/crash_report_cli.dart
@@ -55,17 +55,17 @@ Future<int> _execute(ArgResults results) async {
     all: results['all'] as bool,
   );
 
-  final result = await fetchCrashReport(input);
-
   // Warn when the user explicitly passed --last but the platform is Android,
   // where logcat has no native time filter and the flag is ignored.
-  if (results.wasParsed('last') && result is CrashReportFound) {
+  // Emitted before result processing so it fires regardless of result variant.
+  if (results.wasParsed('last')) {
     final platformInfo = readPlatformInfo();
     if (platformInfo != null && platformInfo.platform.toLowerCase().startsWith('android')) {
       stderr.writeln('WARNING: --last is not supported on Android, the flag was ignored');
     }
   }
 
+  final result = await fetchCrashReport(input);
   return _format(result);
 }
 

--- a/lib/cli/adapters/crash_report_cli.dart
+++ b/lib/cli/adapters/crash_report_cli.dart
@@ -1,0 +1,112 @@
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:fdb/cli/args_helpers.dart';
+import 'package:fdb/core/commands/crash_report/crash_report.dart';
+
+/// CLI adapter for `fdb crash-report`.
+///
+/// Output contract:
+///
+///   CRASH_REPORT_FOUND ENTRIES=N            (success — header line)
+///   ---                                     (separator before each entry)
+///   LABEL=[iOS sim]                         (per-entry label)
+///   FILE=/path/to/crash.ips                 (per-entry file, if available)
+///   (raw log text)                          (per-entry raw content)
+///   CRASH_REPORT_NONE                       (no records found)
+///   ERROR: --app-id is required ...         (missing app id)
+///   ERROR: tool not found. hint             (missing tool)
+///   ERROR: message                          (generic)
+Future<int> runCrashReportCli(List<String> args) => runCliAdapter(
+      ArgParser()
+        ..addOption(
+          'app-id',
+          help: 'App bundle id (iOS/macOS) or package name (Android). '
+              'Auto-detected from .fdb/app_id.txt if omitted.',
+        )
+        ..addOption(
+          'last',
+          defaultsTo: '1h',
+          help: 'Time window to search (e.g. 30s, 5m, 1h). Default: 1h',
+        )
+        ..addFlag(
+          'all',
+          negatable: false,
+          help: 'Return all crash records in the window, not just the latest.',
+        ),
+      args,
+      _execute,
+    );
+
+Future<int> _execute(ArgResults results) async {
+  final last = results['last'] as String;
+  if (!_isValidDuration(last)) {
+    stderr.writeln(
+      'ERROR: Invalid --last value: $last. '
+      'Use a number followed by s, m, or h (e.g. 30s, 5m, 1h)',
+    );
+    return 1;
+  }
+
+  final input = (
+    appId: results['app-id'] as String?,
+    last: last,
+    all: results['all'] as bool,
+  );
+
+  final result = await fetchCrashReport(input);
+  return _format(result);
+}
+
+int _format(CrashReportResult result) {
+  switch (result) {
+    case CrashReportFound(:final entries):
+      stdout.writeln('CRASH_REPORT_FOUND ENTRIES=${entries.length}');
+      for (final entry in entries) {
+        stdout.writeln('---');
+        stdout.writeln('LABEL=${entry.label}');
+        if (entry.filePath != null) {
+          stdout.writeln('FILE=${entry.filePath}');
+        }
+        stdout.writeln(entry.text);
+      }
+      return 0;
+
+    case CrashReportNone():
+      stdout.writeln('CRASH_REPORT_NONE');
+      return 0;
+
+    case CrashReportMissingAppId():
+      stderr.writeln(
+        'ERROR: --app-id is required for this platform. '
+        'Pass --app-id <bundle-id-or-package> or run fdb launch first '
+        '(it persists the app id to .fdb/app_id.txt).',
+      );
+      return 1;
+
+    case CrashReportToolMissing(:final tool, :final hint):
+      stderr.writeln('ERROR: $tool not found. $hint');
+      return 1;
+
+    case CrashReportUnsupportedPlatform(:final platform):
+      stderr.writeln('ERROR: crash-report is not supported on platform: $platform');
+      return 1;
+
+    case CrashReportNoSession():
+      stderr.writeln('ERROR: No platform info found. Is the app running? Run fdb launch first.');
+      return 1;
+
+    case CrashReportError(:final message):
+      stderr.writeln('ERROR: $message');
+      return 1;
+  }
+}
+
+/// Returns true if [s] is a valid duration string (`<positive-int>[smh]`).
+bool _isValidDuration(String s) {
+  if (s.isEmpty) return false;
+  final suffix = s[s.length - 1];
+  if (!const {'s', 'm', 'h'}.contains(suffix)) return false;
+  final n = int.tryParse(s.substring(0, s.length - 1));
+  return n != null && n > 0;
+}

--- a/lib/cli/adapters/crash_report_cli.dart
+++ b/lib/cli/adapters/crash_report_cli.dart
@@ -33,7 +33,7 @@ Future<int> runCrashReportCli(List<String> args) => runCliAdapter(
         ..addFlag(
           'all',
           negatable: false,
-          help: 'Return all crash records in the window, not just the latest.',
+          help: 'Return all crash records (no time limit), not just the latest.',
         ),
       args,
       _execute,

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -111,6 +111,7 @@ String get vmUriFile => '$_sessionDir/vm_uri.txt';
 String get launcherScript => '$_sessionDir/launcher.sh';
 String get deviceFile => '$_sessionDir/device.txt';
 String get platformFile => '$_sessionDir/platform.txt';
+String get appIdFile => '$_sessionDir/app_id.txt';
 String get defaultScreenshotPath => '$_sessionDir/screenshot.png';
 
 const launchTimeoutSeconds = 300; // 5 minutes

--- a/lib/core/commands/crash_report/crash_report.dart
+++ b/lib/core/commands/crash_report/crash_report.dart
@@ -207,16 +207,12 @@ Future<CrashReportResult> _runIosPhysical({
 
   // When --all is true, skip the mtime filter (consistent with iOS Simulator).
   final duration = input.all ? null : _parseDuration(input.last);
-  final ipsFiles = tmpDir
-      .listSync()
-      .whereType<File>()
-      .where((f) {
-        if (!f.path.endsWith('.ips')) return false;
-        if (duration == null) return true;
-        final cutoff = DateTime.now().subtract(duration);
-        return f.statSync().modified.isAfter(cutoff);
-      })
-      .toList()
+  final ipsFiles = tmpDir.listSync().whereType<File>().where((f) {
+    if (!f.path.endsWith('.ips')) return false;
+    if (duration == null) return true;
+    final cutoff = DateTime.now().subtract(duration);
+    return f.statSync().modified.isAfter(cutoff);
+  }).toList()
     ..sort((a, b) => b.statSync().modified.compareTo(a.statSync().modified));
 
   if (ipsFiles.isEmpty) return const CrashReportNone();
@@ -327,5 +323,3 @@ String? _safeReadFile(File file) {
     return null;
   }
 }
-
-

--- a/lib/core/commands/crash_report/crash_report.dart
+++ b/lib/core/commands/crash_report/crash_report.dart
@@ -134,7 +134,7 @@ Future<CrashReportResult> _runIosSimulator({
   if (appId != null) {
     predicateParts.add('eventMessage CONTAINS "$appId"');
   }
-  final predicate = predicateParts.join(' OR ');
+  final predicate = predicateParts.join(' AND ');
 
   // When --all is true, omit --last so the query is not time-bounded.
   final logArgs = [

--- a/lib/core/commands/crash_report/crash_report.dart
+++ b/lib/core/commands/crash_report/crash_report.dart
@@ -1,0 +1,316 @@
+import 'dart:io';
+
+import 'package:fdb/constants.dart';
+import 'package:fdb/core/commands/crash_report/crash_report_models.dart';
+import 'package:fdb/core/process_utils.dart';
+
+export 'package:fdb/core/commands/crash_report/crash_report_models.dart';
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/// Fetches the most recent OS-level crash record(s) for the app under debug.
+///
+/// Platform dispatch:
+///   Android       — adb logcat -b crash + adb shell dumpsys dropbox + LMK events
+///   iOS simulator — xcrun simctl log show (jetsam/crash predicate) + .ips files
+///   iOS physical  — idevicecrashreport (requires libimobiledevice)
+///   macOS         — log show + ~/Library/Logs/DiagnosticReports/
+///
+/// Never throws; all error conditions are represented as sealed result cases.
+Future<CrashReportResult> fetchCrashReport(CrashReportInput input) async {
+  try {
+    final platformInfo = readPlatformInfo();
+    if (platformInfo == null) return const CrashReportNoSession();
+
+    final appId = input.appId ?? readAppId();
+
+    final platform = platformInfo.platform.toLowerCase();
+    final emulator = platformInfo.emulator;
+    final device = readDevice();
+
+    if (platform.startsWith('android')) {
+      return _runAndroid(device: device, appId: appId, input: input);
+    } else if (platform == 'ios' || platform.startsWith('ios-')) {
+      if (emulator) {
+        return _runIosSimulator(device: device, appId: appId, input: input);
+      } else {
+        return _runIosPhysical(appId: appId, input: input);
+      }
+    } else if (platform == 'darwin' || platform == 'macos') {
+      return _runMacos(appId: appId, input: input);
+    } else {
+      return CrashReportUnsupportedPlatform(platform);
+    }
+  } catch (e) {
+    return CrashReportError(e.toString());
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Platform implementations
+// ---------------------------------------------------------------------------
+
+Future<CrashReportResult> _runAndroid({
+  required String? device,
+  required String? appId,
+  required CrashReportInput input,
+}) async {
+  if (!_isToolOnPath('adb')) {
+    return const CrashReportToolMissing(
+      tool: 'adb',
+      hint: 'Install Android SDK platform-tools and ensure adb is on PATH.',
+    );
+  }
+
+  final adbPrefix = <String>[if (device != null) ...['-s', device]];
+  final entries = <CrashReportEntry>[];
+
+  // --- logcat crash buffer ---
+  final logcatArgs = [...adbPrefix, 'logcat', '-b', 'crash', '-d'];
+  final logcatResult = Process.runSync('adb', logcatArgs);
+  final logcatText = (logcatResult.stdout as String).trim();
+  if (logcatText.isNotEmpty) {
+    final filtered = appId != null ? _filterLines(logcatText, appId) : logcatText;
+    if (filtered.isNotEmpty) {
+      entries.add(CrashReportEntry(label: '[Android logcat crash]', text: filtered));
+    }
+  }
+
+  // --- logcat LMK (low memory killer) events ---
+  final lmkArgs = [...adbPrefix, 'logcat', '-b', 'system', '-d', '-s', 'lowmemorykiller'];
+  final lmkResult = Process.runSync('adb', lmkArgs);
+  final lmkText = (lmkResult.stdout as String).trim();
+  if (lmkText.isNotEmpty) {
+    final filtered = appId != null ? _filterLines(lmkText, appId) : lmkText;
+    if (filtered.isNotEmpty) {
+      entries.add(CrashReportEntry(label: '[Android LMK]', text: filtered));
+    }
+  }
+
+  // --- dropbox ---
+  final dropboxArgs = [...adbPrefix, 'shell', 'dumpsys', 'dropbox', '--print'];
+  final dropboxResult = Process.runSync('adb', dropboxArgs);
+  final dropboxText = (dropboxResult.stdout as String).trim();
+  if (dropboxText.isNotEmpty && appId != null) {
+    final filtered = _filterLines(dropboxText, appId);
+    if (filtered.isNotEmpty) {
+      entries.add(CrashReportEntry(label: '[Android dropbox]', text: filtered));
+    }
+  } else if (dropboxText.isNotEmpty && appId == null) {
+    entries.add(CrashReportEntry(label: '[Android dropbox]', text: dropboxText));
+  }
+
+  if (entries.isEmpty) return const CrashReportNone();
+  return CrashReportFound(input.all ? entries : [entries.last]);
+}
+
+Future<CrashReportResult> _runIosSimulator({
+  required String? device,
+  required String? appId,
+  required CrashReportInput input,
+}) async {
+  if (!_isToolOnPath('xcrun')) {
+    return const CrashReportToolMissing(
+      tool: 'xcrun',
+      hint: 'Install Xcode command-line tools: xcode-select --install',
+    );
+  }
+
+  if (device == null) {
+    return const CrashReportError('No device ID found. Is the app running?');
+  }
+
+  final entries = <CrashReportEntry>[];
+
+  // --- system log: jetsam / crash events ---
+  final predicateParts = <String>['eventMessage CONTAINS "jetsam"'];
+  if (appId != null) {
+    predicateParts.add('eventMessage CONTAINS "$appId"');
+  }
+  final predicate = predicateParts.join(' OR ');
+
+  final logArgs = [
+    'simctl',
+    'spawn',
+    device,
+    'log',
+    'show',
+    '--last',
+    input.last,
+    '--style',
+    'compact',
+    '--predicate',
+    predicate,
+  ];
+
+  final logResult = Process.runSync('xcrun', logArgs);
+  final logText = (logResult.stdout as String).trim();
+  if (logText.isNotEmpty) {
+    entries.add(CrashReportEntry(label: '[iOS sim log]', text: logText));
+  }
+
+  // --- .ips diagnostic report files ---
+  final reportsDir = Directory('${Platform.environment['HOME']}/Library/Logs/DiagnosticReports');
+  if (reportsDir.existsSync()) {
+    final ipsFiles = reportsDir
+        .listSync()
+        .whereType<File>()
+        .where((f) => f.path.endsWith('.ips') && (appId == null || f.path.contains(appId)))
+        .toList()
+      ..sort((a, b) => b.statSync().modified.compareTo(a.statSync().modified));
+
+    final filesToRead = input.all ? ipsFiles : (ipsFiles.isNotEmpty ? [ipsFiles.first] : <File>[]);
+    for (final file in filesToRead) {
+      final text = _safeReadFile(file);
+      if (text != null) {
+        entries.add(CrashReportEntry(label: '[iOS sim .ips]', filePath: file.path, text: text));
+      }
+    }
+  }
+
+  if (entries.isEmpty) return const CrashReportNone();
+  return CrashReportFound(entries);
+}
+
+Future<CrashReportResult> _runIosPhysical({
+  required String? appId,
+  required CrashReportInput input,
+}) async {
+  if (!_isToolOnPath('idevicecrashreport')) {
+    return const CrashReportToolMissing(
+      tool: 'idevicecrashreport',
+      hint: 'Install: brew install libimobiledevice',
+    );
+  }
+
+  if (appId == null) {
+    return const CrashReportMissingAppId();
+  }
+
+  final tmpDir = Directory.systemTemp.createTempSync('fdb_crash_');
+  try {
+    final result = Process.runSync('idevicecrashreport', ['-e', '-k', appId, tmpDir.path]);
+    if (result.exitCode != 0) {
+      final err = (result.stderr as String).trim();
+      return CrashReportError('idevicecrashreport failed: $err');
+    }
+
+    final ipsFiles = tmpDir
+        .listSync()
+        .whereType<File>()
+        .where((f) => f.path.endsWith('.ips'))
+        .toList()
+      ..sort((a, b) => b.statSync().modified.compareTo(a.statSync().modified));
+
+    if (ipsFiles.isEmpty) return const CrashReportNone();
+
+    final filesToRead = input.all ? ipsFiles : [ipsFiles.first];
+    final entries = <CrashReportEntry>[];
+    for (final file in filesToRead) {
+      final text = _safeReadFile(file);
+      if (text != null) {
+        entries.add(CrashReportEntry(label: '[iOS physical .ips]', filePath: file.path, text: text));
+      }
+    }
+
+    if (entries.isEmpty) return const CrashReportNone();
+    return CrashReportFound(entries);
+  } finally {
+    try {
+      tmpDir.deleteSync(recursive: true);
+    } catch (_) {}
+  }
+}
+
+Future<CrashReportResult> _runMacos({
+  required String? appId,
+  required CrashReportInput input,
+}) async {
+  if (!_isToolOnPath('log')) {
+    return const CrashReportToolMissing(
+      tool: 'log',
+      hint: 'This is unexpected on macOS — ensure /usr/bin is on PATH.',
+    );
+  }
+
+  final entries = <CrashReportEntry>[];
+
+  // --- system log ---
+  final logArgs = ['show', '--last', input.last, '--style', 'compact'];
+  if (appId != null) {
+    logArgs.addAll(['--predicate', 'process == "$appId"']);
+  }
+
+  final logResult = Process.runSync('log', logArgs);
+  final logText = (logResult.stdout as String).trim();
+  if (logText.isNotEmpty) {
+    entries.add(CrashReportEntry(label: '[macOS log]', text: logText));
+  }
+
+  // --- DiagnosticReports ---
+  final reportsDir = Directory('${Platform.environment['HOME']}/Library/Logs/DiagnosticReports');
+  if (reportsDir.existsSync()) {
+    final ipsFiles = reportsDir
+        .listSync()
+        .whereType<File>()
+        .where((f) => f.path.endsWith('.ips') && (appId == null || f.path.contains(appId)))
+        .toList()
+      ..sort((a, b) => b.statSync().modified.compareTo(a.statSync().modified));
+
+    final filesToRead = input.all ? ipsFiles : (ipsFiles.isNotEmpty ? [ipsFiles.first] : <File>[]);
+    for (final file in filesToRead) {
+      final text = _safeReadFile(file);
+      if (text != null) {
+        entries.add(CrashReportEntry(label: '[macOS .ips]', filePath: file.path, text: text));
+      }
+    }
+  }
+
+  if (entries.isEmpty) return const CrashReportNone();
+  return CrashReportFound(entries);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Returns true if [tool] can be found via `which`.
+bool _isToolOnPath(String tool) {
+  try {
+    final result = Process.runSync('which', [tool]);
+    return result.exitCode == 0;
+  } catch (_) {
+    return false;
+  }
+}
+
+/// Returns only lines containing [substring].
+String _filterLines(String text, String substring) =>
+    text.split('\n').where((l) => l.contains(substring)).join('\n').trim();
+
+/// Reads a file's content, returning null on any error.
+String? _safeReadFile(File file) {
+  try {
+    return file.readAsStringSync();
+  } catch (_) {
+    return null;
+  }
+}
+
+/// Reads the persisted app bundle id / package name from `.fdb/app_id.txt`.
+///
+/// Returns null if the file does not exist or is empty.
+String? readAppId() {
+  final file = File(appIdFile);
+  if (!file.existsSync()) return null;
+  final content = file.readAsStringSync().trim();
+  return content.isEmpty ? null : content;
+}
+
+/// Persists [appId] to `.fdb/app_id.txt` so later commands (e.g. crash-report)
+/// can use it without requiring `--app-id`.
+void writeAppId(String appId) {
+  File(appIdFile).writeAsStringSync(appId);
+}

--- a/lib/core/commands/crash_report/crash_report.dart
+++ b/lib/core/commands/crash_report/crash_report.dart
@@ -136,14 +136,18 @@ Future<CrashReportResult> _runIosSimulator({
   }
   final predicate = predicateParts.join(' AND ');
 
-  // When --all is true, omit --last so the query is not time-bounded.
+  // --all returns all crash sources (log + every .ips file) but still bounds the
+  // log query to 24h to avoid scanning the entire simulator log history, which
+  // can be very large and cause the command to hang.
+  final logWindow = input.all ? '24h' : input.last;
   final logArgs = [
     'simctl',
     'spawn',
     device,
     'log',
     'show',
-    if (!input.all) ...['--last', input.last],
+    '--last',
+    logWindow,
     '--style',
     'compact',
     '--predicate',
@@ -244,10 +248,14 @@ Future<CrashReportResult> _runMacos({
   final entries = <CrashReportEntry>[];
 
   // --- system log ---
-  // When --all is true, omit --last so the query is not time-bounded.
+  // --all returns all crash sources (log + every .ips file) but still bounds the
+  // log query to 24h to avoid scanning the entire macOS log archive, which can
+  // take minutes and produce gigabytes of output.
+  final logWindow = input.all ? '24h' : input.last;
   final logArgs = [
     'show',
-    if (!input.all) ...['--last', input.last],
+    '--last',
+    logWindow,
     '--style',
     'compact',
     if (appId != null) ...['--predicate', 'process == "$appId"'],

--- a/lib/core/commands/crash_report/crash_report.dart
+++ b/lib/core/commands/crash_report/crash_report.dart
@@ -105,16 +105,10 @@ Future<CrashReportResult> _runAndroid({
 
   if (entries.isEmpty) return const CrashReportNone();
 
-  // Android logcat has no native --last filter. All available records from
-  // logcat buffers are returned; the --last flag is ignored.
+  // Android logcat has no native --last filter; the flag is ignored.
   // When --all is false, entries.first (logcat crash buffer) is returned as the
   // most likely source of the most recent crash.
-  final returnedEntries = input.all ? entries : [entries.first];
-  final warnings = [
-    '--last is not supported on Android, '
-        '${input.all ? 'returning all available records' : 'returning first available record'}',
-  ];
-  return CrashReportFound(returnedEntries, warnings: warnings);
+  return CrashReportFound(input.all ? entries : [entries.first]);
 }
 
 Future<CrashReportResult> _runIosSimulator({
@@ -205,13 +199,14 @@ Future<CrashReportResult> _runIosPhysical({
   // Each invocation creates a fresh temp dir so they do not accumulate
   // unboundedly; the OS will eventually reclaim them.
   final tmpDir = Directory.systemTemp.createTempSync('fdb_crash_');
-  final result = Process.runSync('idevicecrashreport', ['-e', '-k', appId, tmpDir.path]);
+  final result = Process.runSync('idevicecrashreport', ['-e', '-k', '-f', appId, tmpDir.path]);
   if (result.exitCode != 0) {
     final err = (result.stderr as String).trim();
     return CrashReportError('idevicecrashreport failed: $err');
   }
 
-  final duration = _parseDuration(input.last);
+  // When --all is true, skip the mtime filter (consistent with iOS Simulator).
+  final duration = input.all ? null : _parseDuration(input.last);
   final ipsFiles = tmpDir
       .listSync()
       .whereType<File>()
@@ -253,10 +248,14 @@ Future<CrashReportResult> _runMacos({
   final entries = <CrashReportEntry>[];
 
   // --- system log ---
-  final logArgs = ['show', '--last', input.last, '--style', 'compact'];
-  if (appId != null) {
-    logArgs.addAll(['--predicate', 'process == "$appId"']);
-  }
+  // When --all is true, omit --last so the query is not time-bounded.
+  final logArgs = [
+    'show',
+    if (!input.all) ...['--last', input.last],
+    '--style',
+    'compact',
+    if (appId != null) ...['--predicate', 'process == "$appId"'],
+  ];
 
   final logResult = Process.runSync('log', logArgs);
   final logText = (logResult.stdout as String).trim();

--- a/lib/core/commands/crash_report/crash_report.dart
+++ b/lib/core/commands/crash_report/crash_report.dart
@@ -105,14 +105,16 @@ Future<CrashReportResult> _runAndroid({
 
   if (entries.isEmpty) return const CrashReportNone();
 
-  // Android logcat has no native --last filter. We return all available records
-  // and emit an advisory warning so callers know filtering was not applied.
-  // logcat entries are returned in chronological order; logcat crash buffer is
-  // checked first, so entries.first is the most likely source for the latest crash.
+  // Android logcat has no native --last filter. All available records from
+  // logcat buffers are returned; the --last flag is ignored.
+  // When --all is false, entries.first (logcat crash buffer) is returned as the
+  // most likely source of the most recent crash.
+  final returnedEntries = input.all ? entries : [entries.first];
   final warnings = [
-    '--last is not supported on Android, returning all available records',
+    '--last is not supported on Android, '
+        '${input.all ? 'returning all available records' : 'returning first available record'}',
   ];
-  return CrashReportFound(input.all ? entries : [entries.first], warnings: warnings);
+  return CrashReportFound(returnedEntries, warnings: warnings);
 }
 
 Future<CrashReportResult> _runIosSimulator({
@@ -140,14 +142,14 @@ Future<CrashReportResult> _runIosSimulator({
   }
   final predicate = predicateParts.join(' OR ');
 
+  // When --all is true, omit --last so the query is not time-bounded.
   final logArgs = [
     'simctl',
     'spawn',
     device,
     'log',
     'show',
-    '--last',
-    input.last,
+    if (!input.all) ...['--last', input.last],
     '--style',
     'compact',
     '--predicate',
@@ -198,40 +200,43 @@ Future<CrashReportResult> _runIosPhysical({
     return const CrashReportMissingAppId();
   }
 
+  // The temp dir is intentionally NOT deleted after the call. The caller
+  // requested these files and their paths are surfaced via FILE= tokens.
+  // Each invocation creates a fresh temp dir so they do not accumulate
+  // unboundedly; the OS will eventually reclaim them.
   final tmpDir = Directory.systemTemp.createTempSync('fdb_crash_');
-  try {
-    final result = Process.runSync('idevicecrashreport', ['-e', '-k', appId, tmpDir.path]);
-    if (result.exitCode != 0) {
-      final err = (result.stderr as String).trim();
-      return CrashReportError('idevicecrashreport failed: $err');
-    }
-
-    final cutoff = DateTime.now().subtract(_parseDuration(input.last));
-    final ipsFiles = tmpDir
-        .listSync()
-        .whereType<File>()
-        .where((f) => f.path.endsWith('.ips') && f.statSync().modified.isAfter(cutoff))
-        .toList()
-      ..sort((a, b) => b.statSync().modified.compareTo(a.statSync().modified));
-
-    if (ipsFiles.isEmpty) return const CrashReportNone();
-
-    final filesToRead = input.all ? ipsFiles : [ipsFiles.first];
-    final entries = <CrashReportEntry>[];
-    for (final file in filesToRead) {
-      final text = _safeReadFile(file);
-      if (text != null) {
-        entries.add(CrashReportEntry(label: '[iOS physical .ips]', filePath: file.path, text: text));
-      }
-    }
-
-    if (entries.isEmpty) return const CrashReportNone();
-    return CrashReportFound(entries);
-  } finally {
-    try {
-      tmpDir.deleteSync(recursive: true);
-    } catch (_) {}
+  final result = Process.runSync('idevicecrashreport', ['-e', '-k', appId, tmpDir.path]);
+  if (result.exitCode != 0) {
+    final err = (result.stderr as String).trim();
+    return CrashReportError('idevicecrashreport failed: $err');
   }
+
+  final duration = _parseDuration(input.last);
+  final ipsFiles = tmpDir
+      .listSync()
+      .whereType<File>()
+      .where((f) {
+        if (!f.path.endsWith('.ips')) return false;
+        if (duration == null) return true;
+        final cutoff = DateTime.now().subtract(duration);
+        return f.statSync().modified.isAfter(cutoff);
+      })
+      .toList()
+    ..sort((a, b) => b.statSync().modified.compareTo(a.statSync().modified));
+
+  if (ipsFiles.isEmpty) return const CrashReportNone();
+
+  final filesToRead = input.all ? ipsFiles : [ipsFiles.first];
+  final entries = <CrashReportEntry>[];
+  for (final file in filesToRead) {
+    final text = _safeReadFile(file);
+    if (text != null) {
+      entries.add(CrashReportEntry(label: '[iOS physical .ips]', filePath: file.path, text: text));
+    }
+  }
+
+  if (entries.isEmpty) return const CrashReportNone();
+  return CrashReportFound(entries);
 }
 
 Future<CrashReportResult> _runMacos({
@@ -301,17 +306,17 @@ String _filterLines(String text, String substring) =>
     text.split('\n').where((l) => l.contains(substring)).join('\n').trim();
 
 /// Parses a duration string of the form `<n>s`, `<n>m`, or `<n>h`.
-/// Returns [Duration.zero] if the string cannot be parsed.
-Duration _parseDuration(String s) {
-  if (s.isEmpty) return Duration.zero;
+/// Returns null if the string cannot be parsed.
+Duration? _parseDuration(String s) {
+  if (s.isEmpty) return null;
   final suffix = s[s.length - 1];
   final n = int.tryParse(s.substring(0, s.length - 1));
-  if (n == null) return Duration.zero;
+  if (n == null) return null;
   return switch (suffix) {
     's' => Duration(seconds: n),
     'm' => Duration(minutes: n),
     'h' => Duration(hours: n),
-    _ => Duration.zero,
+    _ => null,
   };
 }
 

--- a/lib/core/commands/crash_report/crash_report.dart
+++ b/lib/core/commands/crash_report/crash_report.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:fdb/constants.dart';
 import 'package:fdb/core/commands/crash_report/crash_report_models.dart';
 import 'package:fdb/core/process_utils.dart';
 
@@ -105,7 +104,15 @@ Future<CrashReportResult> _runAndroid({
   }
 
   if (entries.isEmpty) return const CrashReportNone();
-  return CrashReportFound(input.all ? entries : [entries.last]);
+
+  // Android logcat has no native --last filter. We return all available records
+  // and emit an advisory warning so callers know filtering was not applied.
+  // logcat entries are returned in chronological order; logcat crash buffer is
+  // checked first, so entries.first is the most likely source for the latest crash.
+  final warnings = [
+    '--last is not supported on Android, returning all available records',
+  ];
+  return CrashReportFound(input.all ? entries : [entries.first], warnings: warnings);
 }
 
 Future<CrashReportResult> _runIosSimulator({
@@ -199,7 +206,12 @@ Future<CrashReportResult> _runIosPhysical({
       return CrashReportError('idevicecrashreport failed: $err');
     }
 
-    final ipsFiles = tmpDir.listSync().whereType<File>().where((f) => f.path.endsWith('.ips')).toList()
+    final cutoff = DateTime.now().subtract(_parseDuration(input.last));
+    final ipsFiles = tmpDir
+        .listSync()
+        .whereType<File>()
+        .where((f) => f.path.endsWith('.ips') && f.statSync().modified.isAfter(cutoff))
+        .toList()
       ..sort((a, b) => b.statSync().modified.compareTo(a.statSync().modified));
 
     if (ipsFiles.isEmpty) return const CrashReportNone();
@@ -288,6 +300,21 @@ bool _isToolOnPath(String tool) {
 String _filterLines(String text, String substring) =>
     text.split('\n').where((l) => l.contains(substring)).join('\n').trim();
 
+/// Parses a duration string of the form `<n>s`, `<n>m`, or `<n>h`.
+/// Returns [Duration.zero] if the string cannot be parsed.
+Duration _parseDuration(String s) {
+  if (s.isEmpty) return Duration.zero;
+  final suffix = s[s.length - 1];
+  final n = int.tryParse(s.substring(0, s.length - 1));
+  if (n == null) return Duration.zero;
+  return switch (suffix) {
+    's' => Duration(seconds: n),
+    'm' => Duration(minutes: n),
+    'h' => Duration(hours: n),
+    _ => Duration.zero,
+  };
+}
+
 /// Reads a file's content, returning null on any error.
 String? _safeReadFile(File file) {
   try {
@@ -297,18 +324,4 @@ String? _safeReadFile(File file) {
   }
 }
 
-/// Reads the persisted app bundle id / package name from `.fdb/app_id.txt`.
-///
-/// Returns null if the file does not exist or is empty.
-String? readAppId() {
-  final file = File(appIdFile);
-  if (!file.existsSync()) return null;
-  final content = file.readAsStringSync().trim();
-  return content.isEmpty ? null : content;
-}
 
-/// Persists [appId] to `.fdb/app_id.txt` so later commands (e.g. crash-report)
-/// can use it without requiring `--app-id`.
-void writeAppId(String appId) {
-  File(appIdFile).writeAsStringSync(appId);
-}

--- a/lib/core/commands/crash_report/crash_report.dart
+++ b/lib/core/commands/crash_report/crash_report.dart
@@ -64,7 +64,9 @@ Future<CrashReportResult> _runAndroid({
     );
   }
 
-  final adbPrefix = <String>[if (device != null) ...['-s', device]];
+  final adbPrefix = <String>[
+    if (device != null) ...['-s', device]
+  ];
   final entries = <CrashReportEntry>[];
 
   // --- logcat crash buffer ---
@@ -197,11 +199,7 @@ Future<CrashReportResult> _runIosPhysical({
       return CrashReportError('idevicecrashreport failed: $err');
     }
 
-    final ipsFiles = tmpDir
-        .listSync()
-        .whereType<File>()
-        .where((f) => f.path.endsWith('.ips'))
-        .toList()
+    final ipsFiles = tmpDir.listSync().whereType<File>().where((f) => f.path.endsWith('.ips')).toList()
       ..sort((a, b) => b.statSync().modified.compareTo(a.statSync().modified));
 
     if (ipsFiles.isEmpty) return const CrashReportNone();

--- a/lib/core/commands/crash_report/crash_report_models.dart
+++ b/lib/core/commands/crash_report/crash_report_models.dart
@@ -1,0 +1,80 @@
+import 'package:fdb/core/models/command_result.dart';
+
+/// Input parameters for [fetchCrashReport].
+typedef CrashReportInput = ({
+  String? appId,
+  String last,
+  bool all,
+});
+
+// ---------------------------------------------------------------------------
+// Result hierarchy
+// ---------------------------------------------------------------------------
+
+sealed class CrashReportResult extends CommandResult {
+  const CrashReportResult();
+}
+
+/// At least one crash record was found and its content is in [entries].
+///
+/// Each [CrashReportEntry] carries a platform label, a path to the crash file
+/// on disk (if any), and the raw log text to display.
+class CrashReportFound extends CrashReportResult {
+  const CrashReportFound(this.entries);
+
+  final List<CrashReportEntry> entries;
+}
+
+/// No crash records were found in the requested time window.
+class CrashReportNone extends CrashReportResult {
+  const CrashReportNone();
+}
+
+/// The app bundle id / package name is required but was not found.
+class CrashReportMissingAppId extends CrashReportResult {
+  const CrashReportMissingAppId();
+}
+
+/// A required platform tool (e.g. `xcrun`, `adb`) was not on PATH.
+class CrashReportToolMissing extends CrashReportResult {
+  const CrashReportToolMissing({required this.tool, required this.hint});
+
+  final String tool;
+  final String hint;
+}
+
+/// The platform stored in .fdb/platform.txt is not supported.
+class CrashReportUnsupportedPlatform extends CrashReportResult {
+  const CrashReportUnsupportedPlatform(this.platform);
+
+  final String platform;
+}
+
+/// No platform info was found — app is probably not running.
+class CrashReportNoSession extends CrashReportResult {
+  const CrashReportNoSession();
+}
+
+/// Generic / unrecognised error.
+class CrashReportError extends CrashReportResult {
+  const CrashReportError(this.message);
+
+  final String message;
+}
+
+// ---------------------------------------------------------------------------
+// Data
+// ---------------------------------------------------------------------------
+
+class CrashReportEntry {
+  const CrashReportEntry({required this.label, this.filePath, required this.text});
+
+  /// Short human-readable label, e.g. `[iOS sim]` or `[Android]`.
+  final String label;
+
+  /// Path to the full crash file on disk, if available.
+  final String? filePath;
+
+  /// Raw text of the crash record (log lines or .ips content).
+  final String text;
+}

--- a/lib/core/commands/crash_report/crash_report_models.dart
+++ b/lib/core/commands/crash_report/crash_report_models.dart
@@ -19,10 +19,14 @@ sealed class CrashReportResult extends CommandResult {
 ///
 /// Each [CrashReportEntry] carries a platform label, a path to the crash file
 /// on disk (if any), and the raw log text to display.
+///
+/// [warnings] carries non-fatal advisory messages (e.g. unsupported flags on
+/// a given platform) that the CLI adapter should print to stderr.
 class CrashReportFound extends CrashReportResult {
-  const CrashReportFound(this.entries);
+  const CrashReportFound(this.entries, {this.warnings = const []});
 
   final List<CrashReportEntry> entries;
+  final List<String> warnings;
 }
 
 /// No crash records were found in the requested time window.

--- a/lib/core/commands/crash_report/crash_report_models.dart
+++ b/lib/core/commands/crash_report/crash_report_models.dart
@@ -19,14 +19,10 @@ sealed class CrashReportResult extends CommandResult {
 ///
 /// Each [CrashReportEntry] carries a platform label, a path to the crash file
 /// on disk (if any), and the raw log text to display.
-///
-/// [warnings] carries non-fatal advisory messages (e.g. unsupported flags on
-/// a given platform) that the CLI adapter should print to stderr.
 class CrashReportFound extends CrashReportResult {
-  const CrashReportFound(this.entries, {this.warnings = const []});
+  const CrashReportFound(this.entries);
 
   final List<CrashReportEntry> entries;
-  final List<String> warnings;
 }
 
 /// No crash records were found in the requested time window.

--- a/lib/core/commands/launch/launch.dart
+++ b/lib/core/commands/launch/launch.dart
@@ -4,7 +4,6 @@ import 'dart:io';
 import 'dart:isolate';
 
 import 'package:fdb/constants.dart';
-import 'package:fdb/core/commands/crash_report/crash_report.dart';
 import 'package:fdb/core/commands/launch/launch_models.dart';
 import 'package:fdb/core/process_utils.dart';
 import 'package:fdb/core/vm_service.dart';

--- a/lib/core/commands/launch/launch.dart
+++ b/lib/core/commands/launch/launch.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'dart:isolate';
 
 import 'package:fdb/constants.dart';
+import 'package:fdb/core/commands/crash_report/crash_report.dart';
 import 'package:fdb/core/commands/launch/launch_models.dart';
 import 'package:fdb/core/process_utils.dart';
 import 'package:fdb/core/vm_service.dart';
@@ -77,6 +78,10 @@ Future<LaunchResult> launchApp(
     // Used by `fdb screenshot` to dispatch to the correct capture backend.
     // Non-fatal: screenshot falls back to the old heuristic if this fails.
     await _writePlatformInfo(device, flutter);
+
+    // Persist the app bundle id / package name for later use by crash-report.
+    // Non-fatal: crash-report will ask the user for --app-id if this fails.
+    _writeAppIdFromProject(project, device);
 
     // Build the flutter run command string.
     final flutterArgs = [
@@ -310,6 +315,88 @@ Future<void> _writePlatformInfo(String device, String flutter) async {
   } catch (_) {
     // Non-fatal: screenshot will work without platform info.
   }
+}
+
+// ---------------------------------------------------------------------------
+// App id
+// ---------------------------------------------------------------------------
+
+/// Reads the app bundle id (iOS/macOS) or application id (Android) from the
+/// project's native config files and persists it to [appIdFile].
+///
+/// Silently no-ops on any failure — crash-report falls back to --app-id flag.
+void _writeAppIdFromProject(String projectPath, String device) {
+  try {
+    // Android: android/app/build.gradle or build.gradle.kts
+    final androidGradleKts = File('$projectPath/android/app/build.gradle.kts');
+    final androidGradle = File('$projectPath/android/app/build.gradle');
+    if (androidGradleKts.existsSync()) {
+      final id = _extractApplicationId(androidGradleKts.readAsStringSync());
+      if (id != null) {
+        writeAppId(id);
+        return;
+      }
+    }
+    if (androidGradle.existsSync()) {
+      final id = _extractApplicationId(androidGradle.readAsStringSync());
+      if (id != null) {
+        writeAppId(id);
+        return;
+      }
+    }
+
+    // iOS: ios/Runner/Info.plist
+    final iosPlist = File('$projectPath/ios/Runner/Info.plist');
+    if (iosPlist.existsSync()) {
+      final id = _extractPlistBundleId(iosPlist.readAsStringSync());
+      if (id != null) {
+        writeAppId(id);
+        return;
+      }
+    }
+
+    // macOS: macos/Runner/Info.plist
+    final macosPlist = File('$projectPath/macos/Runner/Info.plist');
+    if (macosPlist.existsSync()) {
+      final id = _extractPlistBundleId(macosPlist.readAsStringSync());
+      if (id != null) {
+        writeAppId(id);
+        return;
+      }
+    }
+  } catch (_) {
+    // Non-fatal: crash-report will prompt for --app-id.
+  }
+}
+
+/// Extracts `applicationId` or `namespace` from a Gradle build file.
+String? _extractApplicationId(String content) {
+  // Kotlin DSL: applicationId = "com.example.app" or namespace = "com.example.app"
+  // Groovy DSL: applicationId "com.example.app" or namespace "com.example.app"
+  final patterns = [
+    RegExp(r'applicationId\s*[=\s]\s*["\x27]([a-zA-Z0-9._]+)["\x27]'),
+    RegExp(r'namespace\s*[=\s]\s*["\x27]([a-zA-Z0-9._]+)["\x27]'),
+  ];
+  for (final pattern in patterns) {
+    final match = pattern.firstMatch(content);
+    if (match != null) return match.group(1);
+  }
+  return null;
+}
+
+/// Extracts `CFBundleIdentifier` from an Info.plist file.
+///
+/// Handles both literal values and `$(PRODUCT_BUNDLE_IDENTIFIER)` references.
+/// Returns null for placeholder values that cannot be resolved statically.
+String? _extractPlistBundleId(String content) {
+  final match = RegExp(
+    r'<key>CFBundleIdentifier</key>\s*<string>([^<]+)</string>',
+  ).firstMatch(content);
+  if (match == null) return null;
+  final value = match.group(1)!;
+  // Skip unresolved Xcode variable substitutions like $(VAR) or ${VAR}.
+  if (value.contains(r'$(') || value.contains(r'${')) return null;
+  return value;
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/core/process_utils.dart
+++ b/lib/core/process_utils.dart
@@ -102,6 +102,22 @@ Future<bool> isVmServiceReachable(String uri) async {
   }
 }
 
+/// Reads the persisted app bundle id / package name from `.fdb/app_id.txt`.
+///
+/// Returns null if the file does not exist or is empty.
+String? readAppId() {
+  final file = File(appIdFile);
+  if (!file.existsSync()) return null;
+  final content = file.readAsStringSync().trim();
+  return content.isEmpty ? null : content;
+}
+
+/// Persists [appId] to `.fdb/app_id.txt` so later commands (e.g. crash-report)
+/// can use it without requiring `--app-id`.
+void writeAppId(String appId) {
+  File(appIdFile).writeAsStringSync(appId);
+}
+
 void cleanupTempFiles() {
   for (final path in [
     pidFile,

--- a/skills/using-fdb/SKILL.md
+++ b/skills/using-fdb/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-fdb
-description: Uses fdb (Flutter Debug Bridge) CLI to interact with running Flutter apps on devices and simulators. Launches, hot reloads, screenshots, reads app logs (`fdb logs`) and native system logs (`fdb syslog` — Android logcat, iOS syslog, macOS log), inspects widget trees, describes screens including off-screen GridView/ListView children, and taps/inputs/scrolls/swipes/navigates. Use when launching a Flutter app on device, hot reloading, taking screenshots, reading app or native system logs, diagnosing native crashes (jetsam, LMK), inspecting or describing the UI, or interacting with widgets via fdb.
+description: Uses fdb (Flutter Debug Bridge) CLI to interact with running Flutter apps on devices and simulators. Launches, hot reloads, screenshots, reads app logs (`fdb logs`) and native system logs (`fdb syslog` — Android logcat, iOS syslog, macOS log), fetches OS-level crash records (`fdb crash-report` — jetsam, LMK, native .ips), inspects widget trees, describes screens including off-screen GridView/ListView children, and taps/inputs/scrolls/swipes/navigates. Use when launching a Flutter app on device, hot reloading, taking screenshots, reading app or native system logs, diagnosing native crashes (jetsam, LMK), fetching post-mortem crash reports, inspecting or describing the UI, or interacting with widgets via fdb.
 license: MIT
 compatibility: opencode
 ---
@@ -132,6 +132,31 @@ Flags:
 - `--follow` — stream live, exit cleanly on Ctrl-C.
 
 Output is the raw native log format — not parsed into fdb tokens. Errors print `ERROR: ...` (e.g. `ERROR: idevicesyslog not found. Install: brew install libimobiledevice`).
+
+### Crash report (OS-level crash and OOM diagnostics)
+
+```bash
+fdb crash-report                           # last 1h, most recent record
+fdb crash-report --last 30m               # custom time window
+fdb crash-report --all                    # all records in the window
+fdb crash-report --app-id com.example.app # explicit bundle id / package name
+```
+
+Use this to retrieve OS-level crash records that never reach Crashlytics: iOS jetsam kills, Android low-memory-killer (LMK) events, and native crash reports. Runs after the fact — "what killed the app 10 minutes ago?" Requires a session (`.fdb/platform.txt`) but the app does not need to be running.
+
+The app bundle id / package name is auto-detected from `.fdb/app_id.txt` (written by `fdb launch`). Pass `--app-id` to override.
+
+Output tokens:
+- `CRASH_REPORT_FOUND ENTRIES=N` — one or more crash records found; followed by `---`, `LABEL=`, optional `FILE=`, and raw text for each entry.
+- `CRASH_REPORT_NONE` — no crash records found in the time window.
+
+Platform dispatch:
+- **Android**: `adb logcat -b crash` + `adb shell dumpsys dropbox` + `adb logcat -b system -s lowmemorykiller`
+- **iOS simulator**: `xcrun simctl spawn <udid> log show` (jetsam predicate) + `~/Library/Logs/DiagnosticReports/*.ips`
+- **iOS physical**: `idevicecrashreport` (requires `brew install libimobiledevice`)
+- **macOS**: `log show` + `~/Library/Logs/DiagnosticReports/*.ips`
+
+Errors print `ERROR: ...` with install hints when a required tool is missing.
 
 ### Widget tree
 
@@ -547,5 +572,6 @@ All state lives in `<project>/.fdb/`. fdb resolves this directory automatically 
 - `<project>/.fdb/logs.txt` - full app output
 - `<project>/.fdb/vm_uri.txt` - VM service websocket URI
 - `<project>/.fdb/device.txt` - device ID used at launch
-- `<project>/.fdb/platform.txt` - target platform + emulator flag (written at launch, read by screenshot and syslog)
+- `<project>/.fdb/platform.txt` - target platform + emulator flag (written at launch, read by screenshot, syslog, and crash-report)
+- `<project>/.fdb/app_id.txt` - app bundle id / package name (written at launch, read by crash-report)
 - `<project>/.fdb/screenshot.png` - last screenshot

--- a/skills/using-fdb/SKILL.md
+++ b/skills/using-fdb/SKILL.md
@@ -150,6 +150,8 @@ Output tokens:
 - `CRASH_REPORT_FOUND ENTRIES=N` — one or more crash records found; followed by `---`, `LABEL=`, optional `FILE=`, and raw text for each entry.
 - `CRASH_REPORT_NONE` — no crash records found in the time window.
 
+Note: `--all` returns all available crash sources (logcat buffers, `.ips` files) rather than just the most recent one. The underlying log query is still capped at 24h on iOS simulator and macOS to avoid scanning the entire log archive.
+
 Platform dispatch:
 - **Android**: `adb logcat -b crash` + `adb shell dumpsys dropbox` + `adb logcat -b system -s lowmemorykiller`
 - **iOS simulator**: `xcrun simctl spawn <udid> log show` (jetsam predicate) + `~/Library/Logs/DiagnosticReports/*.ips`

--- a/skills/using-fdb/SKILL.md
+++ b/skills/using-fdb/SKILL.md
@@ -133,32 +133,20 @@ Flags:
 
 Output is the raw native log format — not parsed into fdb tokens. Errors print `ERROR: ...` (e.g. `ERROR: idevicesyslog not found. Install: brew install libimobiledevice`).
 
-### Crash report (OS-level crash and OOM diagnostics)
+### OS-level crash and OOM records
 
 ```bash
-fdb crash-report                           # last 1h, most recent record
+fdb crash-report                           # most recent record, last 1h
 fdb crash-report --last 30m               # custom time window
-fdb crash-report --all                    # all records (no time limit)
+fdb crash-report --all                    # all crash sources in window
 fdb crash-report --app-id com.example.app # explicit bundle id / package name
 ```
 
-Use this to retrieve OS-level crash records that never reach Crashlytics: iOS jetsam kills, Android low-memory-killer (LMK) events, and native crash reports. Runs after the fact — "what killed the app 10 minutes ago?" Requires a session (`.fdb/platform.txt`) but the app does not need to be running.
+Fetches jetsam kills, Android LMK events, and native crash files that never reach Crashlytics. Works after the app has died — no running session required, only `.fdb/platform.txt`.
 
-The app bundle id / package name is auto-detected from `.fdb/app_id.txt` (written by `fdb launch`). Pass `--app-id` to override.
+App id auto-read from `.fdb/app_id.txt` (written by `fdb launch`). Pass `--app-id` to override.
 
-Output tokens:
-- `CRASH_REPORT_FOUND ENTRIES=N` — one or more crash records found; followed by `---`, `LABEL=`, optional `FILE=`, and raw text for each entry.
-- `CRASH_REPORT_NONE` — no crash records found in the time window.
-
-Note: `--all` returns all available crash sources (logcat buffers, `.ips` files) rather than just the most recent one. The underlying log query is still capped at 24h on iOS simulator and macOS to avoid scanning the entire log archive.
-
-Platform dispatch:
-- **Android**: `adb logcat -b crash` + `adb shell dumpsys dropbox` + `adb logcat -b system -s lowmemorykiller`
-- **iOS simulator**: `xcrun simctl spawn <udid> log show` (jetsam predicate) + `~/Library/Logs/DiagnosticReports/*.ips`
-- **iOS physical**: `idevicecrashreport` (requires `brew install libimobiledevice`)
-- **macOS**: `log show` + `~/Library/Logs/DiagnosticReports/*.ips`
-
-Errors print `ERROR: ...` with install hints when a required tool is missing.
+Output tokens: `CRASH_REPORT_FOUND ENTRIES=N` (followed by `---` / `LABEL=` / optional `FILE=` / raw text per entry) or `CRASH_REPORT_NONE`. Errors include install hints when a required platform tool is missing.
 
 ### Widget tree
 

--- a/skills/using-fdb/SKILL.md
+++ b/skills/using-fdb/SKILL.md
@@ -138,7 +138,7 @@ Output is the raw native log format — not parsed into fdb tokens. Errors print
 ```bash
 fdb crash-report                           # last 1h, most recent record
 fdb crash-report --last 30m               # custom time window
-fdb crash-report --all                    # all records in the window
+fdb crash-report --all                    # all records (no time limit)
 fdb crash-report --app-id com.example.app # explicit bundle id / package name
 ```
 


### PR DESCRIPTION
Jetsam kills and Android LMK events never reach Crashlytics, so when an app dies silently there's no trace of what happened. This adds `fdb crash-report` to fetch those OS-level records after the fact.

The command dispatches per platform: `xcrun simctl log show` plus `~/Library/Logs/DiagnosticReports/*.ips` on iOS simulator, `idevicecrashreport` on iOS physical, `adb logcat -b crash` + `dumpsys dropbox` + lowmemorykiller events on Android, and `log show` plus DiagnosticReports on macOS. Flags: `--last <duration>` (default 1h), `--all` (return every record in the window), `--app-id` (override the bundle id/package auto-detected from `.fdb/app_id.txt`). `fdb launch` now persists the app id to `.fdb/app_id.txt` so `crash-report` works without manual input.

Closes #58