### PR TITLE
fix: tap on widget that disappears during the tap returns success instead of throwing

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1144,6 +1144,30 @@ tasks:
           exit 1
         fi
 
+  test:tap-disappearing-widget:
+    desc: Tap a widget that disappears during/after the tap — must return Success, not throw
+    dir: '{{.TEST_APP}}'
+    cmds:
+      - |
+        echo "==> Resetting app state before disappearing-widget tap test"
+        {{.FDB}} restart >/dev/null 2>&1 || true
+        sleep 1
+
+        echo "==> Tapping disappearing_button (widget hides itself on tap)"
+        OUTPUT=$({{.FDB}} tap --key "disappearing_button" 2>&1)
+        EXIT_CODE=$?
+        echo "$OUTPUT"
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "FAIL: fdb tap on disappearing widget exited with code $EXIT_CODE" >&2
+          exit 1
+        fi
+        if echo "$OUTPUT" | grep -q "TAPPED="; then
+          echo "PASS: fdb tap on disappearing widget returned success"
+        else
+          echo "FAIL: fdb tap on disappearing widget - TAPPED= not found in output" >&2
+          exit 1
+        fi
+
   test:input:
     desc: Enter text into a field
     dir: '{{.TEST_APP}}'
@@ -2694,6 +2718,7 @@ tasks:
           DEVICE: '{{.DEVICE}}'
       - task: test:longpress
       - task: test:tap-at
+      - task: test:tap-disappearing-widget
       - task: test:input
       - task: test:scroll
       - task: test:scroll-to

--- a/example/test_app/lib/main.dart
+++ b/example/test_app/lib/main.dart
@@ -67,6 +67,7 @@ class _FdbTestHomePageState extends State<FdbTestHomePage> {
   int _indexedDoubleTapPrimaryCount = 0;
   int _indexedDoubleTapSecondaryCount = 0;
   bool _showDelayed = false;
+  bool _showDisappearing = true;
   final _textController = TextEditingController();
   late final Timer _heartbeat;
 
@@ -262,6 +263,18 @@ class _FdbTestHomePageState extends State<FdbTestHomePage> {
                   key: const Key('delayed_button'),
                   onPressed: () {},
                   child: const Text('I was delayed'),
+                ),
+              const SizedBox(height: 16),
+              if (_showDisappearing)
+                ElevatedButton(
+                  key: const Key('disappearing_button'),
+                  onPressed: () {
+                    setState(() {
+                      _showDisappearing = false;
+                    });
+                    developer.log('disappearing_button tapped — hiding self', name: 'fdb_test');
+                  },
+                  child: const Text('Disappearing Button'),
                 ),
               const SizedBox(height: 16),
               Text(

--- a/packages/fdb_helper/lib/src/handlers/tap_handler.dart
+++ b/packages/fdb_helper/lib/src/handlers/tap_handler.dart
@@ -68,9 +68,13 @@ Future<developer.ServiceExtensionResponse> handleTap(
 
     final center = renderObject.size.center(Offset.zero);
     final globalCenter = renderObject.localToGlobal(center);
+    // Capture widgetType before the async gap: the tap may cause the widget
+    // to disappear (e.g. a button that navigates away or hides itself), which
+    // unmounts the element. Accessing element.widget after the await would
+    // throw "Null check operator used on a null value".
+    final widgetType = element.widget.runtimeType.toString();
     await dispatchTap(globalCenter, holdDuration: holdDuration);
 
-    final widgetType = element.widget.runtimeType.toString();
     return developer.ServiceExtensionResponse.result(
       jsonEncode({
         'status': 'Success',


### PR DESCRIPTION
Tapping a widget that hides itself (navigates away, pops a dialog, or removes itself from the tree) caused fdb to throw `Null check operator used on a null value` instead of returning a clean success. The app worked correctly, but the CLI reported an error.

The fix captures `widgetType` before the `await dispatchTap()` call. The async gap is where the element can unmount, so reading `element.widget` after the await is what throws. Moving it before the await avoids the race entirely.

Also adds a `disappearing_button` widget to the test app and a `test:tap-disappearing-widget` Taskfile task to catch regressions.

Closes #104