### PR TITLE
fix: honor FVM flutter resolution in devices

### DIFF
--- a/lib/cli/adapters/devices_cli.dart
+++ b/lib/cli/adapters/devices_cli.dart
@@ -15,7 +15,9 @@ import 'package:fdb/core/commands/devices/devices.dart';
 Future<int> runDevicesCli(List<String> args) => runCliAdapter(ArgParser(), args, _execute);
 
 Future<int> _execute(ArgResults _) async {
-  final result = await listDevices(());
+  final result = await listDevices(
+    (projectPath: Directory.current.path, processRunner: Process.run),
+  );
   return _format(result);
 }
 

--- a/lib/core/commands/devices/devices.dart
+++ b/lib/core/commands/devices/devices.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:fdb/core/commands/devices/devices_models.dart';
+import 'package:fdb/core/flutter_binary.dart';
 import 'package:fdb/core/process_utils.dart';
 
 export 'package:fdb/core/commands/devices/devices_models.dart';
@@ -10,9 +11,11 @@ export 'package:fdb/core/commands/devices/devices_models.dart';
 ///
 /// Never throws; never writes to stdio. All error conditions are represented
 /// as distinct [DevicesResult] subtypes.
-Future<DevicesResult> listDevices(DevicesInput _) async {
+Future<DevicesResult> listDevices(DevicesInput input) async {
   final ProcessResult result;
-  result = await Process.run('flutter', ['devices', '--machine']);
+  final flutter = resolveFlutterBinary(input.projectPath);
+
+  result = await input.processRunner(flutter, ['devices', '--machine']);
 
   if (result.exitCode != 0) {
     return DevicesFlutterFailed(result.stderr as String);

--- a/lib/core/commands/devices/devices_models.dart
+++ b/lib/core/commands/devices/devices_models.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:fdb/core/models/command_result.dart';
 
 /// A single connected device entry returned by `flutter devices --machine`.
@@ -8,9 +10,13 @@ typedef DeviceInfo = ({
   bool emulator,
 });
 
-/// Input parameters for [listDevices]. Empty record because `fdb devices`
-/// takes no arguments today.
-typedef DevicesInput = ();
+/// Input parameters for [listDevices].
+typedef DevicesInput = ({String projectPath, ProcessRunner processRunner});
+
+typedef ProcessRunner = Future<ProcessResult> Function(
+  String executable,
+  List<String> arguments,
+);
 
 /// Result of a [listDevices] invocation.
 ///

--- a/lib/core/commands/launch/launch.dart
+++ b/lib/core/commands/launch/launch.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:fdb/constants.dart';
 import 'package:fdb/core/commands/launch/launch_models.dart';
+import 'package:fdb/core/flutter_binary.dart';
 import 'package:fdb/core/process_utils.dart';
 
 export 'package:fdb/core/commands/launch/launch_models.dart';
@@ -70,7 +71,11 @@ Future<LaunchResult> launchApp(
     File(deviceFile).writeAsStringSync(device);
 
     // Resolve the flutter binary: explicit --flutter-sdk, FVM auto-detect, or PATH.
-    final flutter = _resolveFlutter(project, flutterSdk, onProgress);
+    final flutter = resolveFlutterBinary(
+      project,
+      explicitSdk: flutterSdk,
+      onWarning: onProgress,
+    );
 
     // Resolve and persist the target platform + emulator flag for this device.
     // Used by `fdb screenshot` to dispatch to the correct capture backend.
@@ -312,38 +317,6 @@ String? _findLocalControllerEntrypoint() {
   } catch (_) {
     return null;
   }
-}
-
-// ---------------------------------------------------------------------------
-// Flutter binary resolution
-// ---------------------------------------------------------------------------
-
-/// Resolve the flutter binary path.
-///
-/// Priority:
-/// 1. Explicit --flutter-sdk path → path/bin/flutter
-/// 2. FVM auto-detect: project/.fvm/flutter_sdk/bin/flutter
-/// 3. flutter from PATH
-String _resolveFlutter(
-  String projectPath,
-  String? explicitSdk,
-  void Function(String) onProgress,
-) {
-  if (explicitSdk != null) {
-    final bin = '$explicitSdk/bin/flutter';
-    if (File(bin).existsSync()) return bin;
-    onProgress(
-      'WARNING: --flutter-sdk path not found ($bin), falling back to PATH',
-    );
-  }
-
-  // FVM stores a symlink at .fvm/flutter_sdk → sdk-version
-  final fvmBin = '$projectPath/.fvm/flutter_sdk/bin/flutter';
-  if (File(fvmBin).existsSync() || Link(fvmBin).existsSync()) {
-    return fvmBin;
-  }
-
-  return 'flutter';
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/core/flutter_binary.dart
+++ b/lib/core/flutter_binary.dart
@@ -1,0 +1,29 @@
+import 'dart:io';
+
+/// Resolve the flutter binary path for a project.
+///
+/// Priority:
+/// 1. Explicit Flutter SDK path -> `path/bin/flutter`
+/// 2. FVM auto-detect: `project/.fvm/flutter_sdk/bin/flutter`
+/// 3. `flutter` from PATH
+String resolveFlutterBinary(
+  String projectPath, {
+  String? explicitSdk,
+  void Function(String)? onWarning,
+}) {
+  if (explicitSdk != null) {
+    final bin = '$explicitSdk/bin/flutter';
+    if (File(bin).existsSync()) return bin;
+    onWarning?.call(
+      'WARNING: --flutter-sdk path not found ($bin), falling back to PATH',
+    );
+  }
+
+  // FVM stores a symlink at .fvm/flutter_sdk -> sdk-version.
+  final fvmBin = '$projectPath/.fvm/flutter_sdk/bin/flutter';
+  if (File(fvmBin).existsSync() || Link(fvmBin).existsSync()) {
+    return fvmBin;
+  }
+
+  return 'flutter';
+}

--- a/test/devices_test.dart
+++ b/test/devices_test.dart
@@ -1,0 +1,40 @@
+import 'dart:io';
+
+import 'package:fdb/core/commands/devices/devices.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('listDevices', () {
+    test('uses project-local FVM flutter when available', () async {
+      final root = await Directory.systemTemp.createTemp('fdb_devices_test_');
+      addTearDown(() async {
+        await root.delete(recursive: true);
+      });
+
+      final flutterBin = File('${root.path}/.fvm/flutter_sdk/bin/flutter')
+        ..createSync(recursive: true);
+
+      String? executable;
+      List<String>? arguments;
+      final result = await listDevices(
+        (
+          projectPath: root.path,
+          processRunner: (command, args) async {
+            executable = command;
+            arguments = args;
+            return ProcessResult(
+              1,
+              0,
+              '[{"id":"device-1","name":"Phone","targetPlatform":"ios","emulator":true}]',
+              '',
+            );
+          },
+        ),
+      );
+
+      expect(executable, flutterBin.path);
+      expect(arguments, ['devices', '--machine']);
+      expect(result, isA<DevicesListed>());
+    });
+  });
+}

--- a/test/devices_test.dart
+++ b/test/devices_test.dart
@@ -11,8 +11,7 @@ void main() {
         await root.delete(recursive: true);
       });
 
-      final flutterBin = File('${root.path}/.fvm/flutter_sdk/bin/flutter')
-        ..createSync(recursive: true);
+      final flutterBin = File('${root.path}/.fvm/flutter_sdk/bin/flutter')..createSync(recursive: true);
 
       String? executable;
       List<String>? arguments;

--- a/test/log_collector_source_test.dart
+++ b/test/log_collector_source_test.dart
@@ -248,7 +248,10 @@ Future<void> main(List<String> args) async {
   initSessionDirFromPath(args[0]);
   final manager = LogCollectorManager(logWarning: (_) {});
   await manager.start(args[1]);
-  await Future<void>.delayed(const Duration(milliseconds: 200));
+  final deadline = DateTime.now().add(const Duration(seconds: 5));
+  while (!File(logCollectorPidFile).existsSync() && DateTime.now().isBefore(deadline)) {
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+  }
   stdout.writeln('STARTED=' + File(logCollectorPidFile).existsSync().toString());
   manager.stop();
 }


### PR DESCRIPTION
fdb devices was bypassing the project-local Flutter lookup and failed inside FVM-managed repos without a global flutter on PATH. This reuses the shared Flutter binary resolver so devices follows the same FVM-or-PATH behavior as the other command paths, and adds a regression test for the FVM case.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
