### PR TITLE
feat: add fdb gc — force full garbage collection across all isolates

### DIFF
--- a/.agents/skills/testing-fdb/SKILL.md
+++ b/.agents/skills/testing-fdb/SKILL.md
@@ -65,6 +65,7 @@ task test:input
 task test:scroll
 task test:scroll-to
 task test:mem
+task test:gc
 task test:wait
 task test:swipe
 task test:back

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ fdb ext call ext.flutter.collectLeaks
 | `fdb mem [--json]` | Per-isolate heap totals (usage, external, capacity) |
 | `fdb mem profile --output <file> [--isolate <id>] [--all-isolates]` | Capture a full allocation profile to a JSON file |
 | `fdb mem diff <before.json> <after.json> [--sort count\|bytes] [--top N] [--all] [--json]` | Show classes that grew between two profiles |
+| `fdb gc [--json]` | Force a full garbage collection across all isolates |
 
 **Three-tier heap workflow:**
 1. `fdb mem` — inspect live per-isolate heap state (usage, external, capacity) to get a quick health check.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2353,6 +2353,43 @@ tasks:
         rm -rf "$MEM_TMP_DIR"
         echo "PASS: fdb mem"
 
+  test:gc:
+    desc: Force full GC across all isolates and verify output
+    dir: '{{.TEST_APP}}'
+    cmds:
+      - |
+        echo "==> fdb gc — human-readable summary"
+        OUTPUT=$({{.FDB}} gc 2>&1)
+        EXIT_CODE=$?
+        echo "$OUTPUT"
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "FAIL: fdb gc exited with code $EXIT_CODE" >&2
+          exit 1
+        fi
+        if echo "$OUTPUT" | grep -q "GC_COMPLETE"; then
+          echo "PASS: fdb gc (human-readable)"
+        else
+          echo "FAIL: fdb gc - GC_COMPLETE not found in output" >&2
+          exit 1
+        fi
+
+        echo "==> fdb gc --json — KEY=value output"
+        OUTPUT=$({{.FDB}} gc --json 2>&1)
+        EXIT_CODE=$?
+        echo "$OUTPUT"
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "FAIL: fdb gc --json exited with code $EXIT_CODE" >&2
+          exit 1
+        fi
+        if echo "$OUTPUT" | grep -q "HEAP_BEFORE=" && echo "$OUTPUT" | grep -q "HEAP_AFTER=" && echo "$OUTPUT" | grep -q "HEAP_DELTA="; then
+          echo "PASS: fdb gc --json"
+        else
+          echo "FAIL: fdb gc --json - expected HEAP_BEFORE=, HEAP_AFTER=, HEAP_DELTA= in output" >&2
+          exit 1
+        fi
+
+        echo "PASS: fdb gc"
+
   test:status-stopped:
     desc: Verify status shows not running after kill
     dir: '{{.TEST_APP}}'
@@ -2698,6 +2735,7 @@ tasks:
       - task: test:scroll
       - task: test:scroll-to
       - task: test:mem
+      - task: test:gc
       - task: test:wait
       - task: test:swipe
       - task: test:back

--- a/bin/fdb.dart
+++ b/bin/fdb.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 
 import 'package:fdb/cli/adapters/back_cli.dart';
 import 'package:fdb/cli/adapters/clean_cli.dart';
-import 'package:fdb/cli/adapters/gc_cli.dart';
 import 'package:fdb/cli/adapters/crash_report_cli.dart';
 import 'package:fdb/cli/adapters/deeplink_cli.dart';
 import 'package:fdb/cli/adapters/describe_cli.dart';
@@ -10,6 +9,7 @@ import 'package:fdb/cli/adapters/devices_cli.dart';
 import 'package:fdb/cli/adapters/doctor_cli.dart';
 import 'package:fdb/cli/adapters/double_tap_cli.dart';
 import 'package:fdb/cli/adapters/ext_cli.dart';
+import 'package:fdb/cli/adapters/gc_cli.dart';
 import 'package:fdb/cli/adapters/input_cli.dart';
 import 'package:fdb/cli/adapters/kill_cli.dart';
 import 'package:fdb/cli/adapters/launch_cli.dart';

--- a/bin/fdb.dart
+++ b/bin/fdb.dart
@@ -32,8 +32,8 @@ import 'package:fdb/cli/adapters/syslog_cli.dart';
 import 'package:fdb/cli/adapters/tap_cli.dart';
 import 'package:fdb/cli/adapters/tree_cli.dart';
 import 'package:fdb/cli/adapters/wait_cli.dart';
-import 'package:fdb/core/app_died_exception.dart';
 import 'package:fdb/constants.dart';
+import 'package:fdb/core/app_died_exception.dart';
 
 const usage = '''
 Usage: fdb [--session-dir <path>] <command> [args]

--- a/bin/fdb.dart
+++ b/bin/fdb.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:fdb/cli/adapters/back_cli.dart';
 import 'package:fdb/cli/adapters/clean_cli.dart';
+import 'package:fdb/cli/adapters/gc_cli.dart';
 import 'package:fdb/cli/adapters/crash_report_cli.dart';
 import 'package:fdb/cli/adapters/deeplink_cli.dart';
 import 'package:fdb/cli/adapters/describe_cli.dart';
@@ -76,6 +77,8 @@ Commands:
   select      Toggle widget selection mode
   selected    Get the currently selected widget
   mem         Inspect heap usage; subcommands: profile, diff
+  gc          Force a full garbage collection across all isolates
+               --json              Output KEY=value tokens (HEAP_BEFORE, HEAP_AFTER, HEAP_DELTA)
   status      Check if the app is running
   kill        Stop the running app
   skill       Print the AI agent skill file (SKILL.md)
@@ -222,6 +225,8 @@ Future<int> _runCommand(String command, List<String> args) {
       return runKillCli(args);
     case 'mem':
       return runMemCli(args);
+    case 'gc':
+      return runGcCli(args);
     case 'skill':
       return runSkillCli(args);
     default:

--- a/lib/cli/adapters/gc_cli.dart
+++ b/lib/cli/adapters/gc_cli.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:fdb/cli/args_helpers.dart';
-import 'package:fdb/core/app_died_exception.dart';
 import 'package:fdb/core/commands/gc/gc.dart';
 
 /// CLI adapter for `fdb gc`.
@@ -36,7 +35,10 @@ Future<int> _execute(ArgResults results) async {
 
 int _format(GcResult result, {required bool jsonMode}) {
   switch (result) {
-    case GcSuccess(:final heapBefore, :final heapAfter, :final heapDelta):
+    case GcSuccess(:final heapBefore, :final heapAfter, :final heapDelta, :final warnings):
+      for (final w in warnings) {
+        stderr.writeln('WARNING: $w');
+      }
       if (jsonMode) {
         stdout.writeln('HEAP_BEFORE=$heapBefore');
         stdout.writeln('HEAP_AFTER=$heapAfter');
@@ -55,8 +57,6 @@ int _format(GcResult result, {required bool jsonMode}) {
     case GcAllFailed():
       stderr.writeln('ERROR: All isolates failed to GC.');
       return 1;
-    case GcAppDied(:final logLines, :final reason):
-      throw AppDiedException(logLines: logLines, reason: reason);
     case GcError(:final message):
       stderr.writeln('ERROR: $message');
       return 1;

--- a/lib/cli/adapters/gc_cli.dart
+++ b/lib/cli/adapters/gc_cli.dart
@@ -1,0 +1,64 @@
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:fdb/cli/args_helpers.dart';
+import 'package:fdb/core/app_died_exception.dart';
+import 'package:fdb/core/commands/gc/gc.dart';
+
+/// CLI adapter for `fdb gc`.
+///
+/// Output contract (human-readable):
+///
+///   GC_COMPLETE HEAP_BEFORE=`bytes` HEAP_AFTER=`bytes` HEAP_DELTA=`bytes`
+///
+/// Output contract (`--json` / KEY=value):
+///
+///   HEAP_BEFORE=`bytes`
+///   HEAP_AFTER=`bytes`
+///   HEAP_DELTA=`bytes`
+///
+/// Error cases:
+///
+///   ERROR: No app is running.                     (no session / no isolates)
+///   ERROR: All isolates failed to GC.             (all isolates errored)
+///   ERROR: `message`                              (generic error)
+Future<int> runGcCli(List<String> args) {
+  final parser = ArgParser()
+    ..addFlag('json', negatable: false, help: 'Output KEY=value tokens instead of human-readable summary');
+  return runCliAdapter(parser, args, _execute);
+}
+
+Future<int> _execute(ArgResults results) async {
+  final jsonMode = results['json'] as bool;
+  final result = await runGc(());
+  return _format(result, jsonMode: jsonMode);
+}
+
+int _format(GcResult result, {required bool jsonMode}) {
+  switch (result) {
+    case GcSuccess(:final heapBefore, :final heapAfter, :final heapDelta):
+      if (jsonMode) {
+        stdout.writeln('HEAP_BEFORE=$heapBefore');
+        stdout.writeln('HEAP_AFTER=$heapAfter');
+        stdout.writeln('HEAP_DELTA=$heapDelta');
+      } else {
+        final beforeStr = fmtBytes(heapBefore);
+        final afterStr = fmtBytes(heapAfter);
+        final deltaStr = fmtBytes(heapDelta.abs());
+        final sign = heapDelta <= 0 ? '-' : '+';
+        stdout.writeln('GC_COMPLETE HEAP_BEFORE=$beforeStr HEAP_AFTER=$afterStr HEAP_DELTA=$sign$deltaStr');
+      }
+      return 0;
+    case GcNoIsolates():
+      stderr.writeln('ERROR: No app is running.');
+      return 1;
+    case GcAllFailed():
+      stderr.writeln('ERROR: All isolates failed to GC.');
+      return 1;
+    case GcAppDied(:final logLines, :final reason):
+      throw AppDiedException(logLines: logLines, reason: reason);
+    case GcError(:final message):
+      stderr.writeln('ERROR: $message');
+      return 1;
+  }
+}

--- a/lib/cli/adapters/gc_cli.dart
+++ b/lib/cli/adapters/gc_cli.dart
@@ -42,7 +42,7 @@ int _format(GcResult result, {required bool jsonMode}) {
       if (jsonMode) {
         stdout.writeln('HEAP_BEFORE=$heapBefore');
         stdout.writeln('HEAP_AFTER=$heapAfter');
-        stdout.writeln('HEAP_DELTA=$heapDelta');
+        stdout.writeln('HEAP_DELTA=${heapDelta < 0 ? '' : '+'}$heapDelta');
       } else {
         final beforeStr = fmtBytes(heapBefore);
         final afterStr = fmtBytes(heapAfter);
@@ -57,8 +57,8 @@ int _format(GcResult result, {required bool jsonMode}) {
     case GcAllFailed():
       stderr.writeln('ERROR: All isolates failed to GC.');
       return 1;
-    case GcError(:final message):
-      stderr.writeln('ERROR: $message');
+    case GcError():
+      stderr.writeln('ERROR: No app is running.');
       return 1;
   }
 }

--- a/lib/cli/adapters/gc_cli.dart
+++ b/lib/cli/adapters/gc_cli.dart
@@ -47,7 +47,7 @@ int _format(GcResult result, {required bool jsonMode}) {
         final beforeStr = fmtBytes(heapBefore);
         final afterStr = fmtBytes(heapAfter);
         final deltaStr = fmtBytes(heapDelta.abs());
-        final sign = heapDelta <= 0 ? '-' : '+';
+        final sign = heapDelta < 0 ? '-' : '+';
         stdout.writeln('GC_COMPLETE HEAP_BEFORE=$beforeStr HEAP_AFTER=$afterStr HEAP_DELTA=$sign$deltaStr');
       }
       return 0;

--- a/lib/core/commands/gc/gc.dart
+++ b/lib/core/commands/gc/gc.dart
@@ -61,6 +61,8 @@ Future<GcResult> runGc(GcInput _) async {
       heapDelta: totalAfter - totalBefore,
       warnings: warnings,
     );
+  } on AppDiedException {
+    rethrow;
   } catch (e) {
     return GcError(e.toString());
   }

--- a/lib/core/commands/gc/gc.dart
+++ b/lib/core/commands/gc/gc.dart
@@ -1,0 +1,69 @@
+import 'dart:io';
+
+import 'package:fdb/core/app_died_exception.dart';
+import 'package:fdb/core/commands/gc/gc_models.dart';
+import 'package:fdb/core/vm_service.dart';
+
+export 'package:fdb/core/commands/gc/gc_models.dart';
+
+/// Forces a full garbage collection across all isolates in the running VM.
+///
+/// Reads `getMemoryUsage` before, then calls `getAllocationProfile` with
+/// `gc: true` (which triggers a GC) on every isolate, then reads
+/// `getMemoryUsage` again after. Returns a single [GcSuccess] with the
+/// summed before/after heap bytes.
+///
+/// Per-isolate failures are tolerated: the failed isolate is logged to
+/// stderr and processing continues. Returns [GcAllFailed] only when every
+/// isolate fails. Returns [GcNoIsolates] when no isolates are found.
+///
+/// Never throws; all error conditions are represented as sealed result cases.
+Future<GcResult> runGc(GcInput _) async {
+  try {
+    final isolateIds = await findAllIsolateIds();
+    if (isolateIds.isEmpty) return const GcNoIsolates();
+
+    var totalBefore = 0;
+    var totalAfter = 0;
+    var successCount = 0;
+
+    for (final id in isolateIds) {
+      try {
+        // Capture heap usage before GC.
+        final beforeMem =
+            (await vmServiceCall('getMemoryUsage', params: {'isolateId': id}))['result'] as Map<String, dynamic>?;
+        final heapBefore = (beforeMem?['heapUsage'] as num?)?.toInt() ?? 0;
+
+        // Trigger GC via getAllocationProfile with gc: true.
+        // The response also includes post-GC memoryUsage, but we re-query
+        // getMemoryUsage for consistency with the before measurement.
+        await vmServiceCall('getAllocationProfile', params: {'isolateId': id, 'gc': 'true', 'reset': 'false'});
+
+        // Capture heap usage after GC.
+        final afterMem =
+            (await vmServiceCall('getMemoryUsage', params: {'isolateId': id}))['result'] as Map<String, dynamic>?;
+        final heapAfter = (afterMem?['heapUsage'] as num?)?.toInt() ?? 0;
+
+        totalBefore += heapBefore;
+        totalAfter += heapAfter;
+        successCount++;
+      } on AppDiedException {
+        rethrow;
+      } catch (e) {
+        stderr.writeln('WARNING: GC failed for isolate $id: $e');
+      }
+    }
+
+    if (successCount == 0) return const GcAllFailed();
+
+    return GcSuccess(
+      heapBefore: totalBefore,
+      heapAfter: totalAfter,
+      heapDelta: totalAfter - totalBefore,
+    );
+  } on AppDiedException catch (e) {
+    return GcAppDied(logLines: e.logLines, reason: e.reason);
+  } catch (e) {
+    return GcError(e.toString());
+  }
+}

--- a/lib/core/commands/gc/gc.dart
+++ b/lib/core/commands/gc/gc.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:fdb/core/app_died_exception.dart';
 import 'package:fdb/core/commands/gc/gc_models.dart';
 import 'package:fdb/core/vm_service.dart';
@@ -26,6 +24,7 @@ Future<GcResult> runGc(GcInput _) async {
     var totalBefore = 0;
     var totalAfter = 0;
     var successCount = 0;
+    final warnings = <String>[];
 
     for (final id in isolateIds) {
       try {
@@ -37,7 +36,7 @@ Future<GcResult> runGc(GcInput _) async {
         // Trigger GC via getAllocationProfile with gc: true.
         // The response also includes post-GC memoryUsage, but we re-query
         // getMemoryUsage for consistency with the before measurement.
-        await vmServiceCall('getAllocationProfile', params: {'isolateId': id, 'gc': 'true', 'reset': 'false'});
+        await vmServiceCall('getAllocationProfile', params: {'isolateId': id, 'gc': true, 'reset': false});
 
         // Capture heap usage after GC.
         final afterMem =
@@ -50,7 +49,7 @@ Future<GcResult> runGc(GcInput _) async {
       } on AppDiedException {
         rethrow;
       } catch (e) {
-        stderr.writeln('WARNING: GC failed for isolate $id: $e');
+        warnings.add('GC failed for isolate $id: $e');
       }
     }
 
@@ -60,9 +59,8 @@ Future<GcResult> runGc(GcInput _) async {
       heapBefore: totalBefore,
       heapAfter: totalAfter,
       heapDelta: totalAfter - totalBefore,
+      warnings: warnings,
     );
-  } on AppDiedException catch (e) {
-    return GcAppDied(logLines: e.logLines, reason: e.reason);
   } catch (e) {
     return GcError(e.toString());
   }

--- a/lib/core/commands/gc/gc.dart
+++ b/lib/core/commands/gc/gc.dart
@@ -11,8 +11,8 @@ export 'package:fdb/core/commands/gc/gc_models.dart';
 /// `getMemoryUsage` again after. Returns a single [GcSuccess] with the
 /// summed before/after heap bytes.
 ///
-/// Per-isolate failures are tolerated: the failed isolate is logged to
-/// stderr and processing continues. Returns [GcAllFailed] only when every
+/// Per-isolate failures are tolerated: the failure is recorded as a warning
+/// in the result and processing continues. Returns [GcAllFailed] only when every
 /// isolate fails. Returns [GcNoIsolates] when no isolates are found.
 ///
 /// Never throws; all error conditions are represented as sealed result cases.

--- a/lib/core/commands/gc/gc_models.dart
+++ b/lib/core/commands/gc/gc_models.dart
@@ -1,0 +1,55 @@
+import 'package:fdb/core/models/command_result.dart';
+
+/// Input parameters for [runGc]. No fields required — GC runs on all isolates.
+typedef GcInput = ();
+
+/// Result of a [runGc] invocation.
+///
+/// The CLI adapter translates these into stdout/stderr tokens; other
+/// adapters (MCP, REST) may translate them differently.
+sealed class GcResult extends CommandResult {
+  const GcResult();
+}
+
+/// GC completed successfully across at least one isolate.
+class GcSuccess extends GcResult {
+  const GcSuccess({
+    required this.heapBefore,
+    required this.heapAfter,
+    required this.heapDelta,
+  });
+
+  /// Total heap usage in bytes before GC (summed across all isolates).
+  final int heapBefore;
+
+  /// Total heap usage in bytes after GC (summed across all isolates).
+  final int heapAfter;
+
+  /// Delta in bytes (heapAfter - heapBefore; negative means reclaimed).
+  final int heapDelta;
+}
+
+/// No isolates were found in the running VM.
+class GcNoIsolates extends GcResult {
+  const GcNoIsolates();
+}
+
+/// Every isolate failed to GC — nothing succeeded.
+class GcAllFailed extends GcResult {
+  const GcAllFailed();
+}
+
+/// The app process died while fdb was communicating with it.
+class GcAppDied extends GcResult {
+  const GcAppDied({required this.logLines, this.reason});
+
+  final List<String> logLines;
+  final String? reason;
+}
+
+/// Generic / unrecognised error.
+class GcError extends GcResult {
+  const GcError(this.message);
+
+  final String message;
+}

--- a/lib/core/commands/gc/gc_models.dart
+++ b/lib/core/commands/gc/gc_models.dart
@@ -17,6 +17,7 @@ class GcSuccess extends GcResult {
     required this.heapBefore,
     required this.heapAfter,
     required this.heapDelta,
+    this.warnings = const [],
   });
 
   /// Total heap usage in bytes before GC (summed across all isolates).
@@ -27,6 +28,9 @@ class GcSuccess extends GcResult {
 
   /// Delta in bytes (heapAfter - heapBefore; negative means reclaimed).
   final int heapDelta;
+
+  /// Per-isolate warning messages for isolates that failed to GC.
+  final List<String> warnings;
 }
 
 /// No isolates were found in the running VM.
@@ -37,14 +41,6 @@ class GcNoIsolates extends GcResult {
 /// Every isolate failed to GC — nothing succeeded.
 class GcAllFailed extends GcResult {
   const GcAllFailed();
-}
-
-/// The app process died while fdb was communicating with it.
-class GcAppDied extends GcResult {
-  const GcAppDied({required this.logLines, this.reason});
-
-  final List<String> logLines;
-  final String? reason;
 }
 
 /// Generic / unrecognised error.

--- a/skills/using-fdb/SKILL.md
+++ b/skills/using-fdb/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: using-fdb
-description: Uses fdb (Flutter Debug Bridge) CLI to interact with running Flutter apps on devices and simulators. Launches, hot reloads, screenshots, reads app logs (`fdb logs`) and native system logs (`fdb syslog` — Android logcat, iOS syslog, macOS log), fetches OS-level crash records (`fdb crash-report` — jetsam, LMK, native .ips), inspects widget trees, describes screens including off-screen GridView/ListView children, and taps/inputs/scrolls/swipes/navigates. Use when launching a Flutter app on device, hot reloading, taking screenshots, reading app or native system logs, diagnosing native crashes (jetsam, LMK), fetching post-mortem crash reports, inspecting or describing the UI, or interacting with widgets via fdb.
+description: Uses fdb (Flutter Debug Bridge) CLI to interact with running Flutter apps on devices and simulators. Launches, hot reloads, screenshots, reads app logs (`fdb logs`) and native system logs (`fdb syslog` — Android logcat, iOS syslog, macOS log), fetches OS-level crash records (`fdb crash-report` — jetsam, LMK, native .ips), inspects widget trees, describes screens including off-screen GridView/ListView children, taps/inputs/scrolls/swipes/navigates, and forces garbage collection (`fdb gc`). Use when launching a Flutter app on device, hot reloading, taking screenshots, reading app or native system logs, diagnosing native crashes (jetsam, LMK), fetching post-mortem crash reports, inspecting or describing the UI, interacting with widgets via fdb, or forcing a GC to disambiguate live-retained vs unreachable-but-uncollected memory.
 license: MIT
 compatibility: opencode
 ---
 
-## Overview - skill version 1.4.0
+## Overview - skill version 1.5.0
 
 > **Version check:** Run `fdb --version`. This skill may describe unreleased branch behavior,
 > so do not assume the published `1.4.0` release includes every command example below. To use
@@ -430,6 +430,37 @@ Leak-hunting workflow:
 ```bash
 fdb mem profile --output /tmp/before.json
 # ... navigate, trigger suspected leak ...
+fdb mem profile --output /tmp/after.json
+fdb mem diff /tmp/before.json /tmp/after.json
+```
+
+### Forced garbage collection
+
+No `fdb_helper` required — pure VM service, works on any platform fdb supports.
+
+```bash
+fdb gc           # force GC across all isolates; print human-readable summary
+fdb gc --json    # same, KEY=value tokens for scripting
+```
+
+`fdb gc` output:
+```
+GC_COMPLETE HEAP_BEFORE=322.4 MB HEAP_AFTER=287.1 MB HEAP_DELTA=-35.3 MB
+```
+
+`fdb gc --json` output (one line per key):
+```
+HEAP_BEFORE=338033664
+HEAP_AFTER=301020160
+HEAP_DELTA=-37013504
+```
+
+Force GC before/after a suspected-leak navigation to remove GC noise from `fdb mem` readings:
+```bash
+fdb gc
+fdb mem profile --output /tmp/before.json
+# ... navigate through the suspected-leak scenario ...
+fdb gc
 fdb mem profile --output /tmp/after.json
 fdb mem diff /tmp/before.json /tmp/after.json
 ```


### PR DESCRIPTION
Without a forced GC, `fdb mem` numbers are ambiguous: a few MB of growth could be a real leak or just objects waiting to be collected. `fdb gc` removes that ambiguity by triggering a full GC across every Dart isolate before you snapshot memory, so before/after `fdb mem profile` comparisons reflect only live-retained objects.

No `fdb_helper` required — pure VM service, works on macOS, Android, and iOS.

Closes #49