### PR TITLE
fix: Windows compatibility for which/where, sigterm.watch, and PID liveness

### DIFF
--- a/CODE-STYLE.md
+++ b/CODE-STYLE.md
@@ -82,6 +82,23 @@ Split files only when the consolidated command file becomes hard to read.
 - Null-check every external read (files, JSON fields, process output).
 - `bin/fdb.dart` has a top-level catch-all for unexpected exceptions.
 
+## Cross-platform host support
+
+fdb runs as a host process on macOS, Linux, and Windows (separate from the *target device
+platform*, which is read from `.fdb/platform.txt`). Do not shell out directly to POSIX-only
+tools or assume POSIX signal semantics:
+
+- Checking whether a tool is on `PATH`: use `isToolOnPath()` from `lib/core/process_utils.dart`
+  (dispatches to `where` on Windows, `which` elsewhere). Do not add another private
+  `_isToolOnPath`/`Process.runSync('which', ...)` copy.
+- Checking whether a PID is alive: use `isProcessAlive()` from `lib/core/process_utils.dart`
+  (dispatches to `tasklist` on Windows, `kill -0` elsewhere). Do not shell out to `kill -0`
+  directly.
+- `ProcessSignal.sigterm.watch()` (and `sigusr1`/`sigusr2`/`sigwinch`) throws a synchronous,
+  unhandled exception on Windows — the Dart VM does not support watching them there. Guard any
+  new `.watch()` call on one of these signals with `if (!Platform.isWindows)`. `sigint` (Ctrl-C)
+  is watchable on all three platforms.
+
 ## Doc comments
 
 - `///` on non-trivial public functions only.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ dart pub global activate fdb
 
 Requires Dart SDK >= 3.0.0. Make sure `~/.pub-cache/bin` is in your `PATH`.
 
+Runs on macOS, Linux, and Windows. Windows support is newer and less battle-tested than
+macOS/Linux — see [Troubleshooting](#troubleshooting) if `fdb launch`/`fdb kill` behave
+unexpectedly on Windows.
+
 **Or from git (latest main):**
 
 ```bash
@@ -372,6 +376,8 @@ Release builds compile a safe `fdb_helper` stub on Android, iOS, and macOS, so A
 **Widget interaction fails** - `fdb_helper` missing from `pubspec.yaml`, or `FdbBinding.ensureInitialized()` not called.
 
 **Agent setup fails mid-flow** - Run `fdb doctor` to check app process, VM service reachability, `fdb_helper`, platform tools, and stored device state before continuing.
+
+**Running fdb itself on Windows** - fdb resolves platform tools (`adb`, `xcrun`, etc.) via `where` instead of `which`, and probes process liveness via `tasklist` instead of `kill -0`. `Ctrl-C` (SIGINT) is handled during `fdb launch`/`fdb attach`; graceful SIGTERM shutdown is not available on Windows (Dart itself doesn't support watching it there) — `fdb kill`/`fdb launch`'s cleanup falls back to a forceful terminate. This is newer, less-tested territory than macOS/Linux; please file an issue with the exact command and error if something doesn't work.
 
 ## Contributing
 

--- a/bin/log_collector.dart
+++ b/bin/log_collector.dart
@@ -18,7 +18,12 @@ Future<void> main(List<String> args) async {
     exit(0);
   }
 
-  ProcessSignal.sigterm.watch().listen((_) => cleanup());
+  // ProcessSignal.sigterm.watch() throws a synchronous SignalException on
+  // Windows (sigterm/sigusr1/sigusr2/sigwinch are not watchable there).
+  // Skip it on Windows; sigint (Ctrl-C) below still works.
+  if (!Platform.isWindows) {
+    ProcessSignal.sigterm.watch().listen((_) => cleanup());
+  }
   ProcessSignal.sigint.watch().listen((_) => cleanup());
 
   try {

--- a/lib/core/commands/attach/attach.dart
+++ b/lib/core/commands/attach/attach.dart
@@ -111,10 +111,15 @@ Future<AttachResult> attachApp(
       _killPid(controllerProcess.pid);
       exit(1);
     });
-    final sigtermSub = ProcessSignal.sigterm.watch().listen((_) {
-      _killPid(controllerProcess.pid);
-      exit(1);
-    });
+    // ProcessSignal.sigterm.watch() throws a synchronous SignalException on
+    // Windows (sigterm/sigusr1/sigusr2/sigwinch are not watchable there).
+    // Skip it on Windows; sigint (Ctrl-C) above still works.
+    final sigtermSub = Platform.isWindows
+        ? null
+        : ProcessSignal.sigterm.watch().listen((_) {
+            _killPid(controllerProcess.pid);
+            exit(1);
+          });
 
     final stopwatch = Stopwatch()..start();
     var lastHeartbeat = 0;
@@ -178,7 +183,7 @@ Future<AttachResult> attachApp(
       );
     } finally {
       await sigintSub.cancel();
-      await sigtermSub.cancel();
+      await sigtermSub?.cancel();
     }
   } catch (e) {
     return AttachError(e.toString());

--- a/lib/core/commands/attach/vm_uri_discovery.dart
+++ b/lib/core/commands/attach/vm_uri_discovery.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:fdb/core/process_utils.dart';
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -57,7 +59,7 @@ Future<String?> _discoverAndroid({
   required Duration timeout,
   required void Function(String) onProgress,
 }) async {
-  if (!_isToolOnPath('adb')) return null;
+  if (!isToolOnPath('adb')) return null;
   onProgress('attach: scanning Android logcat for VM service URI');
   try {
     // Dump the current logcat buffer for the flutter tag only.
@@ -93,7 +95,7 @@ Future<String?> _discoverIosSimulator({
   required Duration timeout,
   required void Function(String) onProgress,
 }) async {
-  if (!_isToolOnPath('xcrun')) return null;
+  if (!isToolOnPath('xcrun')) return null;
   onProgress('attach: scanning iOS Simulator log for VM service URI');
   try {
     // Try the last 5 minutes of the unified log with a predicate filter.
@@ -138,7 +140,7 @@ Future<String?> _discoverIosPhysical({
   required Duration timeout,
   required void Function(String) onProgress,
 }) async {
-  if (!_isToolOnPath('idevicesyslog')) return null;
+  if (!isToolOnPath('idevicesyslog')) return null;
   onProgress('attach: scanning physical iOS device log for VM service URI');
 
   final tmpDir = Directory.systemTemp.createTempSync('fdb_ios_log_');
@@ -247,17 +249,4 @@ String? _normalizeUri(String uri) {
   if (normalized.endsWith('/ws/')) return normalized.substring(0, normalized.length - 3);
   if (normalized.endsWith('/ws')) return normalized.substring(0, normalized.length - 2);
   return normalized;
-}
-
-// ---------------------------------------------------------------------------
-// Utility
-// ---------------------------------------------------------------------------
-
-bool _isToolOnPath(String tool) {
-  try {
-    final result = Process.runSync('which', [tool]);
-    return result.exitCode == 0;
-  } catch (_) {
-    return false;
-  }
 }

--- a/lib/core/commands/crash_report/crash_report.dart
+++ b/lib/core/commands/crash_report/crash_report.dart
@@ -56,7 +56,7 @@ Future<CrashReportResult> _runAndroid({
   required String? appId,
   required CrashReportInput input,
 }) async {
-  if (!_isToolOnPath('adb')) {
+  if (!isToolOnPath('adb')) {
     return const CrashReportToolMissing(
       tool: 'adb',
       hint: 'Install Android SDK platform-tools and ensure adb is on PATH.',
@@ -116,7 +116,7 @@ Future<CrashReportResult> _runIosSimulator({
   required String? appId,
   required CrashReportInput input,
 }) async {
-  if (!_isToolOnPath('xcrun')) {
+  if (!isToolOnPath('xcrun')) {
     return const CrashReportToolMissing(
       tool: 'xcrun',
       hint: 'Install Xcode command-line tools: xcode-select --install',
@@ -187,7 +187,7 @@ Future<CrashReportResult> _runIosPhysical({
   required String? appId,
   required CrashReportInput input,
 }) async {
-  if (!_isToolOnPath('idevicecrashreport')) {
+  if (!isToolOnPath('idevicecrashreport')) {
     return const CrashReportToolMissing(
       tool: 'idevicecrashreport',
       hint: 'Install: brew install libimobiledevice',
@@ -238,7 +238,7 @@ Future<CrashReportResult> _runMacos({
   required String? appId,
   required CrashReportInput input,
 }) async {
-  if (!_isToolOnPath('log')) {
+  if (!isToolOnPath('log')) {
     return const CrashReportToolMissing(
       tool: 'log',
       hint: 'This is unexpected on macOS — ensure /usr/bin is on PATH.',
@@ -293,16 +293,6 @@ Future<CrashReportResult> _runMacos({
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/// Returns true if [tool] can be found via `which`.
-bool _isToolOnPath(String tool) {
-  try {
-    final result = Process.runSync('which', [tool]);
-    return result.exitCode == 0;
-  } catch (_) {
-    return false;
-  }
-}
 
 /// Returns only lines containing [substring].
 String _filterLines(String text, String substring) =>

--- a/lib/core/commands/doctor/doctor.dart
+++ b/lib/core/commands/doctor/doctor.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:fdb/core/commands/doctor/doctor_models.dart';
 import 'package:fdb/core/commands/status/status.dart';
 import 'package:fdb/src/controller/fdb_controller.dart';
@@ -132,8 +130,7 @@ Future<({List<String> present, List<String> missing})> _checkPlatformTools() asy
   final missing = <String>[];
 
   for (final tool in ['adb', 'xcrun', 'screencapture']) {
-    final result = await Process.run('which', [tool]);
-    if (result.exitCode == 0) {
+    if (isToolOnPath(tool)) {
       present.add(tool);
     } else {
       missing.add(tool);

--- a/lib/core/commands/launch/launch.dart
+++ b/lib/core/commands/launch/launch.dart
@@ -123,12 +123,17 @@ Future<LaunchResult> launchApp(
       } catch (_) {}
       exit(1);
     });
-    final sigtermSub = ProcessSignal.sigterm.watch().listen((_) {
-      try {
-        Process.killPid(controllerProcess.pid, ProcessSignal.sigterm);
-      } catch (_) {}
-      exit(1);
-    });
+    // ProcessSignal.sigterm.watch() throws a synchronous SignalException on
+    // Windows (sigterm/sigusr1/sigusr2/sigwinch are not watchable there).
+    // Skip it on Windows; sigint (Ctrl-C) above still works.
+    final sigtermSub = Platform.isWindows
+        ? null
+        : ProcessSignal.sigterm.watch().listen((_) {
+            try {
+              Process.killPid(controllerProcess.pid, ProcessSignal.sigterm);
+            } catch (_) {}
+            exit(1);
+          });
 
     // Poll log file for VM service URI.
     final stopwatch = Stopwatch()..start();
@@ -151,7 +156,7 @@ Future<LaunchResult> launchApp(
         }
 
         // Check if the controller process died unexpectedly.
-        if (!_isAlive(controllerProcess.pid)) {
+        if (!isProcessAlive(controllerProcess.pid)) {
           final logExists = File(logFile).existsSync();
           if (logExists) {
             final logContent = File(logFile).readAsStringSync();
@@ -198,7 +203,7 @@ Future<LaunchResult> launchApp(
       );
     } finally {
       await sigintSub.cancel();
-      await sigtermSub.cancel();
+      await sigtermSub?.cancel();
     }
   } catch (e) {
     return LaunchError(e.toString());
@@ -750,18 +755,5 @@ void ensureGitignored(String projectPath) {
     );
   } else {
     gitignore.writeAsStringSync('# fdb session state\n.fdb/\n');
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-bool _isAlive(int pid) {
-  try {
-    final result = Process.runSync('kill', ['-0', pid.toString()]);
-    return result.exitCode == 0;
-  } catch (_) {
-    return false;
   }
 }

--- a/lib/core/commands/mem/mem.dart
+++ b/lib/core/commands/mem/mem.dart
@@ -309,7 +309,7 @@ Future<MemNativeResult> _runAndroid({
     );
   }
 
-  if (!_isToolOnPath('adb')) {
+  if (!isToolOnPath('adb')) {
     return const MemNativeToolMissing(
       tool: 'adb',
       hint: 'Install Android SDK platform-tools and ensure adb is on PATH.',
@@ -348,7 +348,7 @@ Future<MemNativeResult> _runIosSimulator({
     );
   }
 
-  if (!_isToolOnPath('vmmap')) {
+  if (!isToolOnPath('vmmap')) {
     return const MemNativeToolMissing(
       tool: 'vmmap',
       hint: 'vmmap is bundled with Xcode command-line tools: xcode-select --install',
@@ -380,7 +380,7 @@ Future<MemNativeResult> _runMacos({
     return MemNativeError('Unknown tool "$toolName". Supported tools on macOS: footprint, vmmap');
   }
 
-  if (!_isToolOnPath(toolName)) {
+  if (!isToolOnPath(toolName)) {
     return MemNativeToolMissing(
       tool: toolName,
       hint: toolName == 'footprint'
@@ -429,14 +429,4 @@ Future<MemNativeResult> _captureOutput({
   await process.exitCode; // wait for process to finish
 
   return MemNativeSuccess(buffer.toString());
-}
-
-/// Returns true if [tool] can be found via `which`.
-bool _isToolOnPath(String tool) {
-  try {
-    final result = Process.runSync('which', [tool]);
-    return result.exitCode == 0;
-  } catch (_) {
-    return false;
-  }
 }

--- a/lib/core/commands/syslog/syslog.dart
+++ b/lib/core/commands/syslog/syslog.dart
@@ -53,7 +53,7 @@ Future<SyslogResult> _runAndroid({
   required String? device,
   required SyslogInput input,
 }) async {
-  if (!_isToolOnPath('adb')) {
+  if (!isToolOnPath('adb')) {
     return const SyslogToolMissing(
       tool: 'adb',
       hint: 'Install Android SDK platform-tools and ensure adb is on PATH.',
@@ -87,7 +87,7 @@ Future<SyslogResult> _runIosSimulator({
   required String? device,
   required SyslogInput input,
 }) async {
-  if (!_isToolOnPath('xcrun')) {
+  if (!isToolOnPath('xcrun')) {
     return const SyslogToolMissing(
       tool: 'xcrun',
       hint: 'Install Xcode command-line tools: xcode-select --install',
@@ -142,7 +142,7 @@ Future<SyslogResult> _runIosSimulator({
 }
 
 Future<SyslogResult> _runIosPhysical({required SyslogInput input}) async {
-  if (!_isToolOnPath('idevicesyslog')) {
+  if (!isToolOnPath('idevicesyslog')) {
     return const SyslogToolMissing(
       tool: 'idevicesyslog',
       hint: 'Install: brew install libimobiledevice',
@@ -171,7 +171,7 @@ Future<SyslogResult> _runIosPhysical({required SyslogInput input}) async {
 }
 
 Future<SyslogResult> _runMacos({required SyslogInput input}) async {
-  if (!_isToolOnPath('log')) {
+  if (!isToolOnPath('log')) {
     return const SyslogToolMissing(
       tool: 'log',
       hint: 'This is unexpected on macOS — ensure /usr/bin is on PATH.',
@@ -333,16 +333,6 @@ Future<SyslogResult> _snapshotStream({
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/// Returns true if [tool] can be found via `which`.
-bool _isToolOnPath(String tool) {
-  try {
-    final result = Process.runSync('which', [tool]);
-    return result.exitCode == 0;
-  } catch (_) {
-    return false;
-  }
-}
 
 /// Parses a duration string like `30s`, `5m`, `1h` into seconds.
 /// Returns null if the format is unrecognised.

--- a/lib/src/controller/pid_liveness.dart
+++ b/lib/src/controller/pid_liveness.dart
@@ -1,0 +1,47 @@
+import 'dart:io';
+
+/// Returns true if a process with [pid] is currently running.
+///
+/// Dart has no portable "is PID alive" API, so this shells out to a
+/// platform-specific tool: `kill -0` on POSIX (macOS/Linux) and `tasklist`
+/// on Windows. Never throws — any failure to invoke the tool is treated as
+/// "not alive".
+bool isProcessAlive(int pid) {
+  return Platform.isWindows ? _isProcessAliveWindows(pid) : _isProcessAlivePosix(pid);
+}
+
+bool _isProcessAlivePosix(int pid) {
+  try {
+    final result = Process.runSync('kill', ['-0', pid.toString()]);
+    return result.exitCode == 0;
+  } catch (_) {
+    return false;
+  }
+}
+
+/// `tasklist` has no POSIX `kill -0` equivalent, so this filters by PID and
+/// checks whether the CSV output contains a matching row. With no matching
+/// process, `tasklist` still exits 0 but prints an "INFO: No tasks..."
+/// message instead of a CSV row.
+bool _isProcessAliveWindows(int pid) {
+  try {
+    final result = Process.runSync('tasklist', ['/FI', 'PID eq $pid', '/NH', '/FO', 'CSV']);
+    if (result.exitCode != 0) return false;
+    return tasklistOutputHasPid(result.stdout as String, pid);
+  } catch (_) {
+    return false;
+  }
+}
+
+/// Returns true if [output] — `tasklist`'s CSV output filtered to a single
+/// PID — contains a matching row for [pid].
+///
+/// Split out from [_isProcessAliveWindows] so the parsing logic can be
+/// unit-tested against captured `tasklist` output without requiring an
+/// actual Windows host.
+bool tasklistOutputHasPid(String output, int pid) {
+  final trimmed = output.trim();
+  if (trimmed.isEmpty) return false;
+  if (trimmed.toUpperCase().contains('NO TASKS')) return false;
+  return trimmed.contains('"$pid"');
+}

--- a/lib/src/controller/process_utils.dart
+++ b/lib/src/controller/process_utils.dart
@@ -1,8 +1,24 @@
 import 'dart:io';
 
+import 'package:fdb/src/controller/pid_liveness.dart';
 import 'package:fdb/src/controller/session.dart';
 
+export 'package:fdb/src/controller/pid_liveness.dart' show isProcessAlive;
+
 String adbExecutable = 'adb';
+
+/// Returns true if [tool] can be found on `PATH`.
+///
+/// Uses `where` on Windows and `which` everywhere else, since Windows does
+/// not ship a `which` binary.
+bool isToolOnPath(String tool) {
+  try {
+    final result = Process.runSync(Platform.isWindows ? 'where' : 'which', [tool]);
+    return result.exitCode == 0;
+  } catch (_) {
+    return false;
+  }
+}
 
 int? readPid() {
   final file = File(pidFile);
@@ -97,15 +113,6 @@ String? extractDevicesJson(String output) {
   final end = output.lastIndexOf(']');
   if (end == -1 || end < start) return null;
   return output.substring(start, end + 1);
-}
-
-bool isProcessAlive(int pid) {
-  try {
-    final result = Process.runSync('kill', ['-0', pid.toString()]);
-    return result.exitCode == 0;
-  } catch (_) {
-    return false;
-  }
 }
 
 bool isAndroidTarget() {

--- a/lib/src/controller/session.dart
+++ b/lib/src/controller/session.dart
@@ -1,5 +1,7 @@
 import 'dart:io';
 
+import 'package:fdb/src/controller/pid_liveness.dart';
+
 /// Name of the session directory created inside the Flutter project.
 const sessionDirName = '.fdb';
 
@@ -75,11 +77,7 @@ bool _isPidFileAlive(String path) {
     return false;
   }
 
-  try {
-    return Process.runSync('kill', ['-0', pid.toString()]).exitCode == 0;
-  } catch (_) {
-    return false;
-  }
+  return isProcessAlive(pid);
 }
 
 /// Ensure the session directory exists and return its path.

--- a/test/pid_liveness_test.dart
+++ b/test/pid_liveness_test.dart
@@ -1,0 +1,47 @@
+import 'dart:io';
+
+import 'package:fdb/src/controller/pid_liveness.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('isProcessAlive (POSIX branch — exercised on the current host)', () {
+    test('returns true for the current process', () {
+      expect(isProcessAlive(pid), isTrue);
+    });
+
+    test('returns false for a PID that does not exist', () {
+      // PIDs above 4194304 (Linux's traditional max) are never assigned.
+      expect(isProcessAlive(999999999), isFalse);
+    });
+  });
+
+  group('tasklistOutputHasPid (Windows CSV parsing — testable without a Windows host)', () {
+    test('returns true when the CSV output contains a matching PID column', () {
+      const output = '"flutter.exe","4821","Console","1","123,456 K"';
+
+      expect(tasklistOutputHasPid(output, 4821), isTrue);
+    });
+
+    test('returns false when tasklist reports no matching tasks', () {
+      const output = 'INFO: No tasks are running which match the specified criteria.';
+
+      expect(tasklistOutputHasPid(output, 4821), isFalse);
+    });
+
+    test('returns false for empty output', () {
+      expect(tasklistOutputHasPid('', 4821), isFalse);
+    });
+
+    test('returns false when a different PID is present', () {
+      const output = '"flutter.exe","1234","Console","1","123,456 K"';
+
+      expect(tasklistOutputHasPid(output, 4821), isFalse);
+    });
+
+    test('is tolerant of surrounding whitespace/newlines', () {
+      const output = '\n\r\n"dart.exe","9001","Console","1","50,000 K"\r\n';
+
+      expect(tasklistOutputHasPid(output, 9001), isTrue);
+    });
+  });
+}

--- a/test/pid_liveness_test.dart
+++ b/test/pid_liveness_test.dart
@@ -38,6 +38,23 @@ void main() {
       expect(tasklistOutputHasPid(output, 4821), isFalse);
     });
 
+    test('returns false when the queried PID is a numeric prefix of the actual PID', () {
+      // Guards against a naive numeric-substring match: 123 must not match
+      // a row for PID 1234 just because "123" is a substring of "1234".
+      const output = '"flutter.exe","1234","Console","1","123,456 K"';
+
+      expect(tasklistOutputHasPid(output, 123), isFalse);
+    });
+
+    test('returns false when the queried PID matches only inside the memory usage column', () {
+      // The mem usage column can contain the same digits as a PID once comma
+      // separators are stripped mentally, but it is never wrapped in its own
+      // matching quotes the way the PID column is — must not false-match.
+      const output = '"flutter.exe","4821","Console","1","123,456 K"';
+
+      expect(tasklistOutputHasPid(output, 123), isFalse);
+    });
+
     test('is tolerant of surrounding whitespace/newlines', () {
       const output = '\n\r\n"dart.exe","9001","Console","1","50,000 K"\r\n';
 

--- a/test/process_utils_test.dart
+++ b/test/process_utils_test.dart
@@ -1,0 +1,15 @@
+import 'package:fdb/src/controller/process_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('isToolOnPath (which/where dispatch — which branch exercised on the current host)', () {
+    test('returns true for a tool that is definitely on PATH', () {
+      // The test runner itself is invoked via `dart`, so it must be resolvable.
+      expect(isToolOnPath('dart'), isTrue);
+    });
+
+    test('returns false for a tool name that does not exist', () {
+      expect(isToolOnPath('fdb-definitely-not-a-real-binary-xyz'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Windows users hit a crash in fdb devices/doctor/mem/syslog/crash-report because those commands shell out to which, which doesn't exist on Windows (issue #155). Digging into it turned up two more blockers that go deeper than the reported crash: fdb launch and fdb attach crash outright on Windows because Dart throws watching sigterm there, and PID-liveness checks (kill -0) always report false on Windows, which made fdb launch falsely conclude the app died a few seconds in, and made fdb kill silently report success without killing anything.

This fixes all three so Windows is actually usable end to end, not just the which/where swap. Consolidated the duplicated tool-lookup and PID-liveness helpers into single implementations rather than patching each of the 5-6 copies separately.

No Windows machine was available to test this on directly. Verified via Dart SDK source/docs for the documented Windows behavior of ProcessSignal.watch() and Process.runSync, added unit tests for the new Windows-specific parsing logic, and confirmed the POSIX code paths are unchanged via the full test suite plus manual verification of launch/status/kill/doctor/mem/syslog on macOS.

Known remaining gaps, called out as follow-ups rather than blocking this fix: flutter.bat spawning correctness on Windows hasn't been verified end-to-end, session/file paths are built with hardcoded forward slashes (cosmetic, dart:io normalizes it), and fdb_helper's pubspec.yaml has no windows: plugin platform entry yet.

Closes #155