### PR TITLE
fix(skill): move grant-permission docs from shim to lib/skill/SKILL.md

### DIFF
--- a/lib/skill/SKILL.md
+++ b/lib/skill/SKILL.md
@@ -501,7 +501,7 @@ fdb mem profile --output /tmp/after.json
 fdb mem diff /tmp/before.json /tmp/after.json
 ```
 
-### Grant / revoke / reset runtime permissions
+### Grant, revoke, or reset runtime permissions
 
 ```bash
 # Grant a permission (iOS simulator or Android)
@@ -526,10 +526,7 @@ fdb grant-permission --bundle com.example.app camera
 
 Supported tokens: `camera`, `microphone`, `location`, `location-always`, `contacts`, `contacts-read`, `photos`, `photos-add`, `calendar`, `reminders`, `motion`, `media-library`, `siri` (iOS), `notifications` (Android), `screen-capture` (macOS).
 
-Notes:
-- Supported on iOS simulator and Android. Physical iOS devices are not supported.
-- macOS supports `--reset` only; grant/revoke emit `WARNING:` and exit 1.
-- On iOS simulator, a successful grant emits `WARNING: Permission change may have terminated the app. Run \`fdb reload\` or \`fdb launch\` to restart.` on stderr.
+Supported on iOS simulator and Android. Physical iOS devices are not supported. macOS supports `--reset` only; grant/revoke emit `WARNING:` and exit 1. On iOS simulator, a successful grant emits `WARNING: Permission change may have terminated the app. Run \`fdb reload\` or \`fdb launch\` to restart.` on stderr.
 
 ### Status / Kill
 

--- a/lib/skill/SKILL.md
+++ b/lib/skill/SKILL.md
@@ -501,6 +501,36 @@ fdb mem profile --output /tmp/after.json
 fdb mem diff /tmp/before.json /tmp/after.json
 ```
 
+### Grant / revoke / reset runtime permissions
+
+```bash
+# Grant a permission (iOS simulator or Android)
+fdb grant-permission camera
+# stdout: PERMISSION_GRANTED=camera
+
+# Revoke a permission
+fdb grant-permission camera --revoke
+# stdout: PERMISSION_REVOKED=camera
+
+# Reset a single permission (re-prompts on next access)
+fdb grant-permission camera --reset
+# stdout: PERMISSION_RESET=camera
+
+# Reset ALL permissions for the app
+fdb grant-permission --reset-all
+# stdout: PERMISSION_RESET_ALL=true
+
+# Override bundle ID / package name
+fdb grant-permission --bundle com.example.app camera
+```
+
+Supported tokens: `camera`, `microphone`, `location`, `location-always`, `contacts`, `contacts-read`, `photos`, `photos-add`, `calendar`, `reminders`, `motion`, `media-library`, `siri` (iOS), `notifications` (Android), `screen-capture` (macOS).
+
+Notes:
+- Supported on iOS simulator and Android. Physical iOS devices are not supported.
+- macOS supports `--reset` only; grant/revoke emit `WARNING:` and exit 1.
+- On iOS simulator, a successful grant emits `WARNING: Permission change may have terminated the app. Run \`fdb reload\` or \`fdb launch\` to restart.` on stderr.
+
 ### Status / Kill
 
 ```bash

--- a/skills/using-fdb/SKILL.md
+++ b/skills/using-fdb/SKILL.md
@@ -8,34 +8,3 @@ compatibility: opencode
 Run `fdb skill` and read its full stdout output before doing anything with fdb.
 That output is the authoritative, version-matched reference for every command, flag, and output token.
 
-## grant-permission
-
-Grant, revoke, or reset a runtime permission for the running Flutter app.
-
-```bash
-# Grant a permission (iOS simulator or Android)
-fdb grant-permission camera
-# stdout: PERMISSION_GRANTED=camera
-
-# Revoke a permission
-fdb grant-permission camera --revoke
-# stdout: PERMISSION_REVOKED=camera
-
-# Reset a single permission (re-prompts on next access)
-fdb grant-permission camera --reset
-# stdout: PERMISSION_RESET=camera
-
-# Reset ALL permissions for the app
-fdb grant-permission --reset-all
-# stdout: PERMISSION_RESET_ALL=true
-
-# Override bundle ID / package name
-fdb grant-permission --bundle com.example.app camera
-```
-
-Supported tokens: `camera`, `microphone`, `location`, `location-always`, `contacts`, `contacts-read`, `photos`, `photos-add`, `calendar`, `reminders`, `motion`, `media-library`, `siri` (iOS), `notifications` (Android), `screen-capture` (macOS).
-
-Notes:
-- Supported on iOS simulator and Android. Physical iOS devices are not supported.
-- macOS supports `--reset` only; grant/revoke emit `WARNING:` and exit 1.
-- On iOS simulator, a successful grant emits `WARNING: Permission change may have terminated the app. Run \`fdb reload\` or \`fdb launch\` to restart.` on stderr.


### PR DESCRIPTION
Commit 6320100 added the `grant-permission` documentation directly into `skills/using-fdb/SKILL.md` — the lean shim — instead of `lib/skill/SKILL.md`, which is the authoritative file read by `fdb skill`. The shim was intentionally refactored in #107 to never need updating, so any command docs added there go stale and contradict the architecture.

- Removes the `grant-permission` block from the shim, restoring it to its 5-line stable form
- Adds the `grant-permission` section to `lib/skill/SKILL.md` where it belongs (before `Status / Kill`)