### PR TITLE
fix: Keep fdb_helper real native tap in profile builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ void main() {
 }
 ```
 
-`fdb_helper` now ships safe native tap stubs in release builds. Android release builds and Apple release builds do not include the real native tap implementation. On iOS/macOS, Flutter's default CocoaPods setup also makes `Profile` use the stub unless the app explicitly overrides the `fdb_helper` pod target build settings. See [`packages/fdb_helper/README.md`](packages/fdb_helper/README.md) for the Profile opt-in snippet.
+Release builds compile a safe `fdb_helper` stub on Android, iOS, and macOS, so App Store / Play Store binaries no longer ship the private-API native tap. Debug and profile builds keep the real native tap implementation, so `fdb native-tap` works in profile builds distributed via Firebase App Distribution or TestFlight internal. See [`packages/fdb_helper/README.md`](packages/fdb_helper/README.md) for build-mode details.
 
 ## Troubleshooting
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3851,8 +3851,16 @@ tasks:
 
         echo "==> Checking Apple build gating"
         grep -q 'SWIFT_ACTIVE_COMPILATION_CONDITIONS\[config=Debug\].*FDB_HELPER_NATIVE_TAP_REAL' packages/fdb_helper/ios/fdb_helper.podspec
+        grep -q 'SWIFT_ACTIVE_COMPILATION_CONDITIONS\[config=Profile\].*FDB_HELPER_NATIVE_TAP_REAL' packages/fdb_helper/ios/fdb_helper.podspec
+        grep -q 'GCC_PREPROCESSOR_DEFINITIONS\[config=Debug\].*FDB_HELPER_NATIVE_TAP_REAL=1' packages/fdb_helper/ios/fdb_helper.podspec
+        grep -q 'GCC_PREPROCESSOR_DEFINITIONS\[config=Profile\].*FDB_HELPER_NATIVE_TAP_REAL=1' packages/fdb_helper/ios/fdb_helper.podspec
         grep -q 'EXCLUDED_SOURCE_FILE_NAMES\[config=Release\].*FdbHelperNativeTap.m' packages/fdb_helper/ios/fdb_helper.podspec
-        grep -q 'EXCLUDED_SOURCE_FILE_NAMES\[config=Profile\].*FdbHelperNativeTap.m' packages/fdb_helper/ios/fdb_helper.podspec
+        if grep -q 'EXCLUDED_SOURCE_FILE_NAMES\[config=Profile\]' packages/fdb_helper/ios/fdb_helper.podspec; then
+          echo "FAIL: Profile must keep the real Apple native tap; remove EXCLUDED_SOURCE_FILE_NAMES[config=Profile]" >&2
+          exit 1
+        fi
+        grep -q 'SWIFT_ACTIVE_COMPILATION_CONDITIONS\[config=Debug\].*FDB_HELPER_NATIVE_TAP_REAL' packages/fdb_helper/macos/fdb_helper.podspec
+        grep -q 'SWIFT_ACTIVE_COMPILATION_CONDITIONS\[config=Profile\].*FDB_HELPER_NATIVE_TAP_REAL' packages/fdb_helper/macos/fdb_helper.podspec
         grep -q '#if FDB_HELPER_NATIVE_TAP_REAL' packages/fdb_helper/ios/Classes/FdbHelperNativeTapImpl.swift
         grep -q '#if FDB_HELPER_NATIVE_TAP_REAL' packages/fdb_helper/macos/Classes/FdbHelperNativeTapImpl.swift
 

--- a/example/test_app/ios/Podfile.lock
+++ b/example/test_app/ios/Podfile.lock
@@ -37,7 +37,7 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/webview_flutter_wkwebview/darwin"
 
 SPEC CHECKSUMS:
-  fdb_helper: 0426ee086da16555dfb88b53efd755d2be687aea
+  fdb_helper: f6485dcf86a8530677d65c69f7b8e62091ee1721
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
   push: 91373ae39c5341c6de6adefa3fda7f7287d646bf

--- a/example/test_app/macos/Podfile.lock
+++ b/example/test_app/macos/Podfile.lock
@@ -32,7 +32,7 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/webview_flutter_wkwebview/darwin
 
 SPEC CHECKSUMS:
-  fdb_helper: 5c32d36d02f83eaef98cbb1ae9acaf80225c25ab
+  fdb_helper: 25f918842df7db5798d37b3a43b7b145c1ea94a3
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
   push: 91373ae39c5341c6de6adefa3fda7f7287d646bf
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb

--- a/packages/fdb_helper/README.md
+++ b/packages/fdb_helper/README.md
@@ -36,49 +36,11 @@ Then run `flutter pub get` and relaunch the app.
 
 ## Build-mode behavior
 
-- **Android debug/profile**: compiles the real native tap implementation. Flutter's Android `profile` build type falls back to the debug plugin variant when the plugin does not publish a profile variant.
-- **Android release**: compiles a stub `FdbHelperNativeTapImpl`; `fdb native-tap` falls back to Flutter gestures and cannot reach native overlays.
-- **iOS/macOS debug**: compiles the real native tap implementation.
-- **iOS/macOS release**: compiles a safe stub and excludes the private iOS native tap Objective-C implementation from the pod target.
-- **iOS/macOS profile**: uses the same safe stub by default. Flutter's default CocoaPods setup maps `Profile` to `:release`, so profile does **not** get the real native tap path unless the consuming app opts in.
+- **Debug** (all platforms): compiles the real native tap implementation.
+- **Profile** (all platforms): compiles the real native tap implementation. Profile is intended for on-device profiling/internal distribution (Firebase App Distribution, TestFlight internal), so `fdb native-tap` works there.
+- **Release** (all platforms): compiles a safe stub. iOS/macOS exclude the private Objective-C native tap implementation from the pod target. Android compiles a stub via Gradle `src/release` source sets. App Store / Play Store binaries no longer ship the private-API native tap.
 
-If you need the real native tap path in an Apple `Profile` build for local/dev-only testing, override the `fdb_helper` pod target in your app's `Podfile`.
-
-For **iOS** `Profile` builds, add the Swift/ObjC flags and clear the excluded-source override for the `fdb_helper` pod target:
-
-```ruby
-post_install do |installer|
-  installer.pods_project.targets.each do |target|
-    next unless target.name == 'fdb_helper'
-
-    target.build_configurations.each do |config|
-      next unless config.name == 'Profile'
-
-      config.build_settings['SWIFT_ACTIVE_COMPILATION_CONDITIONS'] = '$(inherited) FDB_HELPER_NATIVE_TAP_REAL'
-      config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] = '$(inherited) FDB_HELPER_NATIVE_TAP_REAL=1'
-      config.build_settings['EXCLUDED_SOURCE_FILE_NAMES'] = ''
-    end
-  end
-end
-```
-
-For **macOS** `Profile` builds, only the Swift compilation condition is needed:
-
-```ruby
-post_install do |installer|
-  installer.pods_project.targets.each do |target|
-    next unless target.name == 'fdb_helper'
-
-    target.build_configurations.each do |config|
-      next unless config.name == 'Profile'
-
-      config.build_settings['SWIFT_ACTIVE_COMPILATION_CONDITIONS'] = '$(inherited) FDB_HELPER_NATIVE_TAP_REAL'
-    end
-  end
-end
-```
-
-Only use that override in internal/dev builds. Do not ship the real Apple native tap implementation in production binaries.
+The Apple Profile selection works because `fdb_helper` keys its compile flags on the Xcode configuration name (`Profile`) rather than on the CocoaPods configuration type, so Flutter's default `'Profile' => :release` Podfile mapping does not turn Profile into the release stub.
 
 ## Usage
 

--- a/packages/fdb_helper/android/src/release/kotlin/io/fdb/fdb_helper/FdbHelperNativeTapImpl.kt
+++ b/packages/fdb_helper/android/src/release/kotlin/io/fdb/fdb_helper/FdbHelperNativeTapImpl.kt
@@ -1,16 +1,17 @@
 package io.fdb.fdb_helper
 
-/// Safe release/profile stub.
+/// Safe release stub.
 ///
-/// The real implementation depends on debug-only in-process input injection and
-/// must not ship in production Android binaries.
+/// The real implementation depends on in-process input injection and must not
+/// ship in production Android binaries. Profile builds keep the real
+/// implementation via Flutter's `matchingFallbacks` (debug → release).
 class FdbHelperNativeTapImpl(
     @Suppress("UNUSED_PARAMETER") activityProvider: () -> android.app.Activity?,
 ) : NativeTapApi {
     override fun nativeTap(x: Double, y: Double) {
         throw FlutterError(
             "UNAVAILABLE_IN_RELEASE",
-            "Native tap is disabled in release/profile builds of fdb_helper",
+            "Native tap is disabled in release builds of fdb_helper",
             null,
         )
     }

--- a/packages/fdb_helper/ios/Classes/FdbHelperNativeTapImpl.swift
+++ b/packages/fdb_helper/ios/Classes/FdbHelperNativeTapImpl.swift
@@ -46,12 +46,12 @@ class FdbHelperNativeTapImpl: NSObject, NativeTapApi {
 
 #else
 
-/// Safe fallback compiled into profile/release Apple builds by default.
+/// Safe fallback compiled into release Apple builds.
 class FdbHelperNativeTapImpl: NSObject, NativeTapApi {
   func nativeTap(x: Double, y: Double) throws {
     throw PigeonError(
       code: "UNAVAILABLE_IN_RELEASE",
-      message: "Native tap is disabled in release/profile builds of fdb_helper",
+      message: "Native tap is disabled in release builds of fdb_helper",
       details: nil,
     )
   }

--- a/packages/fdb_helper/ios/fdb_helper.podspec
+++ b/packages/fdb_helper/ios/fdb_helper.podspec
@@ -14,8 +14,9 @@ Pod::Spec.new do |s|
     'DEFINES_MODULE' => 'YES',
     'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
     'SWIFT_ACTIVE_COMPILATION_CONDITIONS[config=Debug]' => '$(inherited) FDB_HELPER_NATIVE_TAP_REAL',
+    'SWIFT_ACTIVE_COMPILATION_CONDITIONS[config=Profile]' => '$(inherited) FDB_HELPER_NATIVE_TAP_REAL',
     'GCC_PREPROCESSOR_DEFINITIONS[config=Debug]' => '$(inherited) FDB_HELPER_NATIVE_TAP_REAL=1',
-    'EXCLUDED_SOURCE_FILE_NAMES[config=Profile]' => 'FdbHelperNativeTap.m',
+    'GCC_PREPROCESSOR_DEFINITIONS[config=Profile]' => '$(inherited) FDB_HELPER_NATIVE_TAP_REAL=1',
     'EXCLUDED_SOURCE_FILE_NAMES[config=Release]' => 'FdbHelperNativeTap.m',
   }
   s.swift_version    = '5.0'

--- a/packages/fdb_helper/macos/Classes/FdbHelperNativeTapImpl.swift
+++ b/packages/fdb_helper/macos/Classes/FdbHelperNativeTapImpl.swift
@@ -80,12 +80,12 @@ class FdbHelperNativeTapImpl: NSObject, NativeTapApi {
 
 #else
 
-/// Safe fallback compiled into profile/release macOS builds by default.
+/// Safe fallback compiled into release macOS builds.
 class FdbHelperNativeTapImpl: NSObject, NativeTapApi {
   func nativeTap(x: Double, y: Double) throws {
     throw PigeonError(
       code: "UNAVAILABLE_IN_RELEASE",
-      message: "Native tap is disabled in release/profile builds of fdb_helper",
+      message: "Native tap is disabled in release builds of fdb_helper",
       details: nil,
     )
   }

--- a/packages/fdb_helper/macos/fdb_helper.podspec
+++ b/packages/fdb_helper/macos/fdb_helper.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',
     'SWIFT_ACTIVE_COMPILATION_CONDITIONS[config=Debug]' => '$(inherited) FDB_HELPER_NATIVE_TAP_REAL',
+    'SWIFT_ACTIVE_COMPILATION_CONDITIONS[config=Profile]' => '$(inherited) FDB_HELPER_NATIVE_TAP_REAL',
   }
   s.swift_version    = '5.0'
 end


### PR DESCRIPTION
v1.6.3 also stubbed the iOS/macOS Apple native tap in profile builds, but profile is what we ship to Firebase App Distribution / TestFlight internal and it must remain profilable by fdb. This restores the real implementation in profile while keeping the release stub. Android profile already kept the real implementation via Flutter's matchingFallbacks.

Verified by inspecting the compiled fdb_helper.framework binaries on macOS and iOS device builds: debug + profile contain the real native tap symbols, release contains only the safe stub.