### PR TITLE
fix: fdb describe no longer leaks elements from underlying navigator routes

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -753,6 +753,67 @@ tasks:
         echo "==> Navigating back"
         {{.FDB}} back 2>&1 || echo "INFO: fdb back returned non-zero (already at root — ignored)"
 
+  test:describe-router:
+    desc: Verify fdb describe only shows elements from the current (topmost) route, not underlying routes
+    dir: '{{.TEST_APP}}'
+    cmds:
+      - |
+        echo "==> Navigating to Detail Page (child route)"
+        {{.FDB}} scroll-to --key "go_to_details" >/dev/null 2>&1 || true
+        if ! {{.FDB}} tap --key "go_to_details" >/dev/null 2>&1; then
+          echo "FAIL: could not navigate to Detail Page (fdb tap --key go_to_details failed)" >&2
+          exit 1
+        fi
+        sleep 1
+
+        echo "==> Describing Detail Page (child route)"
+        OUTPUT=$({{.FDB}} describe 2>&1)
+        EXIT_CODE=$?
+        echo "$OUTPUT"
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "FAIL: fdb describe (router child) exited with code $EXIT_CODE" >&2
+          exit 1
+        fi
+
+        # The Detail Page must appear as the current screen.
+        if echo "$OUTPUT" | grep -q "SCREEN: Detail Page"; then
+          echo "PASS: fdb describe shows correct SCREEN name on child route"
+        else
+          echo "FAIL: fdb describe did not show 'SCREEN: Detail Page' when on child route" >&2
+          exit 1
+        fi
+
+        # Home-screen-only elements must NOT leak through.
+        LEAK_FOUND=0
+        for KEY in "show_delayed" "double_tap_target" "longpress_target" "save_button_0" "submit_button"; do
+          if echo "$OUTPUT" | grep -q "key=$KEY"; then
+            echo "FAIL: fdb describe leaked home-screen element key=$KEY onto child route output" >&2
+            LEAK_FOUND=1
+          fi
+        done
+        if [ $LEAK_FOUND -eq 0 ]; then
+          echo "PASS: fdb describe does not leak home-screen elements onto child route"
+        else
+          exit 1
+        fi
+
+        # Home-screen-only VISIBLE TEXT must NOT appear in the output.
+        TEXT_LEAK_FOUND=0
+        for TEXT in "Go to Details" "Show Dialog" "Benchmarks" "Scroll-To Tests"; do
+          if echo "$OUTPUT" | grep -q "\"$TEXT\""; then
+            echo "FAIL: fdb describe leaked home-screen text '$TEXT' into child route VISIBLE TEXT" >&2
+            TEXT_LEAK_FOUND=1
+          fi
+        done
+        if [ $TEXT_LEAK_FOUND -eq 0 ]; then
+          echo "PASS: fdb describe does not leak home-screen text into child route VISIBLE TEXT"
+        else
+          exit 1
+        fi
+
+        echo "==> Navigating back"
+        {{.FDB}} back 2>&1 || echo "INFO: fdb back returned non-zero (already at root — ignored)"
+
   test:tap:
     desc: Tap a widget by text selector
     dir: '{{.TEST_APP}}'
@@ -2742,6 +2803,7 @@ tasks:
       - task: test:describe
       - task: test:describe-grid
       - task: test:describe-nested-gestures
+      - task: test:describe-router
       - task: test:screenshot
       - task: test:native-view-tap
       - task: test:deeplink

--- a/packages/fdb_helper/lib/src/handlers/describe_handler.dart
+++ b/packages/fdb_helper/lib/src/handlers/describe_handler.dart
@@ -60,6 +60,11 @@ Future<developer.ServiceExtensionResponse> handleDescribe(
     // Tracks the nearest enclosing Tooltip message while walking the tree.
     String? currentTooltip;
 
+    // The route that was "current" the last time we saw a ModalRoute boundary
+    // while descending. Used to detect when we enter a non-current route's
+    // subtree so we can skip it entirely.
+    ModalRoute<dynamic>? activeRouteContext;
+
     void visit(Element element) {
       // Stop collecting interactive entries once the cap is reached.
       if (interactive.length >= maxInteractive) return;
@@ -75,10 +80,21 @@ Future<developer.ServiceExtensionResponse> handleDescribe(
         } catch (_) {}
       }
 
-      // Collect route name from ModalRoute.
+      // Skip subtrees belonging to non-current routes (e.g. underlying screens
+      // kept alive by the Navigator stack). When a StatefulElement introduces a
+      // new ModalRoute boundary that is not the current (topmost) route, its
+      // entire subtree is off-screen from the user's perspective — even though
+      // the render objects may report valid pixel coordinates — so we prune it.
       if (element is StatefulElement) {
         final route = ModalRoute.of(element);
-        if (route != null) {
+        if (route != null && route != activeRouteContext) {
+          // We have crossed into a new route boundary.
+          if (!route.isCurrent) {
+            // This route is not the topmost active route — skip its subtree.
+            return;
+          }
+          // This is the current route: record it and collect the route name.
+          activeRouteContext = route;
           routeName = route.settings.name;
         }
       }


### PR DESCRIPTION
When navigating to a child screen with Navigator.push, fdb describe was surfacing interactive elements and visible text from the home screen alongside the current screen's content. The SCREEN name was also reporting the wrong screen (the root route's AppBar title instead of the active one).

Flutter keeps previous route widget trees alive in the element tree for transitions and maintainState. Their render objects report valid pixel coordinates that overlap the viewport, so the existing isOnScreen check alone was not enough to exclude them. The fix tracks the active ModalRoute boundary while descending the tree and prunes any subtree whose route is not the current (topmost) one — the same pattern already used in wait_handler.dart.