### PR TITLE
fix: fdb describe now surfaces nested GestureDetectors inside Stack/Positioned

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -712,6 +712,47 @@ tasks:
         # warning, not a test failure.
         {{.FDB}} back 2>&1 || echo "INFO: fdb back returned non-zero (already at root — ignored)"
 
+  test:describe-nested-gestures:
+    desc: Verify fdb describe surfaces GestureDetectors nested inside Positioned/Stack
+    dir: '{{.TEST_APP}}'
+    cmds:
+      - |
+        echo "==> Navigating to Nested Gesture Describe Test screen"
+        {{.FDB}} scroll-to --key "go_to_nested_gesture_describe_test" >/dev/null 2>&1 || true
+        if ! {{.FDB}} tap --key "go_to_nested_gesture_describe_test" >/dev/null 2>&1; then
+          echo "FAIL: could not navigate to nested gesture describe screen" >&2
+          exit 1
+        fi
+        sleep 1
+
+        echo "==> Describing nested gesture screen"
+        OUTPUT=$({{.FDB}} describe 2>&1)
+        EXIT_CODE=$?
+        echo "$OUTPUT"
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "FAIL: fdb describe (nested gestures) exited with code $EXIT_CODE" >&2
+          exit 1
+        fi
+
+        # Both inner GestureDetectors must appear — keyed so they are
+        # stable regardless of describe output ordering.
+        if echo "$OUTPUT" | grep -q "nested_gesture_reject"; then
+          echo "PASS: fdb describe surfaces nested_gesture_reject"
+        else
+          echo "FAIL: fdb describe did not surface nested_gesture_reject (inner GestureDetector inside Positioned/Stack)" >&2
+          exit 1
+        fi
+
+        if echo "$OUTPUT" | grep -q "nested_gesture_approve"; then
+          echo "PASS: fdb describe surfaces nested_gesture_approve"
+        else
+          echo "FAIL: fdb describe did not surface nested_gesture_approve (inner GestureDetector inside Positioned/Stack)" >&2
+          exit 1
+        fi
+
+        echo "==> Navigating back"
+        {{.FDB}} back 2>&1 || echo "INFO: fdb back returned non-zero (already at root — ignored)"
+
   test:tap:
     desc: Tap a widget by text selector
     dir: '{{.TEST_APP}}'
@@ -2639,6 +2680,7 @@ tasks:
       - task: test:tree
       - task: test:describe
       - task: test:describe-grid
+      - task: test:describe-nested-gestures
       - task: test:screenshot
       - task: test:native-view-tap
       - task: test:deeplink

--- a/example/test_app/lib/main.dart
+++ b/example/test_app/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:flutter/services.dart';
 import 'benchmark_screens.dart';
 import 'grid_describe_screen.dart';
 import 'native_view_test_screen.dart';
+import 'nested_gesture_describe_screen.dart';
 import 'scroll_to_test_screen.dart';
 
 void main() {
@@ -44,6 +45,7 @@ class FdbTestApp extends StatelessWidget {
         scrollToTestReversedRoute: (_) => const ReversedListScrollToPage(),
         scrollToTestAlreadyVisibleRoute: (_) =>
             const AlreadyVisibleScrollToPage(),
+        '/nested-gesture-describe-test': (_) => const NestedGestureDescribeScreen(),
       },
     );
   }
@@ -208,6 +210,13 @@ class _FdbTestHomePageState extends State<FdbTestHomePage> {
                 onPressed: () =>
                     Navigator.pushNamed(context, '/grid-describe-test'),
                 child: const Text('Grid Describe Test'),
+              ),
+              const SizedBox(height: 8),
+              ElevatedButton(
+                key: const Key('go_to_nested_gesture_describe_test'),
+                onPressed: () =>
+                    Navigator.pushNamed(context, '/nested-gesture-describe-test'),
+                child: const Text('Nested Gesture Describe Test'),
               ),
               const SizedBox(height: 8),
               ElevatedButton(

--- a/example/test_app/lib/nested_gesture_describe_screen.dart
+++ b/example/test_app/lib/nested_gesture_describe_screen.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+
+/// A screen with GestureDetectors nested inside a Positioned widget inside a
+/// Stack, matching the real-world pattern where fdb describe previously missed
+/// the inner interactive widgets.
+///
+/// Expected by task test:describe-nested-gestures in Taskfile.yml.
+class NestedGestureDescribeScreen extends StatefulWidget {
+  const NestedGestureDescribeScreen({super.key});
+
+  @override
+  State<NestedGestureDescribeScreen> createState() => _NestedGestureDescribeScreenState();
+}
+
+class _NestedGestureDescribeScreenState extends State<NestedGestureDescribeScreen> {
+  String _last = 'none';
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Nested Gesture Describe Test'),
+      ),
+      body: Stack(
+        children: [
+          // Main content
+          const Center(child: Text('Main content')),
+
+          // Bottom action bar — Positioned inside Stack.
+          // The outer GestureDetector wraps the whole toolbar; the inner
+          // GestureDetectors are the individual tap targets.
+          Positioned(
+            bottom: 0,
+            left: 0,
+            right: 0,
+            child: GestureDetector(
+              // Toolbar root — outer GestureDetector (horizontalDrag only so
+              // it does not absorb the inner onTap callbacks).
+              onHorizontalDragUpdate: (_) {},
+              child: Container(
+                color: Colors.black87,
+                padding: const EdgeInsets.symmetric(vertical: 16),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  children: [
+                    GestureDetector(
+                      key: const ValueKey('nested_gesture_reject'),
+                      onTap: () => setState(() => _last = 'reject'),
+                      child: const CircleAvatar(
+                        radius: 30,
+                        child: Icon(Icons.close, semanticLabel: 'reject'),
+                      ),
+                    ),
+                    GestureDetector(
+                      key: const ValueKey('nested_gesture_approve'),
+                      onTap: () => setState(() => _last = 'approve'),
+                      child: const CircleAvatar(
+                        radius: 30,
+                        child: Icon(Icons.check, semanticLabel: 'approve'),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+      bottomNavigationBar: Padding(
+        padding: const EdgeInsets.all(8),
+        child: Text(
+          'Last tapped: $_last',
+          key: const ValueKey('nested_gesture_last_tapped'),
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+}

--- a/packages/fdb_helper/lib/src/handlers/describe_handler.dart
+++ b/packages/fdb_helper/lib/src/handlers/describe_handler.dart
@@ -173,6 +173,9 @@ Future<developer.ServiceExtensionResponse> handleDescribe(
           // it and include the element unconditionally.
           if (isOnScreen && !isElementHittable(element)) {
             if (typeName == 'Tooltip') currentTooltip = previousTooltip;
+            // Still recurse: an unhittable ancestor may have hittable children
+            // (e.g. Opacity(opacity:0) around individual buttons).
+            element.visitChildren(visit);
             return;
           }
 
@@ -188,9 +191,18 @@ Future<developer.ServiceExtensionResponse> handleDescribe(
             if (gestures != null) 'gestures': gestures,
           });
 
-          // Still collect text from children for the TEXT section (on-screen
-          // children of interactive widgets).
-          if (isOnScreen) {
+          // Gesture-transparent widgets (GestureDetector, InkWell) are pure
+          // wrappers — their children may contain additional independent
+          // interactive widgets (e.g. buttons inside a toolbar
+          // GestureDetector). Continue the walk so nested targets are found.
+          //
+          // Self-contained widgets (ElevatedButton, TextField, etc.) own their
+          // entire subtree — descending into them would expose internal
+          // framework InkWell/GestureDetector children as noise. Stop here.
+          if (_isGestureTransparent(typeName)) {
+            element.visitChildren(visit);
+          } else if (isOnScreen) {
+            // Still collect text from children for the TEXT section.
             void collectText(Element el) {
               final w = el.widget;
               if (w is Text) {
@@ -431,6 +443,19 @@ String? _extractWidgetLevelText(Widget widget) {
   } catch (_) {}
   return null;
 }
+
+/// Returns true for interactive widgets that are pure gesture wrappers whose
+/// children may contain additional independent interactive targets.
+///
+/// These widgets do not own their subtree semantically — descending into their
+/// children is safe and necessary to find nested buttons/gestures.
+///
+/// Self-contained widgets (ElevatedButton, TextField, etc.) are NOT transparent:
+/// their children are internal framework widgets that should not be surfaced.
+bool _isGestureTransparent(String typeName) => const {
+      'GestureDetector',
+      'InkWell',
+    }.contains(typeName);
 
 bool _isDescribeInteractiveWidget(String typeName) => const {
       'Checkbox',


### PR DESCRIPTION
## Summary

- `fdb describe` stopped at the first `GestureDetector`/`InkWell` it found, never visiting children. Buttons inside a toolbar `GestureDetector` (itself inside a `Positioned` inside a `Stack`) were silently dropped from `INTERACTIVE:` output.
- After collecting a gesture-transparent widget (`GestureDetector` or `InkWell`), the handler now continues walking children so nested tap targets are discovered. Self-contained widgets (`ElevatedButton`, `TextField`, etc.) keep the stop-here behaviour to avoid surfacing internal framework children as noise.

Closes #100