### PR TITLE
fix: Improve swipe gesture fidelity

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1846,7 +1846,7 @@ tasks:
           echo "FAIL: fdb swipe scale PageView repro did not start on page 0" >&2
           exit 1
         fi
-        SCALE_OUTPUT=$({{.FDB}} swipe left --at 200,500 --distance 250 2>&1)
+        SCALE_OUTPUT=$({{.FDB}} swipe left --key scale_page_view --distance 250 2>&1)
         SCALE_EXIT_CODE=$?
         echo "$SCALE_OUTPUT"
         if [ $SCALE_EXIT_CODE -ne 0 ]; then

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1840,6 +1840,7 @@ tasks:
         sleep 1
         TAP_OUT=$({{.FDB}} tap --key go_to_scale_page_view_test 2>&1)
         echo "$TAP_OUT"
+        {{.FDB}} wait --key scale_page_view --present --timeout 5000 >/dev/null
         BEFORE=$({{.FDB}} describe 2>&1)
         echo "$BEFORE"
         if ! echo "$BEFORE" | grep -q "Scale PageView page=0"; then
@@ -1853,6 +1854,7 @@ tasks:
           echo "FAIL: fdb swipe scale PageView exited with code $SCALE_EXIT_CODE" >&2
           exit 1
         fi
+        {{.FDB}} wait --text "Scale PageView page=1" --present --timeout 5000 >/dev/null
         AFTER=$({{.FDB}} describe 2>&1)
         echo "$AFTER"
         if echo "$AFTER" | grep -q "Scale PageView page=1"; then

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1847,7 +1847,7 @@ tasks:
           echo "FAIL: fdb swipe scale PageView repro did not start on page 0" >&2
           exit 1
         fi
-        SCALE_OUTPUT=$({{.FDB}} swipe left --key scale_page_view --distance 250 2>&1)
+        SCALE_OUTPUT=$({{.FDB}} swipe left --key scale_page_view 2>&1)
         SCALE_EXIT_CODE=$?
         echo "$SCALE_OUTPUT"
         if [ $SCALE_EXIT_CODE -ne 0 ]; then

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1835,6 +1835,33 @@ tasks:
           exit 1
         fi
 
+        echo "==> Verifying swipe inside PageView page with scale recognizer"
+        {{.FDB}} restart >/dev/null 2>&1
+        sleep 1
+        TAP_OUT=$({{.FDB}} tap --key go_to_scale_page_view_test 2>&1)
+        echo "$TAP_OUT"
+        BEFORE=$({{.FDB}} describe 2>&1)
+        echo "$BEFORE"
+        if ! echo "$BEFORE" | grep -q "Scale PageView page=0"; then
+          echo "FAIL: fdb swipe scale PageView repro did not start on page 0" >&2
+          exit 1
+        fi
+        SCALE_OUTPUT=$({{.FDB}} swipe left --at 200,500 --distance 250 2>&1)
+        SCALE_EXIT_CODE=$?
+        echo "$SCALE_OUTPUT"
+        if [ $SCALE_EXIT_CODE -ne 0 ]; then
+          echo "FAIL: fdb swipe scale PageView exited with code $SCALE_EXIT_CODE" >&2
+          exit 1
+        fi
+        AFTER=$({{.FDB}} describe 2>&1)
+        echo "$AFTER"
+        if echo "$AFTER" | grep -q "Scale PageView page=1"; then
+          echo "PASS: fdb swipe scale PageView"
+        else
+          echo "FAIL: fdb swipe scale PageView did not move to page 1" >&2
+          exit 1
+        fi
+
   test:back:
     desc: Navigate back in the running app
     dir: '{{.TEST_APP}}'

--- a/example/test_app/lib/main.dart
+++ b/example/test_app/lib/main.dart
@@ -47,13 +47,12 @@ class FdbTestApp extends StatelessWidget {
         scrollToTestLazyRoute: (_) => const LazyListScrollToPage(),
         scrollToTestHorizontalRoute: (_) => const HorizontalListScrollToPage(),
         scrollToTestReversedRoute: (_) => const ReversedListScrollToPage(),
-        scrollToTestAlreadyVisibleRoute: (_) =>
-            const AlreadyVisibleScrollToPage(),
-        '/nested-gesture-describe-test': (_) =>
-            const NestedGestureDescribeScreen(),
+        scrollToTestAlreadyVisibleRoute: (_) => const AlreadyVisibleScrollToPage(),
+        '/nested-gesture-describe-test': (_) => const NestedGestureDescribeScreen(),
         '/listtile-describe-test': (_) => const ListTileDescribeScreen(),
         '/notification-test': (_) => NotificationTestScreen(),
         '/permission-test': (_) => const PermissionTestScreen(),
+        '/scale-page-view-test': (_) => const ScalePageViewTestScreen(),
       },
     );
   }
@@ -147,9 +146,14 @@ class _FdbTestHomePageState extends State<FdbTestHomePage> {
               const SizedBox(height: 16),
               ElevatedButton(
                 key: const Key('go_to_notification_test_top'),
-                onPressed: () =>
-                    Navigator.pushNamed(context, '/notification-test'),
+                onPressed: () => Navigator.pushNamed(context, '/notification-test'),
                 child: const Text('Notification Test'),
+              ),
+              const SizedBox(height: 8),
+              ElevatedButton(
+                key: const Key('go_to_scale_page_view_test'),
+                onPressed: () => Navigator.pushNamed(context, '/scale-page-view-test'),
+                child: const Text('Scale PageView Test'),
               ),
               const SizedBox(height: 8),
               // Navigation buttons
@@ -208,23 +212,20 @@ class _FdbTestHomePageState extends State<FdbTestHomePage> {
               const SizedBox(height: 8),
               ElevatedButton(
                 key: const Key('go_to_scroll_to_test'),
-                onPressed: () =>
-                    Navigator.pushNamed(context, scrollToTestRoute),
+                onPressed: () => Navigator.pushNamed(context, scrollToTestRoute),
                 child: const Text('Scroll-To Tests'),
               ),
               const SizedBox(height: 8),
               const SizedBox(height: 8),
               ElevatedButton(
                 key: const Key('go_to_native_view_test'),
-                onPressed: () =>
-                    Navigator.pushNamed(context, '/native-view-test'),
+                onPressed: () => Navigator.pushNamed(context, '/native-view-test'),
                 child: const Text('Native View Test'),
               ),
               const SizedBox(height: 8),
               ElevatedButton(
                 key: const Key('go_to_grid_describe_test'),
-                onPressed: () =>
-                    Navigator.pushNamed(context, '/grid-describe-test'),
+                onPressed: () => Navigator.pushNamed(context, '/grid-describe-test'),
                 child: const Text('Grid Describe Test'),
               ),
               const SizedBox(height: 8),
@@ -239,22 +240,19 @@ class _FdbTestHomePageState extends State<FdbTestHomePage> {
               const SizedBox(height: 8),
               ElevatedButton(
                 key: const Key('go_to_listtile_describe_test'),
-                onPressed: () =>
-                    Navigator.pushNamed(context, '/listtile-describe-test'),
+                onPressed: () => Navigator.pushNamed(context, '/listtile-describe-test'),
                 child: const Text('ListTile Describe Test'),
               ),
               const SizedBox(height: 8),
               ElevatedButton(
                 key: const Key('go_to_notification_test'),
-                onPressed: () =>
-                    Navigator.pushNamed(context, '/notification-test'),
+                onPressed: () => Navigator.pushNamed(context, '/notification-test'),
                 child: const Text('Notification Test'),
               ),
               const SizedBox(height: 8),
               ElevatedButton(
                 key: const Key('go_to_permission_test'),
-                onPressed: () =>
-                    Navigator.pushNamed(context, '/permission-test'),
+                onPressed: () => Navigator.pushNamed(context, '/permission-test'),
                 child: const Text('Permission Test'),
               ),
               const SizedBox(height: 8),
@@ -262,8 +260,7 @@ class _FdbTestHomePageState extends State<FdbTestHomePage> {
                 key: const Key('show_native_alert'),
                 onPressed: () async {
                   try {
-                    final result = await _nativeDialogChannel
-                        .invokeMethod<String>('showNativeAlert');
+                    final result = await _nativeDialogChannel.invokeMethod<String>('showNativeAlert');
                     if (mounted) {
                       setState(() => _nativeAlertResult = result ?? 'null');
                     }
@@ -502,6 +499,68 @@ class DetailPage extends StatelessWidget {
         title: const Text('Detail Page'),
       ),
       body: const Center(child: Text('Detail Page Content')),
+    );
+  }
+}
+
+class ScalePageViewTestScreen extends StatefulWidget {
+  const ScalePageViewTestScreen({super.key});
+
+  @override
+  State<ScalePageViewTestScreen> createState() => _ScalePageViewTestScreenState();
+}
+
+class _ScalePageViewTestScreenState extends State<ScalePageViewTestScreen> {
+  int _page = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Scale PageView Test')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Text(
+              'Scale PageView page=$_page',
+              key: const Key('scale_page_view_page_text'),
+            ),
+          ),
+          Expanded(
+            child: PageView.builder(
+              key: const Key('scale_page_view'),
+              itemCount: 5,
+              onPageChanged: (page) {
+                setState(() {
+                  _page = page;
+                });
+                developer.log('scale_page_view page=$page', name: 'fdb_test');
+              },
+              itemBuilder: (context, index) {
+                return GestureDetector(
+                  key: Key('scale_page_view_child_$index'),
+                  onDoubleTap: () {
+                    developer.log(
+                      'scale_page_view doubleTap page=$index',
+                      name: 'fdb_test',
+                    );
+                  },
+                  onScaleUpdate: (_) {},
+                  child: ColoredBox(
+                    color: Colors.primaries[index],
+                    child: Center(
+                      child: Text(
+                        'Scale Page $index',
+                        style: Theme.of(context).textTheme.headlineLarge,
+                      ),
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/packages/fdb_helper/lib/src/gesture_dispatcher.dart
+++ b/packages/fdb_helper/lib/src/gesture_dispatcher.dart
@@ -252,7 +252,7 @@ Future<void> _dispatchMouseDoubleTap(Offset globalPosition) async {
 Future<void> dispatchScroll({
   required Offset start,
   required Offset end,
-  double maxStepSize = 8.0,
+  double maxStepSize = 40.0,
 }) async {
   final pointerId = _nextPointerId++;
   final delta = end - start;

--- a/packages/fdb_helper/lib/src/gesture_dispatcher.dart
+++ b/packages/fdb_helper/lib/src/gesture_dispatcher.dart
@@ -252,7 +252,7 @@ Future<void> _dispatchMouseDoubleTap(Offset globalPosition) async {
 Future<void> dispatchScroll({
   required Offset start,
   required Offset end,
-  double maxStepSize = 40.0,
+  double maxStepSize = 8.0,
 }) async {
   final pointerId = _nextPointerId++;
   final delta = end - start;

--- a/packages/fdb_helper/lib/src/handlers/swipe_handler.dart
+++ b/packages/fdb_helper/lib/src/handlers/swipe_handler.dart
@@ -114,6 +114,7 @@ Future<developer.ServiceExtensionResponse> handleSwipe(
     await dispatchScroll(
       start: Offset(startX, startY),
       end: Offset(endX, endY),
+      maxStepSize: 8.0,
     );
 
     return developer.ServiceExtensionResponse.result(


### PR DESCRIPTION
fdb synthetic swipes could lose Flutter's gesture arena when a PageView page contained a scale recognizer, so the command reported success without moving the page.

This preserves the repro in the test app and makes swipe movement closer to native touch input.