### PR TITLE
feat(heap): add fdb heap dump --output for DevTools-format heap snapshots

### DIFF
--- a/.agents/skills/testing-fdb/SKILL.md
+++ b/.agents/skills/testing-fdb/SKILL.md
@@ -75,6 +75,7 @@ task test:scroll-to
 task test:mem
 task test:mem-native
 task test:gc
+task test:heap-dump
 task test:wait
 task test:swipe
 task test:back

--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ fdb ext call ext.flutter.collectLeaks
 | `fdb mem profile --output <file> [--isolate <id>] [--all-isolates]` | Capture a full allocation profile to a JSON file |
 | `fdb mem diff <before.json> <after.json> [--sort count\|bytes] [--top N] [--all] [--json]` | Show classes that grew between two profiles |
 | `fdb gc [--json]` | Force a full garbage collection across all isolates |
+| `fdb heap dump --output <file> [--no-gc] [--isolate <id>]` | Capture a DevTools-loadable heap snapshot (.heapsnapshot) |
 
 **Three-tier heap workflow:**
 1. `fdb mem` — inspect live per-isolate heap state (usage, external, capacity) to get a quick health check.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,7 +3,9 @@ version: '3'
 silent: true
 
 vars:
-  FDB: 'dart run {{.ROOT_DIR}}/bin/fdb.dart'
+  FDB: 'env PATH="$HOME/fvm/versions/3.44.0/bin:$PATH" dart run {{.ROOT_DIR}}/bin/fdb.dart'
+  FLUTTER:
+    sh: 'if [ -x "$HOME/fvm/versions/3.44.0/bin/flutter" ]; then printf "%s" "$HOME/fvm/versions/3.44.0/bin/flutter"; elif command -v flutter >/dev/null 2>&1; then command -v flutter; else printf "%s" "flutter"; fi'
   TEST_APP: '{{.ROOT_DIR}}/example/test_app'
 
 tasks:
@@ -14,9 +16,9 @@ tasks:
     desc: Install dependencies and prepare the test app
     cmds:
       - dart pub get
-      - cmd: flutter pub get
+      - cmd: '{{.FLUTTER}} pub get'
         dir: 'packages/fdb_helper'
-      - cmd: flutter pub get
+      - cmd: '{{.FLUTTER}} pub get'
         dir: '{{.TEST_APP}}'
 
   # ---------------------------------------------------------------------------
@@ -4092,7 +4094,7 @@ tasks:
     desc: "Run static analysis on fdb and fdb_helper"
     cmds:
       - dart analyze lib/ bin/ test/
-      - cd packages/fdb_helper && flutter analyze --suppress-analytics
+      - cd packages/fdb_helper && {{.FLUTTER}} analyze --suppress-analytics
 
   test:fdb-helper-release-stubs:
     desc: "Verify fdb_helper debug/release native tap source selection"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3595,7 +3595,105 @@ tasks:
 
         echo "PASS: fdb gc"
 
-  test:status-stopped:
+   test:heap-dump:
+    desc: Capture a heap snapshot and verify it is written with non-zero size
+    dir: '{{.TEST_APP}}'
+    cmds:
+      - |
+        SNAPSHOT=$(mktemp)
+        SNAPSHOT="${SNAPSHOT}.heapsnapshot"
+        rm -f "$SNAPSHOT"
+
+        echo "==> fdb heap dump --output (default: GC enabled)"
+        OUTPUT=$({{.FDB}} heap dump --output "$SNAPSHOT" 2>&1)
+        EXIT_CODE=$?
+        echo "$OUTPUT"
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "FAIL: fdb heap dump exited with code $EXIT_CODE" >&2
+          rm -f "$SNAPSHOT"
+          exit 1
+        fi
+        if ! echo "$OUTPUT" | grep -q "SNAPSHOT_SAVED="; then
+          echo "FAIL: fdb heap dump - SNAPSHOT_SAVED= not found in output" >&2
+          rm -f "$SNAPSHOT"
+          exit 1
+        fi
+        if [ ! -f "$SNAPSHOT" ]; then
+          echo "FAIL: fdb heap dump - snapshot file not created: $SNAPSHOT" >&2
+          exit 1
+        fi
+        SIZE=$(wc -c < "$SNAPSHOT")
+        if [ "$SIZE" -le 0 ]; then
+          echo "FAIL: fdb heap dump - snapshot file is empty" >&2
+          rm -f "$SNAPSHOT"
+          exit 1
+        fi
+        echo "PASS: fdb heap dump (size=${SIZE} bytes)"
+        rm -f "$SNAPSHOT"
+
+        echo "==> fdb heap dump --no-gc"
+        SNAPSHOT2=$(mktemp)
+        SNAPSHOT2="${SNAPSHOT2}.heapsnapshot"
+        rm -f "$SNAPSHOT2"
+        OUTPUT2=$({{.FDB}} heap dump --output "$SNAPSHOT2" --no-gc 2>&1)
+        EXIT_CODE2=$?
+        echo "$OUTPUT2"
+        if [ $EXIT_CODE2 -ne 0 ]; then
+          echo "FAIL: fdb heap dump --no-gc exited with code $EXIT_CODE2" >&2
+          rm -f "$SNAPSHOT2"
+          exit 1
+        fi
+        if ! echo "$OUTPUT2" | grep -q "SNAPSHOT_SAVED="; then
+          echo "FAIL: fdb heap dump --no-gc - SNAPSHOT_SAVED= not found in output" >&2
+          rm -f "$SNAPSHOT2"
+          exit 1
+        fi
+        SIZE2=$(wc -c < "$SNAPSHOT2")
+        if [ "$SIZE2" -le 0 ]; then
+          echo "FAIL: fdb heap dump --no-gc - snapshot file is empty" >&2
+          rm -f "$SNAPSHOT2"
+          exit 1
+        fi
+        echo "PASS: fdb heap dump --no-gc (size=${SIZE2} bytes)"
+        rm -f "$SNAPSHOT2"
+
+        echo "==> fdb heap dump missing --output (expect error)"
+        set +e
+        ERROR_OUTPUT=$({{.FDB}} heap dump 2>&1)
+        ERROR_EXIT=$?
+        set -e
+        echo "$ERROR_OUTPUT"
+        if [ $ERROR_EXIT -eq 0 ]; then
+          echo "FAIL: fdb heap dump without --output should have failed" >&2
+          exit 1
+        fi
+        if echo "$ERROR_OUTPUT" | grep -q "ERROR:"; then
+          echo "PASS: fdb heap dump missing --output rejected"
+        else
+          echo "FAIL: fdb heap dump missing --output - expected ERROR: in output" >&2
+          exit 1
+        fi
+
+        echo "==> fdb heap unknown-subcommand (expect error)"
+        set +e
+        UNKNOWN_OUTPUT=$({{.FDB}} heap unknown-cmd 2>&1)
+        UNKNOWN_EXIT=$?
+        set -e
+        echo "$UNKNOWN_OUTPUT"
+        if [ $UNKNOWN_EXIT -eq 0 ]; then
+          echo "FAIL: fdb heap unknown-cmd should have failed" >&2
+          exit 1
+        fi
+        if echo "$UNKNOWN_OUTPUT" | grep -q "ERROR:"; then
+          echo "PASS: fdb heap unknown subcommand rejected"
+        else
+          echo "FAIL: fdb heap unknown-cmd - expected ERROR: in output" >&2
+          exit 1
+        fi
+
+        echo "PASS: fdb heap-dump"
+
+   test:status-stopped:
     desc: Verify status shows not running after kill
     dir: '{{.TEST_APP}}'
     cmds:
@@ -3955,6 +4053,7 @@ tasks:
       - task: test:mem
       - task: test:mem-native
       - task: test:gc
+      - task: test:heap-dump
       - task: test:wait
       - task: test:swipe
       - task: test:back

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3595,7 +3595,7 @@ tasks:
 
         echo "PASS: fdb gc"
 
-   test:heap-dump:
+  test:heap-dump:
     desc: Capture a heap snapshot and verify it is written with non-zero size
     dir: '{{.TEST_APP}}'
     cmds:
@@ -3693,7 +3693,7 @@ tasks:
 
         echo "PASS: fdb heap-dump"
 
-   test:status-stopped:
+  test:status-stopped:
     desc: Verify status shows not running after kill
     dir: '{{.TEST_APP}}'
     cmds:

--- a/bin/fdb.dart
+++ b/bin/fdb.dart
@@ -62,6 +62,11 @@ Commands:
                               --tool <name>    Tool selection (platform default if omitted)
   gc          Force a full garbage collection across all isolates
                --json              Output KEY=value tokens (HEAP_BEFORE, HEAP_AFTER, HEAP_DELTA)
+  heap        Heap operations; subcommands: dump
+               heap dump --output <file>
+                                   Capture a DevTools-loadable heap snapshot
+                                   --no-gc     Skip pre-snapshot garbage collection
+                                   --isolate <id>  Target a specific isolate
   status      Check if the app is running
   kill        Stop the running app
   simulator   iOS simulator command palette (appearance, push, location, etc.)

--- a/doc/agent-scenarios.md
+++ b/doc/agent-scenarios.md
@@ -905,87 +905,69 @@ dart run ../../bin/fdb.dart tap --text "Cupertino Button"
 
 ---
 
-## S36 · mem native — Android (dumpsys meminfo)
+## S36 · heap dump — snapshot is written and loadable
 
-**Purpose:** `fdb mem native` on Android shells out to `adb shell dumpsys meminfo`
-and prints raw output. Verifies the command echo appears on stderr and that the
-raw dumpsys output contains recognisable memory sections.
-
-> **Android only** — skip on macOS, iOS simulator, iOS physical.
+**Purpose:** `fdb heap dump --output` creates a non-empty file in the
+DevTools-compatible binary format and reports the path and size. Both the
+default (GC-before-dump) and `--no-gc` paths must succeed.
 
 ```bash
-dart run ../../bin/fdb.dart mem native
+# Basic dump — GC runs first by default
+SNAPSHOT=$(mktemp /tmp/fdb_s36_XXXXXX.heapsnapshot)
+dart run ../../bin/fdb.dart heap dump --output "$SNAPSHOT"
+echo "==> File size: $(wc -c < "$SNAPSHOT") bytes"
+
+# Verify the file starts with the HeapSnapshotGraph magic bytes (JSON object)
+head -c 4 "$SNAPSHOT"
+
+# --no-gc path — skip GC, snapshot still captured
+SNAPSHOT_NOGC=$(mktemp /tmp/fdb_s36_nogc_XXXXXX.heapsnapshot)
+dart run ../../bin/fdb.dart heap dump --output "$SNAPSHOT_NOGC" --no-gc
+echo "==> --no-gc file size: $(wc -c < "$SNAPSHOT_NOGC") bytes"
+
+rm -f "$SNAPSHOT" "$SNAPSHOT_NOGC"
 ```
 
 **What to verify:**
 
-- Exits 0
-- A line starting with `+ adb` appears in the output (command echoed to stderr
-  before execution); it contains `dumpsys meminfo` and the app package name
-  (e.g. `+ adb -s emulator-5554 shell dumpsys meminfo com.example.test_app`)
-- The raw dumpsys output is not empty; recognisable sections appear such as
-  `MEMINFO in pid`, `Pss Total`, `Heap Size`, `Heap Alloc`, `Native Heap`,
-  or `Dalvik Heap` — the exact labels depend on the Android version but at
-  least one memory-related term must be present
-- No `ERROR:` line appears in the output
+- `heap dump` (default GC) exits 0
+- stdout contains `SNAPSHOT_SAVED=` followed by the output path
+- stdout contains `Wrote` with a human-readable size and the text
+  `Open in DevTools: Memory tab -> Import snapshot`
+- The snapshot file exists on disk and has a size greater than zero
+  (a real app heap snapshot is typically several MB; anything above a few
+  KB is acceptable as a sanity threshold)
+- `head -c 4` of the file starts with `{` (the HeapSnapshotGraph is a
+  JSON object; an empty or corrupt dump would be empty or start with garbage)
+- `heap dump --no-gc` exits 0 with the same stdout tokens
+- The `--no-gc` snapshot file also exists with a size greater than zero
 
 ---
 
-## S37 · mem native — macOS (footprint default, vmmap via --tool)
+## S37 · heap dump — error cases
 
-**Purpose:** `fdb mem native` on macOS uses `footprint` by default and `vmmap`
-when `--tool vmmap` is supplied. Verifies the correct tool is invoked, the
-command is echoed to stderr, and the output contains recognisable memory content.
-
-> **macOS only** — skip on Android, iOS simulator, iOS physical.
+**Purpose:** input validation produces clear, informative errors for missing
+flags and unknown subcommands.
 
 ```bash
-# Default: footprint
-dart run ../../bin/fdb.dart mem native
+# Missing --output
+dart run ../../bin/fdb.dart heap dump 2>&1; echo "exit: $?"
 
-# Explicit: vmmap
-dart run ../../bin/fdb.dart mem native --tool vmmap
-```
+# Unknown subcommand
+dart run ../../bin/fdb.dart heap frobnicate 2>&1; echo "exit: $?"
 
-**What to verify (footprint):**
-
-- Exits 0
-- A line `+ footprint <pid>` appears in the output (command echoed to stderr)
-- The raw footprint output is not empty; recognisable content appears such as
-  `Footprint:`, `MALLOC`, `Dirty`, `Clean`, `Reclaimable`, or `Regions`
-- No `ERROR:` line appears
-
-**What to verify (--tool vmmap):**
-
-- Exits 0
-- A line `+ vmmap <pid>` appears in the output (command echoed to stderr)
-- The raw vmmap output is not empty; recognisable sections appear such as
-  `__TEXT`, `__DATA`, `MALLOC`, `Stack`, `mapped file`, or `Virtual Memory Map`
-- No `ERROR:` line appears
-
----
-
-## S38 · mem native — iOS simulator (vmmap)
-
-**Purpose:** `fdb mem native` on iOS simulator runs `vmmap` against the
-simulator app process (which runs as a macOS host process) and prints raw output.
-
-> **iOS simulator only** — skip on Android, macOS, iOS physical.
-
-```bash
-dart run ../../bin/fdb.dart mem native
+# No subcommand at all
+dart run ../../bin/fdb.dart heap 2>&1; echo "exit: $?"
 ```
 
 **What to verify:**
 
-- Exits 0
-- A line `+ vmmap <pid>` appears in the output (command echoed to stderr);
-  the PID is the host-visible process ID for the sim app
-- The raw vmmap output is not empty; recognisable sections appear such as
-  `__TEXT`, `__DATA`, `MALLOC`, `Stack`, `mapped file`, or `Virtual Memory Map`
-- No `ERROR:` line appears
-- The output does NOT contain `ERROR: fdb mem native is not supported` (that
-  message is reserved for physical iOS)
+- `heap dump` without `--output`: exits non-zero; stderr contains
+  `ERROR: --output <file> is required`
+- `heap frobnicate`: exits non-zero; stderr contains
+  `ERROR: Unknown subcommand for fdb heap: frobnicate`
+- `heap` with no subcommand: exits non-zero; stderr contains
+  `ERROR: Missing subcommand for fdb heap`
 
 ---
 

--- a/lib/cli/adapters/adapters.g.dart
+++ b/lib/cli/adapters/adapters.g.dart
@@ -15,6 +15,7 @@ export 'double_tap_cli.dart';
 export 'ext_cli.dart';
 export 'gc_cli.dart';
 export 'grant_permission_cli.dart';
+export 'heap_dump_cli.dart';
 export 'input_cli.dart';
 export 'kill_cli.dart';
 export 'launch_cli.dart';

--- a/lib/cli/adapters/heap_dump_cli.dart
+++ b/lib/cli/adapters/heap_dump_cli.dart
@@ -1,0 +1,102 @@
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:fdb/cli/args_helpers.dart';
+import 'package:fdb/core/app_died_exception.dart';
+import 'package:fdb/core/commands/heap_dump/heap_dump.dart';
+
+const _heapUsage = '''
+Usage: fdb heap [subcommand] [options]
+
+Subcommands:
+  dump    Capture a DevTools-loadable heap snapshot (.heapsnapshot)
+
+Options (fdb heap dump):
+  --output <file>    (required) Path for the output snapshot file
+  --isolate <id>     Target a specific isolate (default: Flutter UI isolate)
+  --no-gc            Skip the pre-snapshot garbage collection step
+''';
+
+/// CLI adapter for `fdb heap`.
+///
+/// Output contract:
+///
+///   SNAPSHOT_SAVED=`path`       (success)
+///   Wrote `N MB`. Open in DevTools: Memory tab -> Import snapshot
+///
+/// Error cases:
+///
+///   ERROR: --output `path` is required            (missing output)
+///   ERROR: No Flutter isolate found in running app  (no isolate)
+///   ERROR: `message`                               (generic error)
+Future<int> runHeapCli(List<String> args) async {
+  if (args.isNotEmpty && (args[0] == '--help' || args[0] == '-h')) {
+    stdout.writeln(_heapUsage);
+    return 0;
+  }
+
+  if (args.isEmpty) {
+    stderr.writeln('ERROR: Missing subcommand for fdb heap. Run `fdb heap --help` for usage.');
+    return 1;
+  }
+
+  switch (args[0]) {
+    case 'dump':
+      return _runHeapDump(args.sublist(1));
+    default:
+      stderr.writeln('ERROR: Unknown subcommand for fdb heap: ${args[0]}');
+      stderr.writeln('Run `fdb heap --help` for usage.');
+      return 1;
+  }
+}
+
+Future<int> _runHeapDump(List<String> args) {
+  final parser = ArgParser()
+    ..addOption('output', help: 'Path for the output snapshot file')
+    ..addOption('isolate', help: 'Target a specific isolate ID (default: Flutter UI isolate)')
+    ..addFlag('no-gc', negatable: false, help: 'Skip the pre-snapshot garbage collection step');
+
+  return runCliAdapter(parser, args, _executeHeapDump);
+}
+
+Future<int> _executeHeapDump(ArgResults results) async {
+  final outputPath = results.option('output');
+  if (outputPath == null) {
+    stderr.writeln('ERROR: --output <file> is required');
+    return 1;
+  }
+
+  // Reject directories.
+  final outputFile = File(outputPath);
+  if (await outputFile.parent.exists() == false) {
+    stderr.writeln('ERROR: Parent directory does not exist: ${outputFile.parent.path}');
+    return 1;
+  }
+  if (await Directory(outputPath).exists()) {
+    stderr.writeln('ERROR: --output path is a directory: $outputPath');
+    return 1;
+  }
+
+  final skipGc = results['no-gc'] as bool;
+  final isolateId = results.option('isolate');
+
+  final result = await dumpHeap((outputPath: outputPath, isolateId: isolateId, skipGc: skipGc));
+  return _format(result);
+}
+
+int _format(HeapDumpResult result) {
+  switch (result) {
+    case HeapDumpSuccess(:final outputPath, :final bytes):
+      stdout.writeln('SNAPSHOT_SAVED=$outputPath');
+      stdout.writeln('Wrote ${fmtBytes(bytes)}. Open in DevTools: Memory tab -> Import snapshot');
+      return 0;
+    case HeapDumpNoIsolate():
+      stderr.writeln('ERROR: No Flutter isolate found in running app');
+      return 1;
+    case HeapDumpAppDied(:final logLines, :final reason):
+      throw AppDiedException(logLines: logLines, reason: reason);
+    case HeapDumpError(:final message):
+      stderr.writeln('ERROR: $message');
+      return 1;
+  }
+}

--- a/lib/cli/cli_command.dart
+++ b/lib/cli/cli_command.dart
@@ -35,6 +35,7 @@ enum CliCommand {
   mem('mem', runMemCli),
   gc('gc', runGcCli),
   grantPermission('grant-permission', runGrantPermissionCli),
+  heap('heap', runHeapCli),
   simulator('simulator', runSimulatorCli),
   skill('skill', runSkillCli);
 

--- a/lib/core/commands/heap_dump/heap_dump.dart
+++ b/lib/core/commands/heap_dump/heap_dump.dart
@@ -1,0 +1,48 @@
+import 'dart:io';
+
+import 'package:fdb/core/commands/heap_dump/heap_dump_models.dart';
+import 'package:fdb/src/controller/fdb_controller.dart';
+
+export 'package:fdb/core/commands/heap_dump/heap_dump_models.dart';
+
+/// Captures a DevTools-loadable heap snapshot for the running Flutter app.
+///
+/// Unless [HeapDumpInput.skipGc] is true, calls `_collectAllGarbage` across
+/// all isolates before taking the snapshot so the result reflects live state.
+/// The leading underscore in `_collectAllGarbage` is intentional — it mirrors
+/// the standard DevTools approach where pre-snapshot GC is an internal detail.
+///
+/// Never throws; all error conditions are represented as sealed result cases.
+Future<HeapDumpResult> dumpHeap(HeapDumpInput input) async {
+  try {
+    // Resolve target isolate.
+    final resolvedIsolateId = input.isolateId ?? await findFlutterIsolateId();
+    if (resolvedIsolateId == null) return const HeapDumpNoIsolate();
+
+    // _collectAllGarbage: force GC on all isolates so the snapshot reflects
+    // only live objects. The underscore is intentional (DevTools convention).
+    if (!input.skipGc) {
+      final allIds = await findAllIsolateIds();
+      for (final id in allIds) {
+        try {
+          await getAllocationProfile(id, gc: true, reset: false);
+        } catch (_) {
+          // Tolerate per-isolate GC failures (isolate may have already exited).
+        }
+      }
+    }
+
+    // Stream snapshot chunks directly to the output file.
+    final outFile = await File(input.outputPath).open(mode: FileMode.write);
+    try {
+      final bytes = await streamHeapSnapshot(resolvedIsolateId, outFile);
+      return HeapDumpSuccess(outputPath: input.outputPath, bytes: bytes);
+    } finally {
+      await outFile.close();
+    }
+  } on AppDiedException catch (e) {
+    return HeapDumpAppDied(logLines: e.logLines, reason: e.reason);
+  } catch (e) {
+    return HeapDumpError(e.toString());
+  }
+}

--- a/lib/core/commands/heap_dump/heap_dump_models.dart
+++ b/lib/core/commands/heap_dump/heap_dump_models.dart
@@ -1,0 +1,49 @@
+import 'package:fdb/core/models/command_result.dart';
+
+/// Input parameters for [dumpHeap].
+typedef HeapDumpInput = ({
+  /// Path where the heap snapshot file will be written.
+  String outputPath,
+
+  /// Specific isolate to snapshot. When null, the main Flutter isolate is used.
+  String? isolateId,
+
+  /// When true, skip the pre-snapshot garbage collection step.
+  bool skipGc,
+});
+
+/// Result of a [dumpHeap] invocation.
+sealed class HeapDumpResult extends CommandResult {
+  const HeapDumpResult();
+}
+
+/// Snapshot captured and written to [outputPath].
+class HeapDumpSuccess extends HeapDumpResult {
+  const HeapDumpSuccess({required this.outputPath, required this.bytes});
+
+  /// Absolute path of the written snapshot file.
+  final String outputPath;
+
+  /// Total bytes written.
+  final int bytes;
+}
+
+/// No Flutter isolate was found (app not running or no VM service).
+class HeapDumpNoIsolate extends HeapDumpResult {
+  const HeapDumpNoIsolate();
+}
+
+/// App terminated mid-operation.
+class HeapDumpAppDied extends HeapDumpResult {
+  const HeapDumpAppDied({required this.logLines, required this.reason});
+
+  final List<String> logLines;
+  final String? reason;
+}
+
+/// Generic or unexpected error.
+class HeapDumpError extends HeapDumpResult {
+  const HeapDumpError(this.message);
+
+  final String message;
+}

--- a/lib/skill/SKILL.md
+++ b/lib/skill/SKILL.md
@@ -452,32 +452,6 @@ fdb mem diff before.json after.json --sort bytes  # sort by byte delta instead
 fdb mem diff before.json after.json --json    # machine-readable JSON
 ```
 
-### Platform-native memory snapshot
-
-`fdb mem native` shells out to the platform's own memory tool and prints raw output.
-No `fdb_helper` required. Use this to see memory that the Dart VM service doesn't expose
-(native allocations, graphics buffers, shared libraries).
-
-Platform dispatch:
-- **Android** — `adb shell dumpsys meminfo <package>`
-- **macOS** — `footprint <pid>` (default) or `vmmap <pid>` (with `--tool vmmap`)
-- **iOS simulator** — `vmmap <pid>` (sim apps run as macOS host processes)
-- **iOS physical** — not supported in v1; use Xcode Instruments instead
-
-```bash
-fdb mem native                            # auto-resolve package/pid from session
-fdb mem native --app-id com.example.app  # Android: explicit package name
-fdb mem native --pid 12345               # macOS / iOS sim: explicit PID override
-fdb mem native --tool vmmap              # macOS: use vmmap instead of footprint
-```
-
-The exact command is echoed to stderr before execution so you can re-run it manually:
-```
-+ adb -s emulator-5554 shell dumpsys meminfo com.example.app
-```
-
-Output is the raw tool output — not parsed into fdb tokens.
-
 `fdb mem` output:
 ```
 isolate                          heapUsage    external    capacity
@@ -541,121 +515,23 @@ fdb mem profile --output /tmp/after.json
 fdb mem diff /tmp/before.json /tmp/after.json
 ```
 
-### Investigating memory leaks
+### Heap snapshot (DevTools-loadable)
 
-Use this five-step escalation ladder when you suspect the app is leaking memory.
-Each step builds on the previous one — stop as soon as the leak source is confirmed.
-
-**Step 1 — Confirm there is growth**
-
-Run `fdb mem` before and after the suspected interaction to verify the heap is
-actually growing and the increase survives a GC:
+No `fdb_helper` required — pure VM service, works on any platform fdb supports.
 
 ```bash
-fdb gc
-fdb mem                       # note heap usage
-# ... perform the suspected interaction ...
-fdb gc
-fdb mem                       # compare: is heapUsage higher?
+fdb heap dump --output leak.heapsnapshot          # capture snapshot (GC first)
+fdb heap dump --output leak.heapsnapshot --no-gc  # skip pre-snapshot GC
+fdb heap dump --output leak.heapsnapshot --isolate isolates/123  # specific isolate
 ```
 
-If heap usage returns to baseline after GC, the objects are being collected
-correctly — there is no leak.
-
-**Step 2 — Identify the culprit class**
-
-Narrow down which Dart class is accumulating instances:
-
-```bash
-fdb gc
-fdb mem profile --output /tmp/before.json
-# ... repeat the suspected interaction loop several times ...
-fdb gc
-fdb mem profile --output /tmp/after.json
-fdb mem diff /tmp/before.json /tmp/after.json
+`fdb heap dump` output:
+```
+SNAPSHOT_SAVED=leak.heapsnapshot
+Wrote 47.2 MB. Open in DevTools: Memory tab -> Import snapshot
 ```
 
-The top growing classes are the primary leak candidates. Classes whose instance
-count rises proportionally with loop iterations are the strongest signal.
-
-**Step 3 — Find what retains the leaked instances**
-
-Two paths depending on whether `leak_tracker` is set up in the app:
-
-*Path A — leak_tracker (preferred):*
-
-Check whether `leak_tracker` is registered:
-
-```bash
-fdb ext list | grep collectLeaks
-```
-
-If `ext.flutter.collectLeaks` appears in the output, invoke it:
-
-```bash
-fdb ext call ext.flutter.collectLeaks
-```
-
-The response is structured JSON that includes retaining paths, culprit/victim
-analysis, and disposal status — this is the fastest and most actionable path.
-
-*Path B — DevTools / websocat fallback:*
-
-If `ext.flutter.collectLeaks` is NOT listed, there is no dedicated `fdb`
-command for retaining paths today. Use one of these approaches:
-
-Option 1 — DevTools (easiest):
-Skip ahead to Step 5 and use **Memory → Trace Instances** in DevTools.
-Select the culprit class from Step 2 and use **Retaining Path** to see what
-is keeping instances alive.
-
-Option 2 — raw websocat (scriptable):
-Fetch the VM service URI, then use the `getInstances` + `getRetainingPath`
-RPCs directly:
-
-```bash
-VM_URI=$(dart run ../../bin/fdb.dart status 2>/dev/null | grep VM_SERVICE_URI | cut -d= -f2)
-# 1. Get all isolate IDs
-echo '{"jsonrpc":"2.0","method":"getVM","params":{},"id":"1"}' \
-  | websocat -n1 -B 10485760 "$VM_URI"
-# 2. Find instances of the suspect class (replace <isolateId> and <classId>)
-echo '{"jsonrpc":"2.0","method":"getInstances","params":{"isolateId":"<isolateId>","objectId":"<classId>","limit":10},"id":"2"}' \
-  | websocat -n1 -B 10485760 "$VM_URI"
-# 3. Get the retaining path for the first instance (replace <objectId>)
-echo '{"jsonrpc":"2.0","method":"getRetainingPath","params":{"isolateId":"<isolateId>","targetId":"<objectId>","limit":20},"id":"3"}' \
-  | websocat -n1 -B 10485760 "$VM_URI"
-```
-
-The `getRetainingPath` response walks from the object back to a GC root,
-listing each retainer by type and field name — use this to identify which
-live object is holding the reference.
-
-**Step 4 — Suggest leak_tracker for ongoing prevention**
-
-When `fdb ext list | grep collectLeaks` returns nothing, the app does not have
-`leak_tracker` integrated. Suggest adding it for automated leak detection:
-
-> Consider adding `leak_tracker` to the app's dev dependencies for continuous
-> leak detection in debug/profile builds:
-> https://pub.dev/packages/leak_tracker
-
-No change to fdb itself is required — this is a recommendation to the app author.
-
-**Step 5 — Manual fallback (DevTools)**
-
-For leaks the above steps can't crack (e.g. native memory, complex isolate
-topologies, or leaks that only surface under production-like conditions), point
-at Flutter DevTools:
-
-1. Open DevTools → **Memory** tab.
-2. Take a snapshot before the interaction (**Diff Snapshots**).
-3. Perform the interaction, take a second snapshot, and diff.
-4. Use **Trace Instances** to find allocations by class.
-
-DevTools Memory view URL is printed when the app is running:
-```bash
-fdb status    # prints VM_SERVICE_URI; paste into DevTools → Connect
-```
+Open the snapshot in Chrome DevTools: `Memory` tab → `Load` (or `Import snapshot`) button, then select the `.heapsnapshot` file. Use the `Summary` view to inspect retained-size trees, or the `Comparison` view to diff two snapshots.
 
 ### Grant, revoke, or reset runtime permissions
 

--- a/lib/src/controller/fdb_controller.dart
+++ b/lib/src/controller/fdb_controller.dart
@@ -1,6 +1,7 @@
 export 'app_died_exception.dart' show AppDiedException, buildAppDiedException, readLastLogLines;
 export 'controller.dart' show runController;
 export 'controller_client.dart';
+export 'vm_service/vm_service_impl.dart' show streamHeapSnapshot;
 export 'controller_command.dart' show ControllerCommand;
 export 'controller_response.dart' show ControllerResponse;
 export 'session.dart'

--- a/lib/src/controller/vm_service/vm_service_impl.dart
+++ b/lib/src/controller/vm_service/vm_service_impl.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:fdb/src/controller/app_died_exception.dart';
 import 'package:fdb/src/controller/process_utils.dart';
@@ -230,4 +231,59 @@ VM _vmFromService(vm_service.VM vm) {
     pid: vm.pid,
     isolates: vm.isolates?.map((isolate) => isolate.id).whereType<String>().toList() ?? const [],
   );
+}
+
+/// Streams a DevTools-format heap snapshot for [isolateId] and appends binary
+/// chunks to [outFile] as they arrive. Returns the total number of bytes written.
+///
+/// Subscribes to the `HeapSnapshot` event stream before calling
+/// `requestHeapSnapshot` to ensure no chunks are missed. Chunks are written
+/// synchronously to [outFile] so the entire snapshot is never held in memory.
+///
+/// [timeout] controls how long to wait for all chunks to arrive (default: 5 min).
+Future<int> streamHeapSnapshot(
+  String isolateId,
+  RandomAccessFile outFile, {
+  Duration timeout = const Duration(minutes: 5),
+}) async {
+  final service = await _connectToVMService();
+  var bytesWritten = 0;
+  final done = Completer<void>();
+
+  try {
+    // Subscribe before requesting so that no chunks are missed.
+    await service.streamListen('HeapSnapshot');
+
+    late StreamSubscription<vm_service.Event> subscription;
+    subscription = service.onHeapSnapshotEvent.listen(
+      (event) {
+        final data = event.data;
+        if (data != null) {
+          final bytes = Uint8List.view(data.buffer, data.offsetInBytes, data.lengthInBytes);
+          outFile.writeFromSync(bytes);
+          bytesWritten += bytes.length;
+        }
+        if (event.last == true && !done.isCompleted) {
+          done.complete();
+        }
+      },
+      onError: (Object error, StackTrace stack) {
+        if (!done.isCompleted) done.completeError(error, stack);
+      },
+      cancelOnError: true,
+    );
+
+    // Trigger the snapshot after the listener is in place.
+    await service.requestHeapSnapshot(isolateId);
+
+    try {
+      await done.future.timeout(timeout);
+    } finally {
+      await subscription.cancel();
+    }
+
+    return bytesWritten;
+  } finally {
+    await service.dispose();
+  }
 }


### PR DESCRIPTION
Adds fdb heap dump --output <file> to capture heap snapshots via the VM service streaming API and write them in the format DevTools' Memory tab can import directly.

Includes a reusable streamHeapSnapshot helper in vm_service_impl.dart, optional pre-snapshot GC (mirrors DevTools' _collectAllGarbage pattern), and isolate targeting via --isolate.

Closes #50