### PR TITLE
chore: bump version to 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 1.9.0
+
+### New commands
+- `fdb attach` now auto-discovers the VM service URI from device logs on Android and iOS — no `--debug-url` needed. Android uses `adb logcat`; iOS Simulator uses `xcrun simctl` log; physical iOS uses `idevicesyslog` archive lookback. Falls back to mDNS when discovery returns null.
+- Adding `fdb_helper` to the app enables the `[FDB_VM_URI]` log marker, which fdb prefers over Flutter's own output for more reliable auto-discovery.
+
+### Improvements
+- `fdb skill` now prints a compact core (~60 lines) instead of the full 800-line reference. Full docs are split into 6 topic sub-documents loaded on demand: `fdb skill launch`, `fdb skill interact`, `fdb skill data`, `fdb skill diagnostics`, `fdb skill memory`, `fdb skill simulator`. Each sub-doc includes a best-practices section.
+
+### Fixes
+- Smoke tests replaced timing-based sleeps with deterministic app-state checks to fix intermittent failures on Android.
+
 ## 1.8.0
 
 ### New commands

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ Requires `fdb_helper` in your app. Adding it also enables automatic VM service U
 ```yaml
 # pubspec.yaml
 dev_dependencies:
-  fdb_helper: ^1.8.0
+  fdb_helper: ^1.9.0
 ```
 
 ```dart

--- a/example/example.md
+++ b/example/example.md
@@ -36,7 +36,7 @@ Add `fdb_helper` to your Flutter app for tap, input, scroll commands:
 ```yaml
 # pubspec.yaml
 dev_dependencies:
-  fdb_helper: ^1.8.0
+  fdb_helper: ^1.9.0
 ```
 
 ```dart

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'package:fdb/src/controller/session.dart' as controller;
 
 /// fdb version — update this AND pubspec.yaml on every release.
-const version = '1.8.0';
+const version = '1.9.0';
 
 const sessionDirName = controller.sessionDirName;
 

--- a/lib/skill/SKILL.md
+++ b/lib/skill/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: opencode
 ---
 
-## Overview - skill version 1.8.0
+## Overview - skill version 1.9.0
 
 > **Version check:** Run `fdb --version`. This skill may describe unreleased branch behavior.
 > Update: `dart pub global activate --source git https://github.com/andrzejchm/fdb.git`
@@ -25,7 +25,7 @@ The `describe`, `tap`, `double-tap`, `longpress`, `input`, `scroll`, `scroll-to`
 **`pubspec.yaml`:**
 ```yaml
 dev_dependencies:
-  fdb_helper: ^1.8.0
+  fdb_helper: ^1.9.0
 ```
 
 **`main.dart`:**

--- a/packages/fdb_helper/CHANGELOG.md
+++ b/packages/fdb_helper/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.9.0
+
+### Improvements
+- `FdbBinding.ensureInitialized()` now calls `broadcastVmUri()` at startup, emitting a `[FDB_VM_URI]` log marker that `fdb attach` uses for reliable auto-discovery on Android and iOS without needing `--debug-url`.
+- `broadcastVmUri()` calls `Service.controlWebServer(enable: true)` when `getInfo()` returns null, enabling discovery in profile builds launched without Flutter tooling.
+
 ## 1.8.0
 
 ### Improvements

--- a/packages/fdb_helper/pubspec.yaml
+++ b/packages/fdb_helper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fdb_helper
 description: Helper package for fdb (Flutter Debug Bridge). Registers VM service extensions for widget interaction, SharedPreferences access, and app data cleanup.
-version: 1.8.0
+version: 1.9.0
 repository: https://github.com/andrzejchm/fdb
 homepage: https://pub.dev/packages/fdb
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: fdb
-version: 1.8.0
+version: 1.9.0
 description: Flutter Debug Bridge - CLI for AI agents to interact with running Flutter apps on device. Launch, reload, screenshot, inspect widget tree, filter logs.
 repository: https://github.com/andrzejchm/fdb
 environment:


### PR DESCRIPTION
Version bump for the 1.9.0 release. Covers fdb attach auto-discovery (#149) and fdb skill topic split (#150).